### PR TITLE
Add glProgramParameteri to GL_ARB_separate_shader_objects

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -33239,6 +33239,7 @@ typedef unsigned int GLhandleARB;
             <command name="glGenProgramPipelines"/>
             <command name="glIsProgramPipeline"/>
             <command name="glGetProgramPipelineiv"/>
+            <command name="glProgramParameteri"/>
             <command name="glProgramUniform1i"/>
             <command name="glProgramUniform1iv"/>
             <command name="glProgramUniform1f"/>
@@ -38718,6 +38719,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glGenProgramPipelines"/>
                 <command name="glIsProgramPipeline"/>
                 <command name="glGetProgramPipelineiv"/>
+                <command name="glProgramParameteri"/>
                 <command name="glProgramUniform1i"/>
                 <command name="glProgramUniform1iv"/>
                 <command name="glProgramUniform1f"/>


### PR DESCRIPTION
This function is missing from the extension in the XML file.

Made this pull request as per the comment here https://www.khronos.org/bugzilla/show_bug.cgi?id=1923#c1
This pr closes https://github.com/Dav1dde/glad/issues/73

Cheers, Jakob.