### PR TITLE
Revert changes from #45. 

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -206,12 +206,6 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MIN_EXT"/>
         </group>
 
-        <group name="BlendEquationMode">
-            <enum name="GL_FUNC_ADD"/>
-            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
-            <enum name="GL_FUNC_SUBTRACT"/>
-        </group>
-
         <group name="BlendingFactorDest">
             <enum name="GL_CONSTANT_ALPHA_EXT"/>
             <enum name="GL_CONSTANT_COLOR_EXT"/>
@@ -635,7 +629,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CW"/>
         </group>
 
-        <group name="ColorTableParameterNameSGI">
+        <group name="GetColorTableParameterPNameSGI">
             <enum name="GL_COLOR_TABLE_ALPHA_SIZE_SGI"/>
             <enum name="GL_COLOR_TABLE_BIAS_SGI"/>
             <enum name="GL_COLOR_TABLE_BLUE_SIZE_SGI"/>
@@ -647,8 +641,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_COLOR_TABLE_SCALE_SGI"/>
             <enum name="GL_COLOR_TABLE_WIDTH_SGI"/>
         </group>
-        
-        <group name="ConvolutionParameter">
+
+        <group name="GetConvolutionParameter">
             <enum name="GL_CONVOLUTION_BORDER_MODE_EXT"/>
             <enum name="GL_CONVOLUTION_FILTER_BIAS_EXT"/>
             <enum name="GL_CONVOLUTION_FILTER_SCALE_EXT"/>
@@ -657,6 +651,17 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONVOLUTION_WIDTH_EXT"/>
             <enum name="GL_MAX_CONVOLUTION_HEIGHT_EXT"/>
             <enum name="GL_MAX_CONVOLUTION_WIDTH_EXT"/>
+        </group>
+
+        <group name="GetHistogramParameterPNameEXT">
+            <enum name="GL_HISTOGRAM_ALPHA_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_BLUE_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_FORMAT_EXT"/>
+            <enum name="GL_HISTOGRAM_GREEN_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_LUMINANCE_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_RED_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_SINK_EXT"/>
+            <enum name="GL_HISTOGRAM_WIDTH_EXT"/>
         </group>
 
         <group name="GetMapQuery">
@@ -1093,6 +1098,63 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_VERTEX_ARRAY_POINTER_EXT"/>
         </group>
 
+        <group name="GetTextureParameter">
+            <enum name="GL_DETAIL_TEXTURE_FUNC_POINTS_SGIS"/>
+            <enum name="GL_DETAIL_TEXTURE_LEVEL_SGIS"/>
+            <enum name="GL_DETAIL_TEXTURE_MODE_SGIS"/>
+            <enum name="GL_DUAL_TEXTURE_SELECT_SGIS"/>
+            <enum name="GL_GENERATE_MIPMAP_SGIS"/>
+            <enum name="GL_POST_TEXTURE_FILTER_BIAS_SGIX"/>
+            <enum name="GL_POST_TEXTURE_FILTER_SCALE_SGIX"/>
+            <enum name="GL_QUAD_TEXTURE_SELECT_SGIS"/>
+            <enum name="GL_SHADOW_AMBIENT_SGIX"/>
+            <enum name="GL_SHARPEN_TEXTURE_FUNC_POINTS_SGIS"/>
+            <enum name="GL_TEXTURE_4DSIZE_SGIS"/>
+            <enum name="GL_TEXTURE_ALPHA_SIZE"/>
+            <enum name="GL_TEXTURE_BASE_LEVEL_SGIS"/>
+            <enum name="GL_TEXTURE_BLUE_SIZE"/>
+            <enum name="GL_TEXTURE_BORDER"/>
+            <enum name="GL_TEXTURE_BORDER_COLOR"/>
+            <enum name="GL_TEXTURE_BORDER_COLOR_NV"/>
+            <enum name="GL_TEXTURE_CLIPMAP_CENTER_SGIX"/>
+            <enum name="GL_TEXTURE_CLIPMAP_DEPTH_SGIX"/>
+            <enum name="GL_TEXTURE_CLIPMAP_FRAME_SGIX"/>
+            <enum name="GL_TEXTURE_CLIPMAP_LOD_OFFSET_SGIX"/>
+            <enum name="GL_TEXTURE_CLIPMAP_OFFSET_SGIX"/>
+            <enum name="GL_TEXTURE_CLIPMAP_VIRTUAL_DEPTH_SGIX"/>
+            <enum name="GL_TEXTURE_COMPARE_OPERATOR_SGIX"/>
+            <enum name="GL_TEXTURE_COMPARE_SGIX"/>
+            <enum name="GL_TEXTURE_COMPONENTS"/>
+            <enum name="GL_TEXTURE_DEPTH_EXT"/>
+            <enum name="GL_TEXTURE_FILTER4_SIZE_SGIS"/>
+            <enum name="GL_TEXTURE_GEQUAL_R_SGIX"/>
+            <enum name="GL_TEXTURE_GREEN_SIZE"/>
+            <enum name="GL_TEXTURE_HEIGHT"/>
+            <enum name="GL_TEXTURE_INTENSITY_SIZE"/>
+            <enum name="GL_TEXTURE_INTERNAL_FORMAT"/>
+            <enum name="GL_TEXTURE_LEQUAL_R_SGIX"/>
+            <enum name="GL_TEXTURE_LOD_BIAS_R_SGIX"/>
+            <enum name="GL_TEXTURE_LOD_BIAS_S_SGIX"/>
+            <enum name="GL_TEXTURE_LOD_BIAS_T_SGIX"/>
+            <enum name="GL_TEXTURE_LUMINANCE_SIZE"/>
+            <enum name="GL_TEXTURE_MAG_FILTER"/>
+            <enum name="GL_TEXTURE_MAX_CLAMP_R_SGIX"/>
+            <enum name="GL_TEXTURE_MAX_CLAMP_S_SGIX"/>
+            <enum name="GL_TEXTURE_MAX_CLAMP_T_SGIX"/>
+            <enum name="GL_TEXTURE_MAX_LEVEL_SGIS"/>
+            <enum name="GL_TEXTURE_MAX_LOD_SGIS"/>
+            <enum name="GL_TEXTURE_MIN_FILTER"/>
+            <enum name="GL_TEXTURE_MIN_LOD_SGIS"/>
+            <enum name="GL_TEXTURE_PRIORITY"/>
+            <enum name="GL_TEXTURE_RED_SIZE"/>
+            <enum name="GL_TEXTURE_RESIDENT"/>
+            <enum name="GL_TEXTURE_WIDTH"/>
+            <enum name="GL_TEXTURE_WRAP_Q_SGIS"/>
+            <enum name="GL_TEXTURE_WRAP_R_EXT"/>
+            <enum name="GL_TEXTURE_WRAP_S"/>
+            <enum name="GL_TEXTURE_WRAP_T"/>
+        </group>
+
         <group name="HintMode">
             <enum name="GL_DONT_CARE"/>
             <enum name="GL_FASTEST"/>
@@ -1511,24 +1573,6 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_RGBA8"/>
             <enum name="GL_RGBA_ICC_SGIX"/>
             <enum name="GL_RGB_ICC_SGIX"/>
-            <enum name="GL_COMPRESSED_RED_RGTC1"/>
-            <enum name="GL_COMPRESSED_SIGNED_RED_RGTC1"/>
-            <enum name="GL_COMPRESSED_RG_RGTC2"/>
-            <enum name="GL_COMPRESSED_SIGNED_RG_RGTC2"/>
-            <enum name="GL_COMPRESSED_RGBA_BPTC_UNORM"/>
-            <enum name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM"/>
-            <enum name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT"/>
-            <enum name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT"/>
-            <enum name="GL_COMPRESSED_RGB8_ETC2"/>
-            <enum name="GL_COMPRESSED_SRGB8_ETC2"/>
-            <enum name="GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2"/>
-            <enum name="GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2"/>
-            <enum name="GL_COMPRESSED_RGBA8_ETC2_EAC"/>
-            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC"/>
-            <enum name="GL_COMPRESSED_R11_EAC"/>
-            <enum name="GL_COMPRESSED_SIGNED_R11_EAC"/>
-            <enum name="GL_COMPRESSED_RG11_EAC"/>
-            <enum name="GL_COMPRESSED_SIGNED_RG11_EAC"/>
         </group>
 
         <group name="PixelMap">
@@ -1785,11 +1829,8 @@ typedef unsigned int GLhandleARB;
         </group>
 
         <group name="SeparableTargetEXT">
-            <enum name="GL_SEPARABLE_2D_EXT"/>
-        </group>
-
-        <group name="SeparableTarget">
             <enum name="GL_SEPARABLE_2D"/>
+            <enum name="GL_SEPARABLE_2D_EXT"/>
         </group>
 
         <group name="ShadingModel">
@@ -1966,31 +2007,6 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_SWIZZLE_A"/>
             <enum name="GL_TEXTURE_SWIZZLE_RGBA"/>
             <enum name="GL_DEPTH_STENCIL_TEXTURE_MODE"/>
-            <enum name="GL_DETAIL_TEXTURE_FUNC_POINTS_SGIS"/>
-            <enum name="GL_SHARPEN_TEXTURE_FUNC_POINTS_SGIS"/>
-            <enum name="GL_TEXTURE_4DSIZE_SGIS"/>
-            <enum name="GL_TEXTURE_ALPHA_SIZE"/>
-            <enum name="GL_TEXTURE_BASE_LEVEL_SGIS"/>
-            <enum name="GL_TEXTURE_BLUE_SIZE"/>
-            <enum name="GL_TEXTURE_BORDER"/>
-            <enum name="GL_TEXTURE_BORDER_COLOR_NV"/>
-            <enum name="GL_TEXTURE_COMPARE_OPERATOR_SGIX"/>
-            <enum name="GL_TEXTURE_COMPONENTS"/>
-            <enum name="GL_TEXTURE_DEPTH_EXT"/>
-            <enum name="GL_TEXTURE_FILTER4_SIZE_SGIS"/>
-            <enum name="GL_TEXTURE_GEQUAL_R_SGIX"/>
-            <enum name="GL_TEXTURE_GREEN_SIZE"/>
-            <enum name="GL_TEXTURE_HEIGHT"/>
-            <enum name="GL_TEXTURE_INTENSITY_SIZE"/>
-            <enum name="GL_TEXTURE_INTERNAL_FORMAT"/>
-            <enum name="GL_TEXTURE_LEQUAL_R_SGIX"/>
-            <enum name="GL_TEXTURE_LUMINANCE_SIZE"/>
-            <enum name="GL_TEXTURE_MAX_LEVEL_SGIS"/>
-            <enum name="GL_TEXTURE_MAX_LOD_SGIS"/>
-            <enum name="GL_TEXTURE_MIN_LOD_SGIS"/>
-            <enum name="GL_TEXTURE_RED_SIZE"/>
-            <enum name="GL_TEXTURE_RESIDENT"/>
-            <enum name="GL_TEXTURE_WIDTH"/>
         </group>
 
         <group name="TextureTarget">
@@ -2072,883 +2088,6 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FLOAT"/>
             <enum name="GL_INT"/>
             <enum name="GL_SHORT"/>
-        </group>
-        
-        <group name="FramebufferAttachment">
-            <enum name="GL_MAX_COLOR_ATTACHMENTS"/>
-            <enum name="GL_MAX_COLOR_ATTACHMENTS_EXT"/>
-            <enum name="GL_MAX_COLOR_ATTACHMENTS_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT0"/>
-            <enum name="GL_COLOR_ATTACHMENT0_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT0_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT0_OES"/>
-            <enum name="GL_COLOR_ATTACHMENT1"/>
-            <enum name="GL_COLOR_ATTACHMENT1_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT1_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT2"/>
-            <enum name="GL_COLOR_ATTACHMENT2_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT2_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT3"/>
-            <enum name="GL_COLOR_ATTACHMENT3_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT3_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT4"/>
-            <enum name="GL_COLOR_ATTACHMENT4_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT4_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT5"/>
-            <enum name="GL_COLOR_ATTACHMENT5_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT5_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT6"/>
-            <enum name="GL_COLOR_ATTACHMENT6_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT6_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT7"/>
-            <enum name="GL_COLOR_ATTACHMENT7_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT7_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT8"/>
-            <enum name="GL_COLOR_ATTACHMENT8_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT8_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT9"/>
-            <enum name="GL_COLOR_ATTACHMENT9_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT9_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT10"/>
-            <enum name="GL_COLOR_ATTACHMENT10_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT10_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT11"/>
-            <enum name="GL_COLOR_ATTACHMENT11_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT11_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT12"/>
-            <enum name="GL_COLOR_ATTACHMENT12_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT12_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT13"/>
-            <enum name="GL_COLOR_ATTACHMENT13_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT13_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT14"/>
-            <enum name="GL_COLOR_ATTACHMENT14_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT14_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT15"/>
-            <enum name="GL_COLOR_ATTACHMENT15_EXT"/>
-            <enum name="GL_COLOR_ATTACHMENT15_NV"/>
-            <enum name="GL_COLOR_ATTACHMENT16"/>
-            <enum name="GL_COLOR_ATTACHMENT17"/>
-            <enum name="GL_COLOR_ATTACHMENT18"/>
-            <enum name="GL_COLOR_ATTACHMENT19"/>
-            <enum name="GL_COLOR_ATTACHMENT20"/>
-            <enum name="GL_COLOR_ATTACHMENT21"/>
-            <enum name="GL_COLOR_ATTACHMENT22"/>
-            <enum name="GL_COLOR_ATTACHMENT23"/>
-            <enum name="GL_COLOR_ATTACHMENT24"/>
-            <enum name="GL_COLOR_ATTACHMENT25"/>
-            <enum name="GL_COLOR_ATTACHMENT26"/>
-            <enum name="GL_COLOR_ATTACHMENT27"/>
-            <enum name="GL_COLOR_ATTACHMENT28"/>
-            <enum name="GL_COLOR_ATTACHMENT29"/>
-            <enum name="GL_COLOR_ATTACHMENT30"/>
-            <enum name="GL_COLOR_ATTACHMENT31"/>
-            <enum name="GL_DEPTH_ATTACHMENT"/>
-            <enum name="GL_DEPTH_ATTACHMENT_EXT"/>
-            <enum name="GL_DEPTH_ATTACHMENT_OES"/>
-        </group>
-        
-        <group name="RenderbufferTarget">
-            <enum name="GL_RENDERBUFFER" />
-        </group>
-        
-        <group name="FramebufferTarget">
-            <enum name="GL_FRAMEBUFFER" />
-            <enum name="GL_DRAW_FRAMEBUFFER" />
-            <enum name="GL_READ_FRAMEBUFFER " />
-        </group>
-        
-        <group name="TextureUnit">
-            <enum name="GL_TEXTURE0"/>
-            <enum name="GL_TEXTURE1"/>
-            <enum name="GL_TEXTURE2"/>
-            <enum name="GL_TEXTURE3"/>
-            <enum name="GL_TEXTURE4"/>
-            <enum name="GL_TEXTURE5"/>
-            <enum name="GL_TEXTURE6"/>
-            <enum name="GL_TEXTURE7"/>
-            <enum name="GL_TEXTURE8"/>
-            <enum name="GL_TEXTURE9"/>
-            <enum name="GL_TEXTURE10"/>
-            <enum name="GL_TEXTURE11"/>
-            <enum name="GL_TEXTURE12"/>
-            <enum name="GL_TEXTURE13"/>
-            <enum name="GL_TEXTURE14"/>
-            <enum name="GL_TEXTURE15"/>
-            <enum name="GL_TEXTURE16"/>
-            <enum name="GL_TEXTURE17"/>
-            <enum name="GL_TEXTURE18"/>
-            <enum name="GL_TEXTURE19"/>
-            <enum name="GL_TEXTURE20"/>
-            <enum name="GL_TEXTURE21"/>
-            <enum name="GL_TEXTURE22"/>
-            <enum name="GL_TEXTURE23"/>
-            <enum name="GL_TEXTURE24"/>
-            <enum name="GL_TEXTURE25"/>
-            <enum name="GL_TEXTURE26"/>
-            <enum name="GL_TEXTURE27"/>
-            <enum name="GL_TEXTURE28"/>
-            <enum name="GL_TEXTURE29"/>
-            <enum name="GL_TEXTURE30"/>
-            <enum name="GL_TEXTURE31"/>
-        </group>
-        
-        <group name="TypeEnum">
-            <enum name="GL_QUERY_WAIT"/>
-            <enum name="GL_QUERY_NO_WAIT"/>
-            <enum name="GL_QUERY_BY_REGION_WAIT"/>
-            <enum name="GL_QUERY_BY_REGION_NO_WAIT"/>
-        </group>
-        
-        <group name="FragmentOpATI">
-            <enum name="GL_MOV_ATI"/>
-            <enum name="GL_ADD_ATI"/>
-            <enum name="GL_MUL_ATI"/>
-            <enum name="GL_SUB_ATI"/>
-            <enum name="GL_DOT3_ATI"/>
-            <enum name="GL_DOT4_ATI"/>
-            <enum name="GL_MAD_ATI"/>
-            <enum name="GL_LERP_ATI"/>
-            <enum name="GL_CND_ATI"/>
-            <enum name="GL_CND0_ATI"/>
-            <enum name="GL_DOT2_ADD_ATI"/>
-        </group>
-        
-        <group name="FramebufferStatus">
-            <enum name="GL_FRAMEBUFFER_COMPLETE"/>
-            <enum name="GL_FRAMEBUFFER_UNDEFINED"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER"/>
-            <enum name="GL_FRAMEBUFFER_UNSUPPORTED"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"/>
-            <enum name="GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS"/>
-        </group>
-        
-        <group name="GraphicsResetStatus">
-            <enum name="GL_NO_ERROR"/>
-            <enum name="GL_GUILTY_CONTEXT_RESET"/>
-            <enum name="GL_INNOCENT_CONTEXT_RESET"/>
-            <enum name="GL_UNKNOWN_CONTEXT_RESET"/>
-        </group>
-        
-        <group name="SyncStatus">
-            <enum name="GL_ALREADY_SIGNALED"/>
-            <enum name="GL_TIMEOUT_EXPIRED"/>
-            <enum name="GL_CONDITION_SATISFIED"/>
-            <enum name="GL_WAIT_FAILED"/>
-        </group>
-        
-        <group name="QueryTarget">
-            <enum name="GL_SAMPLES_PASSED"/>
-            <enum name="GL_ANY_SAMPLES_PASSED"/>
-            <enum name="GL_ANY_SAMPLES_PASSED_CONSERVATIVE"/>
-            <enum name="GL_PRIMITIVES_GENERATED"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN"/>
-            <enum name="GL_TIME_ELAPSED"/>
-        </group>
-        
-        <group name="ConvolutionTarget">
-            <enum name="GL_CONVOLUTION_1D"/>
-            <enum name="GL_CONVOLUTION_2D"/>
-        </group>
-        
-        <group name="PathFillMode">
-            <enum name="GL_INVERT"/>
-            <enum name="GL_COUNT_UP_NV"/>
-            <enum name="GL_COUNT_DOWN_NV"/>
-            <enum name="GL_PATH_FILL_MODE_NV"/>
-        </group>
-        
-        <group name="ColorTableTarget">
-            <enum name="GL_COLOR_TABLE"/>
-            <enum name="GL_POST_CONVOLUTION_COLOR_TABLE"/>
-            <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE"/>
-        </group>
-        
-        <group name="ColorTableParameterPName">
-            <enum name="GL_COLOR_TABLE_SCALE"/>
-            <enum name="GL_COLOR_TABLE_BIAS"/>
-        </group>
-        
-        <group name="HistogramTarget">
-            <enum name="GL_HISTOGRAM"/>
-            <enum name="GL_PROXY_HISTOGRAM"/>
-        </group>
-        
-        <group name="MinmaxTarget">
-            <enum name="GL_MINMAX"/>
-        </group>
-        
-        <group name="ColorTableParameterName">
-            <enum name="GL_COLOR_TABLE_BIAS"/>
-            <enum name="GL_COLOR_TABLE_SCALE"/>
-            <enum name="GL_COLOR_TABLE_FORMAT"/>
-            <enum name="GL_COLOR_TABLE_WIDTH"/>
-            <enum name="GL_COLOR_TABLE_RED_SIZE"/>
-            <enum name="GL_COLOR_TABLE_GREEN_SIZE"/>
-            <enum name="GL_COLOR_TABLE_BLUE_SIZE"/>
-            <enum name="GL_COLOR_TABLE_ALPHA_SIZE"/>
-            <enum name="GL_COLOR_TABLE_LUMINANCE_SIZE"/>
-            <enum name="GL_COLOR_TABLE_INTENSITY_SIZE"/>
-        </group>
-        
-        <group name="ConvolutionParameterName">
-            <enum name="GL_CONVOLUTION_BORDER_MODE"/>
-            <enum name="GL_CONVOLUTION_BORDER_COLOR"/>
-            <enum name="GL_CONVOLUTION_FILTER_SCALE"/>
-            <enum name="GL_CONVOLUTION_FILTER_BIAS"/>
-            <enum name="GL_CONVOLUTION_FORMAT"/>
-            <enum name="GL_CONVOLUTION_WIDTH"/>
-            <enum name="GL_CONVOLUTION_HEIGHT"/>
-            <enum name="GL_MAX_CONVOLUTION_WIDTH"/>
-            <enum name="GL_MAX_CONVOLUTION_HEIGHT"/>
-        </group>
-        
-        <group name="HistogramParameterName">
-            <enum name="GL_HISTOGRAM_WIDTH"/>
-            <enum name="GL_HISTOGRAM_FORMAT"/>
-            <enum name="GL_HISTOGRAM_RED_SIZE"/>
-            <enum name="GL_HISTOGRAM_GREEN_SIZE"/>
-            <enum name="GL_HISTOGRAM_BLUE_SIZE"/>
-            <enum name="GL_HISTOGRAM_ALPHA_SIZE"/>
-            <enum name="GL_HISTOGRAM_LUMINANCE_SIZE"/>
-            <enum name="GL_HISTOGRAM_SINK"/>
-            <enum name="GL_HISTOGRAM_ALPHA_SIZE_EXT"/>
-            <enum name="GL_HISTOGRAM_BLUE_SIZE_EXT"/>
-            <enum name="GL_HISTOGRAM_FORMAT_EXT"/>
-            <enum name="GL_HISTOGRAM_GREEN_SIZE_EXT"/>
-            <enum name="GL_HISTOGRAM_LUMINANCE_SIZE_EXT"/>
-            <enum name="GL_HISTOGRAM_RED_SIZE_EXT"/>
-            <enum name="GL_HISTOGRAM_SINK_EXT"/>
-            <enum name="GL_HISTOGRAM_WIDTH_EXT"/>
-        </group>
-        
-        <group name="MinmaxParameterName">
-            <enum name="GL_MINMAX_FORMAT"/>
-            <enum name="GL_MINMAX_SINK"/>
-        </group>
-        
-        <group name="VertexBufferObjectParameter">
-            <enum name="GL_BUFFER_ACCESS"/>
-            <enum name="GL_BUFFER_ACCESS_FLAGS"/>
-            <enum name="GL_BUFFER_IMMUTABLE_STORAGE"/>
-            <enum name="GL_BUFFER_MAPPED"/>
-            <enum name="GL_BUFFER_MAP_LENGTH"/>
-            <enum name="GL_BUFFER_MAP_OFFSET"/>
-            <enum name="GL_BUFFER_SIZE"/>
-            <enum name="GL_BUFFER_STORAGE_FLAGS"/>
-            <enum name="GL_BUFFER_USAGE"/>
-        </group>
-        
-        <group name="RenderbufferParameterName">
-            <enum name="GL_RENDERBUFFER_WIDTH"/>
-            <enum name="GL_RENDERBUFFER_HEIGHT"/>
-            <enum name="GL_RENDERBUFFER_INTERNAL_FORMAT"/>
-            <enum name="GL_RENDERBUFFER_SAMPLES"/>
-            <enum name="GL_RENDERBUFFER_RED_SIZE"/>
-            <enum name="GL_RENDERBUFFER_GREEN_SIZE"/>
-            <enum name="GL_RENDERBUFFER_BLUE_SIZE"/>
-            <enum name="GL_RENDERBUFFER_ALPHA_SIZE"/>
-            <enum name="GL_RENDERBUFFER_DEPTH_SIZE"/>
-            <enum name="GL_RENDERBUFFER_STENCIL_SIZE"/>
-        </group>
-        
-        <group name="VertexBufferObjectUsage">
-            <enum name="GL_STREAM_DRAW"/>
-            <enum name="GL_STREAM_READ"/>
-            <enum name="GL_STREAM_COPY"/>
-            <enum name="GL_STATIC_DRAW"/>
-            <enum name="GL_STATIC_READ"/>
-            <enum name="GL_STATIC_COPY"/>
-            <enum name="GL_DYNAMIC_DRAW"/>
-            <enum name="GL_DYNAMIC_READ"/>
-            <enum name="GL_DYNAMIC_COPY"/>
-        </group>
-        
-        <group name="FramebufferParameterName">
-            <enum name="GL_FRAMEBUFFER_DEFAULT_WIDTH"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_HEIGHT"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_LAYERS"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_SAMPLES"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS"/>
-        </group>
-        
-        <group name="ProgramParameterPName">
-            <enum name="GL_PROGRAM_BINARY_RETRIEVABLE_HINT"/>
-            <enum name="GL_PROGRAM_SEPARABLE"/>
-        </group>
-        
-        <group name="ColorScaleFactor">
-            <enum name="GL_ZERO"/>
-            <enum name="GL_ONE"/>
-            <enum name="GL_SRC_COLOR"/>
-            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
-            <enum name="GL_DST_COLOR"/>
-            <enum name="GL_ONE_MINUS_DST_COLOR"/>
-            <enum name="GL_SRC_ALPHA"/>
-            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
-            <enum name="GL_DST_ALPHA"/>
-            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
-            <enum name="GL_CONSTANT_COLOR"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
-            <enum name="GL_CONSTANT_ALPHA"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
-            <enum name="GL_SRC_ALPHA_SATURATE"/>
-            <enum name="GL_SRC1_COLOR"/>
-            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
-            <enum name="GL_SRC1_ALPHA"/>
-            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
-        </group>
-        
-        <group name="BindTransformFeedbackTarget">
-            <enum name="GL_TRANSFORM_FEEDBACK"/>
-        </group>
-        
-        <group name="BlitFramebufferFilter">
-            <enum name="GL_NEAREST"/>
-            <enum name="GL_LINEAR"/>
-        </group>
-        
-        <group name="BufferStorageTarget">
-            <enum name="GL_ARRAY_BUFFER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER"/>
-            <enum name="GL_COPY_READ_BUFFER"/>
-            <enum name="GL_COPY_WRITE_BUFFER"/>
-            <enum name="GL_DISPATCH_INDIRECT_BUFFER"/>
-            <enum name="GL_DRAW_INDIRECT_BUFFER"/>
-            <enum name="GL_ELEMENT_ARRAY_BUFFER"/>
-            <enum name="GL_PIXEL_PACK_BUFFER"/>
-            <enum name="GL_PIXEL_UNPACK_BUFFER"/>
-            <enum name="GL_QUERY_BUFFER"/>
-            <enum name="GL_SHADER_STORAGE_BUFFER"/>
-            <enum name="GL_TEXTURE_BUFFER"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
-            <enum name="GL_UNIFORM_BUFFER"/>
-        </group>
-        
-        <group name="CheckFramebufferStatusTarget">
-            <enum name="GL_DRAW_FRAMEBUFFER"/>
-            <enum name="GL_READ_FRAMEBUFFER"/>
-            <enum name="GL_FRAMEBUFFER"/>
-        </group>
-        
-        <group name="Buffer">
-            <enum name="GL_COLOR"/>
-            <enum name="GL_DEPTH"/>
-            <enum name="GL_STENCIL"/>
-        </group>
-        
-        <group name="ClipControlOrigin">
-            <enum name="GL_LOWER_LEFT"/>
-            <enum name="GL_UPPER_LEFT"/>
-        </group>
-        
-        <group name="ClipControlDepth">
-            <enum name="GL_NEGATIVE_ONE_TO_ONE"/>
-            <enum name="GL_ZERO_TO_ONE"/>
-        </group>
-        
-        <group name="CopyBufferSubDataTarget">
-            <enum name="GL_ARRAY_BUFFER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER"/>
-            <enum name="GL_COPY_READ_BUFFER"/>
-            <enum name="GL_COPY_WRITE_BUFFER"/>
-            <enum name="GL_DISPATCH_INDIRECT_BUFFER"/>
-            <enum name="GL_DRAW_INDIRECT_BUFFER"/>
-            <enum name="GL_ELEMENT_ARRAY_BUFFER"/>
-            <enum name="GL_PIXEL_PACK_BUFFER"/>
-            <enum name="GL_PIXEL_UNPACK_BUFFER"/>
-            <enum name="GL_QUERY_BUFFER"/>
-            <enum name="GL_SHADER_STORAGE_BUFFER"/>
-            <enum name="GL_TEXTURE_BUFFER"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
-            <enum name="GL_UNIFORM_BUFFER"/>
-        </group>
-        
-        <group name="ShaderType">
-            <enum name="GL_COMPUTE_SHADER"/>
-            <enum name="GL_VERTEX_SHADER"/>
-            <enum name="GL_TESS_CONTROL_SHADER"/>
-            <enum name="GL_TESS_EVALUATION_SHADER"/>
-            <enum name="GL_GEOMETRY_SHADER"/>
-            <enum name="GL_FRAGMENT_SHADER"/>
-        </group>
-        
-        <group name="DebugSource">
-            <enum name="GL_DEBUG_SOURCE_API"/>
-            <enum name="GL_DEBUG_SOURCE_WINDOW_SYSTEM_"/>
-            <enum name="GL_DEBUG_SOURCE_SHADER_COMPILER"/>
-            <enum name="GL_DEBUG_SOURCE_THIRD_PARTY"/>
-            <enum name="GL_DEBUG_SOURCE_APPLICATION"/>
-            <enum name="GL_DEBUG_SOURCE_OTHER"/>
-            <enum name="GL_DONT_CARE"/>
-        </group>
-        
-        <group name="DebugType">
-            <enum name="GL_DEBUG_TYPE_ERROR"/>
-            <enum name="GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR"/>
-            <enum name="GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR"/>
-            <enum name="GL_DEBUG_TYPE_PORTABILITY"/>
-            <enum name="GL_DEBUG_TYPE_PERFORMANCE"/>
-            <enum name="GL_DEBUG_TYPE_MARKER"/>
-            <enum name="GL_DEBUG_TYPE_PUSH_GROUP"/>
-            <enum name="GL_DEBUG_TYPE_POP_GROUP"/>
-            <enum name="GL_DEBUG_TYPE_OTHER"/>
-            <enum name="GL_DONT_CARE"/>
-        </group>
-        
-        <group name="DebugSeverity">
-            <enum name="GL_DEBUG_SEVERITY_LOW"/>
-            <enum name="GL_DEBUG_SEVERITY_MEDIUM"/>
-            <enum name="GL_DEBUG_SEVERITY_HIGH"/>
-            <enum name="GL_DONT_CARE"/>
-        </group>
-        
-        <group name="SyncCondition">
-            <enum name="GL_SYNC_GPU_COMMANDS_COMPLETE"/>
-        </group>
-        
-        <group name="FogPName">
-            <enum name="GL_FOG_MODE"/>
-            <enum name="GL_FOG_DENSITY"/>
-            <enum name="GL_FOG_START"/>
-            <enum name="GL_FOG_END"/>
-            <enum name="GL_FOG_INDEX"/>
-            <enum name="GL_FOG_COORD_SRC"/>
-        </group>
-        
-        <group name="AtomicCounterBufferPName">
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_BINDING"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_DATA_SIZE"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_ACTIVE_ATOMIC_COUNTERS"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_ACTIVE_ATOMIC_COUNTER_INDICES"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_VERTEX_SHADER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TESS_CONTROL_SHADER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TESS_EVALUATION_SHADER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_GEOMETRY_SHADER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_FRAGMENT_SHADER"/>
-            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_COMPUTE_SHADER"/>
-        </group>
-        
-        <group name="UniformBlockPName">
-            <enum name="GL_UNIFORM_BLOCK_BINDING"/>
-            <enum name="GL_UNIFORM_BLOCK_DATA_SIZE"/>
-            <enum name="GL_UNIFORM_BLOCK_NAME_LENGTH"/>
-            <enum name="GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS"/>
-            <enum name="GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_TESS_CONTROL_SHADER"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_GEOMETRY_SHADER"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER"/>
-            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_COMPUTE_SHADER"/>
-        </group>
-        
-        <group name="UniformPName">
-            <enum name="GL_UNIFORM_TYPE"/>
-            <enum name="GL_UNIFORM_SIZE"/>
-            <enum name="GL_UNIFORM_NAME_LENGTH"/>
-            <enum name="GL_UNIFORM_BLOCK_INDEX"/>
-            <enum name="GL_UNIFORM_OFFSET"/>
-            <enum name="GL_UNIFORM_ARRAY_STRIDE"/>
-            <enum name="GL_UNIFORM_MATRIX_STRIDE"/>
-            <enum name="GL_UNIFORM_IS_ROW_MAJOR"/>
-            <enum name="GL_UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX"/>
-        </group>
-        
-        <group name="SamplerParameterName">
-            <enum name="GL_TEXTURE_WRAP_S"/>
-            <enum name="GL_TEXTURE_WRAP_T"/>
-            <enum name="GL_TEXTURE_WRAP_R"/>
-            <enum name="GL_TEXTURE_MIN_FILTER"/>
-            <enum name="GL_TEXTURE_MAG_FILTER"/>
-            <enum name="GL_TEXTURE_BORDER_COLOR"/>
-            <enum name="GL_TEXTURE_MIN_LOD"/>
-            <enum name="GL_TEXTURE_MAX_LOD"/>
-            <enum name="GL_TEXTURE_COMPARE_MODE"/>
-            <enum name="GL_TEXTURE_COMPARE_FUNC"/>
-        </group>
-        
-        <group name="VertexProvokingMode">
-            <enum name="GL_FIRST_VERTEX_CONVENTION"/>
-            <enum name="GL_LAST_VERTEX_CONVENTION"/>
-        </group>
-        
-        <group name="PatchParameterName">
-            <enum name="GL_PATCH_VERTICES"/>
-            <enum name="GL_PATCH_DEFAULT_OUTER_LEVEL"/>
-            <enum name="GL_PATCH_DEFAULT_INNER_LEVEL"/>
-        </group>
-        
-        <group name="ObjectIdentifier">
-            <enum name="GL_BUFFER"/>
-            <enum name="GL_SHADER"/>
-            <enum name="GL_PROGRAM"/>
-            <enum name="GL_VERTEX_ARRAY"/>
-            <enum name="GL_QUERY"/>
-            <enum name="GL_PROGRAM_PIPELINE"/>
-            <enum name="GL_TRANSFORM_FEEDBACK"/>
-            <enum name="GL_SAMPLER"/>
-            <enum name="GL_TEXTURE"/>
-            <enum name="GL_RENDERBUFFER"/>
-            <enum name="GL_FRAMEBUFFER"/>
-        </group>
-        
-        <group name="ColorBuffer">
-            <enum name="GL_NONE"/>
-            <enum name="GL_FRONT_LEFT"/>
-            <enum name="GL_FRONT_RIGHT"/>
-            <enum name="GL_BACK_LEFT"/>
-            <enum name="GL_BACK_RIGHT"/>
-            <enum name="GL_FRONT"/>
-            <enum name="GL_BACK"/>
-            <enum name="GL_LEFT"/>
-            <enum name="GL_RIGHT"/>
-            <enum name="GL_FRONT_AND_BACK"/>
-            <enum name="GL_NONE"/>
-            <enum name="GL_COLOR_ATTACHMENT0"/>
-            <enum name="GL_COLOR_ATTACHMENT1"/>
-            <enum name="GL_COLOR_ATTACHMENT2"/>
-            <enum name="GL_COLOR_ATTACHMENT3"/>
-            <enum name="GL_COLOR_ATTACHMENT4"/>
-            <enum name="GL_COLOR_ATTACHMENT5"/>
-            <enum name="GL_COLOR_ATTACHMENT6"/>
-            <enum name="GL_COLOR_ATTACHMENT7"/>
-            <enum name="GL_COLOR_ATTACHMENT8"/>
-            <enum name="GL_COLOR_ATTACHMENT9"/>
-            <enum name="GL_COLOR_ATTACHMENT10"/>
-            <enum name="GL_COLOR_ATTACHMENT11"/>
-            <enum name="GL_COLOR_ATTACHMENT12"/>
-            <enum name="GL_COLOR_ATTACHMENT13"/>
-            <enum name="GL_COLOR_ATTACHMENT14"/>
-            <enum name="GL_COLOR_ATTACHMENT15"/>
-            <enum name="GL_COLOR_ATTACHMENT16"/>
-            <enum name="GL_COLOR_ATTACHMENT17"/>
-            <enum name="GL_COLOR_ATTACHMENT18"/>
-            <enum name="GL_COLOR_ATTACHMENT19"/>
-            <enum name="GL_COLOR_ATTACHMENT20"/>
-            <enum name="GL_COLOR_ATTACHMENT21"/>
-            <enum name="GL_COLOR_ATTACHMENT22"/>
-            <enum name="GL_COLOR_ATTACHMENT23"/>
-            <enum name="GL_COLOR_ATTACHMENT24"/>
-            <enum name="GL_COLOR_ATTACHMENT25"/>
-            <enum name="GL_COLOR_ATTACHMENT26"/>
-            <enum name="GL_COLOR_ATTACHMENT27"/>
-            <enum name="GL_COLOR_ATTACHMENT28"/>
-            <enum name="GL_COLOR_ATTACHMENT29"/>
-            <enum name="GL_COLOR_ATTACHMENT30"/>
-            <enum name="GL_COLOR_ATTACHMENT31"/>
-        </group>
-        
-        <group name="MapQuery">
-            <enum name="GL_COEFF"/>
-            <enum name="GL_ORDER"/>
-            <enum name="GL_DOMAIN"/>
-        </group>
-        
-        <group name="VertexArrayPName">
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_ENABLED"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_SIZE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_STRIDE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_TYPE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_NORMALIZED"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_LONG"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR"/>
-            <enum name="GL_VERTEX_ATTRIB_RELATIVE_OFFSET"/>
-        </group>
-        
-        <group name="TransformFeedbackPName">
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_BINDING"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_START"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_SIZE"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_PAUSED"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_ACTIVE"/>
-        </group>
-        
-        <group name="SyncParameterName">
-            <enum name="GL_OBJECT_TYPE"/>
-            <enum name="GL_SYNC_STATUS"/>
-            <enum name="GL_SYNC_CONDITION"/>
-            <enum name="GL_SYNC_FLAGS"/>
-        </group>
-        
-        <group name="ShaderParameterName">
-            <enum name="GL_SHADER_TYPE"/>
-            <enum name="GL_DELETE_STATUS"/>
-            <enum name="GL_COMPILE_STATUS"/>
-            <enum name="GL_INFO_LOG_LENGTH"/>
-            <enum name="GL_SHADER_SOURCE_LENGTH"/>
-        </group>
-        
-        <group name="QueryParameterName">
-            <enum name="GL_CURRENT_QUERY"/>
-            <enum name="GL_QUERY_COUNTER_BITS"/>
-        </group>
-        
-        <group name="ProgramStagePName">
-            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORMS"/>
-            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS"/>
-            <enum name="GL_ACTIVE_SUBROUTINES"/>
-            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH"/>
-            <enum name="GL_ACTIVE_SUBROUTINE_MAX_LENGTH"/>
-        </group>
-        
-        <group name="PipelineParameterName">
-            <enum name="GL_ACTIVE_PROGRAM"/>
-            <enum name="GL_VERTEX_SHADER"/>
-            <enum name="GL_TESS_CONTROL_SHADER"/>
-            <enum name="GL_TESS_EVALUATION_SHADER"/>
-            <enum name="GL_GEOMETRY_SHADER"/>
-            <enum name="GL_FRAGMENT_SHADER"/>
-            <enum name="GL_INFO_LOG_LENGTH"/>
-        </group>
-        
-        <group name="ProgramInterface">
-            <enum name="GL_UNIFORM"/>
-            <enum name="GL_UNIFORM_BLOCK"/>
-            <enum name="GL_PROGRAM_INPUT"/>
-            <enum name="GL_PROGRAM_OUTPUT"/>
-            <enum name="GL_VERTEX_SUBROUTINE"/>
-            <enum name="GL_TESS_CONTROL_SUBROUTINE"/>
-            <enum name="GL_TESS_EVALUATION_SUBROUTINE"/>
-            <enum name="GL_GEOMETRY_SUBROUTINE"/>
-            <enum name="GL_FRAGMENT_SUBROUTINE"/>
-            <enum name="GL_COMPUTE_SUBROUTINE"/>
-            <enum name="GL_VERTEX_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_TESS_CONTROL_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_TESS_EVALUATION_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_GEOMETRY_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_FRAGMENT_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_COMPUTE_SUBROUTINE_UNIFORM"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_VARYING"/>
-            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
-            <enum name="GL_BUFFER_VARIABLE"/>
-            <enum name="GL_SHADER_STORAGE_BLOCK"/>
-        </group>
-        
-        <group name="VertexAttribEnum">
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_ENABLED"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_SIZE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_STRIDE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_TYPE"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_NORMALIZED"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER"/>
-            <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR"/>
-            <enum name="GL_CURRENT_VERTEX_ATTRIB"/>
-        </group>
-        
-        <group name="VertexAttribType">
-            <enum name="GL_BYTE"/>
-            <enum name="GL_SHORT"/>
-            <enum name="GL_INT"/>
-            <enum name="GL_FIXED"/>
-            <enum name="GL_FLOAT"/>
-            <enum name="GL_HALF_FLOAT"/>
-            <enum name="GL_DOUBLE"/>
-            <enum name="GL_UNSIGNED_BYTE"/>
-            <enum name="GL_UNSIGNED_SHORT"/>
-            <enum name="GL_UNSIGNED_INT"/>
-            <enum name="GL_INT_2_10_10_10_REV"/>
-            <enum name="GL_UNSIGNED_INT_2_10_10_10_REV"/>
-            <enum name="GL_UNSIGNED_INT_10F_11F_11F_REV"/>
-        </group>
-        
-        <group name="AttributeType">
-            <enum name="GL_FLOAT_VEC2"/>  
-            <enum name="GL_FLOAT_VEC2_ARB"/>  
-            <enum name="GL_FLOAT_VEC3"/>  
-            <enum name="GL_FLOAT_VEC3_ARB"/>  
-            <enum name="GL_FLOAT_VEC4"/>  
-            <enum name="GL_FLOAT_VEC4_ARB"/>  
-            <enum name="GL_INT_VEC2"/>  
-            <enum name="GL_INT_VEC2_ARB"/>  
-            <enum name="GL_INT_VEC3"/>  
-            <enum name="GL_INT_VEC3_ARB"/>  
-            <enum name="GL_INT_VEC4"/>  
-            <enum name="GL_INT_VEC4_ARB"/>  
-            <enum name="GL_BOOL"/>  
-            <enum name="GL_BOOL_ARB"/>  
-            <enum name="GL_BOOL_VEC2"/>  
-            <enum name="GL_BOOL_VEC2_ARB"/>  
-            <enum name="GL_BOOL_VEC3"/>  
-            <enum name="GL_BOOL_VEC3_ARB"/>  
-            <enum name="GL_BOOL_VEC4"/>  
-            <enum name="GL_BOOL_VEC4_ARB"/>  
-            <enum name="GL_FLOAT_MAT2"/>  
-            <enum name="GL_FLOAT_MAT2_ARB"/>  
-            <enum name="GL_FLOAT_MAT3"/>  
-            <enum name="GL_FLOAT_MAT3_ARB"/>  
-            <enum name="GL_FLOAT_MAT4"/>  
-            <enum name="GL_FLOAT_MAT4_ARB"/>  
-            <enum name="GL_SAMPLER_1D"/>  
-            <enum name="GL_SAMPLER_1D_ARB"/>  
-            <enum name="GL_SAMPLER_2D"/>  
-            <enum name="GL_SAMPLER_2D_ARB"/>  
-            <enum name="GL_SAMPLER_3D"/>  
-            <enum name="GL_SAMPLER_3D_ARB"/>  
-            <enum name="GL_SAMPLER_3D_OES"/>  
-            <enum name="GL_SAMPLER_CUBE"/>  
-            <enum name="GL_SAMPLER_CUBE_ARB"/>  
-            <enum name="GL_SAMPLER_1D_SHADOW"/>  
-            <enum name="GL_SAMPLER_1D_SHADOW_ARB"/>  
-            <enum name="GL_SAMPLER_2D_SHADOW"/>  
-            <enum name="GL_SAMPLER_2D_SHADOW_ARB"/>  
-            <enum name="GL_SAMPLER_2D_SHADOW_EXT"/>  
-            <enum name="GL_SAMPLER_2D_RECT"/>  
-            <enum name="GL_SAMPLER_2D_RECT_ARB"/>  
-            <enum name="GL_SAMPLER_2D_RECT_SHADOW"/>  
-            <enum name="GL_SAMPLER_2D_RECT_SHADOW_ARB"/>  
-            <enum name="GL_FLOAT_MAT2x3"/>  
-            <enum name="GL_FLOAT_MAT2x3_NV"/>  
-            <enum name="GL_FLOAT_MAT2x4"/>  
-            <enum name="GL_FLOAT_MAT2x4_NV"/>  
-            <enum name="GL_FLOAT_MAT3x2"/>  
-            <enum name="GL_FLOAT_MAT3x2_NV"/>  
-            <enum name="GL_FLOAT_MAT3x4"/>  
-            <enum name="GL_FLOAT_MAT3x4_NV"/>  
-            <enum name="GL_FLOAT_MAT4x2"/>  
-            <enum name="GL_FLOAT_MAT4x2_NV"/>  
-            <enum name="GL_FLOAT_MAT4x3"/>  
-            <enum name="GL_FLOAT_MAT4x3_NV"/>  
-        </group>
-        
-        <group name="InternalFormatPName">
-            <enum name="GL_NUM_SAMPLE_COUNTS"/>  
-            <enum name="GL_SAMPLES"/>  
-            <enum name="GL_INTERNALFORMAT_SUPPORTED"/>  
-            <enum name="GL_INTERNALFORMAT_PREFERRED"/>  
-            <enum name="GL_INTERNALFORMAT_RED_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_GREEN_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_BLUE_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_ALPHA_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_DEPTH_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_STENCIL_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_SHARED_SIZE"/>  
-            <enum name="GL_INTERNALFORMAT_RED_TYPE"/>  
-            <enum name="GL_INTERNALFORMAT_GREEN_TYPE"/>  
-            <enum name="GL_INTERNALFORMAT_BLUE_TYPE"/>  
-            <enum name="GL_INTERNALFORMAT_ALPHA_TYPE"/>  
-            <enum name="GL_INTERNALFORMAT_DEPTH_TYPE"/>  
-            <enum name="GL_INTERNALFORMAT_STENCIL_TYPE"/>  
-            <enum name="GL_MAX_WIDTH"/>  
-            <enum name="GL_MAX_HEIGHT"/>  
-            <enum name="GL_MAX_DEPTH"/>  
-            <enum name="GL_MAX_LAYERS"/>  
-            <enum name="GL_COLOR_COMPONENTS"/>  
-            <enum name="GL_COLOR_RENDERABLE"/>  
-            <enum name="GL_DEPTH_RENDERABLE"/>  
-            <enum name="GL_STENCIL_RENDERABLE"/>  
-            <enum name="GL_FRAMEBUFFER_RENDERABLE"/>  
-            <enum name="GL_FRAMEBUFFER_RENDERABLE_LAYERED"/>  
-            <enum name="GL_FRAMEBUFFER_BLEND"/>  
-            <enum name="GL_READ_PIXELS"/>  
-            <enum name="GL_READ_PIXELS_FORMAT"/>  
-            <enum name="GL_READ_PIXELS_TYPE"/>  
-            <enum name="GL_TEXTURE_IMAGE_FORMAT"/>  
-            <enum name="GL_TEXTURE_IMAGE_TYPE"/>  
-            <enum name="GL_GET_TEXTURE_IMAGE_FORMAT"/>  
-            <enum name="GL_GET_TEXTURE_IMAGE_TYPE"/>  
-            <enum name="GL_MIPMAP"/>  
-            <enum name="GL_GENERATE_MIPMAP"/>  
-            <enum name="GL_AUTO_GENERATE_MIPMAP"/>  
-            <enum name="GL_COLOR_ENCODING"/>  
-            <enum name="GL_SRGB_READ"/>  
-            <enum name="GL_SRGB_WRITE"/>  
-            <enum name="GL_FILTER"/>  
-            <enum name="GL_VERTEX_TEXTURE"/>  
-            <enum name="GL_TESS_CONTROL_TEXTURE"/>  
-            <enum name="GL_TESS_EVALUATION_TEXTURE"/>  
-            <enum name="GL_GEOMETRY_TEXTURE"/>  
-            <enum name="GL_FRAGMENT_TEXTURE"/>  
-            <enum name="GL_COMPUTE_TEXTURE"/>  
-            <enum name="GL_TEXTURE_SHADOW"/>  
-            <enum name="GL_TEXTURE_GATHER"/>  
-            <enum name="GL_TEXTURE_GATHER_SHADOW"/>  
-            <enum name="GL_SHADER_IMAGE_LOAD"/>  
-            <enum name="GL_SHADER_IMAGE_STORE"/>  
-            <enum name="GL_SHADER_IMAGE_ATOMIC"/>  
-            <enum name="GL_IMAGE_TEXEL_SIZE"/>  
-            <enum name="GL_IMAGE_COMPATIBILITY_CLASS"/>  
-            <enum name="GL_IMAGE_PIXEL_FORMAT"/>  
-            <enum name="GL_IMAGE_PIXEL_TYPE"/>  
-            <enum name="GL_IMAGE_FORMAT_COMPATIBILITY_TYPE"/>  
-            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_TEST"/>  
-            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST"/>  
-            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE"/>  
-            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE"/>  
-            <enum name="GL_TEXTURE_COMPRESSED"/>  
-            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_WIDTH"/>  
-            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_HEIGHT"/>  
-            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_SIZE"/>  
-            <enum name="GL_CLEAR_BUFFER"/>  
-            <enum name="GL_TEXTURE_VIEW"/>  
-            <enum name="GL_VIEW_COMPATIBILITY_CLASS"/>  
-            <enum name="GL_CLEAR_TEXTURE"/>  
-        </group>
-        
-        <group name="FramebufferAttachmentParameterName">
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_LAYERED"/>  
-            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER"/>  
-        </group>
-        
-        <group name="FramebufferParameter">
-            <enum name="GL_FRAMEBUFFER_DEFAULT_WIDTH"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_HEIGHT"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_LAYERS"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_SAMPLES"/>
-            <enum name="GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS"/>
-            <enum name="GL_DOUBLEBUFFER"/>
-            <enum name="GL_IMPLEMENTATION_COLOR_READ_FORMAT"/>
-            <enum name="GL_IMPLEMENTATION_COLOR_READ_TYPE"/>
-            <enum name="GL_SAMPLES"/>
-            <enum name="GL_SAMPLE_BUFFERS"/>
-            <enum name="GL_STEREO"/>
-        </group>
-        
-        <group name="ProgramInterfacePName">
-            <enum name="GL_ACTIVE_RESOURCES"/>
-            <enum name="GL_MAX_NAME_LENGTH"/>
-            <enum name="GL_MAX_NUM_ACTIVE_VARIABLES"/>
-            <enum name="GL_MAX_NUM_COMPATIBLE_SUBROUTINES"/>
-        </group>
-        
-        <group name="PrecisionType">
-            <enum name="GL_LOW_FLOAT"/>
-            <enum name="GL_MEDIUM_FLOAT"/>
-            <enum name="GL_HIGH_FLOAT"/>
-            <enum name="GL_LOW_INT"/>
-            <enum name="GL_MEDIUM_INT"/>
-            <enum name="GL_HIGH_INT"/>
-        </group>
-        
-        <group name="VertexAttribPointerType">
-            <enum name="GL_INT_2_10_10_10_REV"/>
-            <enum name="GL_UNSIGNED_INT_2_10_10_10_REV"/>
-            <enum name="GL_UNSIGNED_INT_10F_11F_11F_REV"/>
-        </group>
-        
-        <group name="SubroutineParameterName">
-            <enum name="GL_NUM_COMPATIBLE_SUBROUTINES"/>
-            <enum name="GL_COMPATIBLE_SUBROUTINES"/>
-            <enum name="GL_UNIFORM_SIZE"/>
-            <enum name="GL_UNIFORM_NAME_LENGTH"/>
         </group>
     </groups>
 
@@ -9694,12 +8833,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glAlphaFuncx</name></proto>
-            <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
+            <param><ptype>GLenum</ptype> <name>func</name></param>
             <param><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
-            <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
+            <param><ptype>GLenum</ptype> <name>func</name></param>
             <param group="ClampedFixed"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
@@ -9805,39 +8944,39 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBeginQuery</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <glx type="render" opcode="231"/>
         </command>
         <command>
             <proto>void <name>glBeginQueryARB</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <alias name="glBeginQuery"/>
         </command>
         <command>
             <proto>void <name>glBeginQueryEXT</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
             <proto>void <name>glBeginQueryIndexed</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedback</name></proto>
-            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedbackEXT</name></proto>
-            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
             <alias name="glBeginTransformFeedback"/>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedbackNV</name></proto>
-            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
             <alias name="glBeginTransformFeedback"/>
         </command>
         <command>
@@ -9873,34 +9012,34 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferBase</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glBindBufferBaseEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glBindBufferBase"/>
         </command>
         <command>
             <proto>void <name>glBindBufferBaseNV</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glBindBufferBase"/>
         </command>
         <command>
             <proto>void <name>glBindBufferOffsetEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBindBufferOffsetNV</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -9908,7 +9047,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferRange</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -9916,7 +9055,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferRangeEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -9925,7 +9064,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferRangeNV</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -9934,14 +9073,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBuffersBase</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>buffers</name></param>
         </command>
         <command>
             <proto>void <name>glBindBuffersRange</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>buffers</name></param>
@@ -9994,7 +9133,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindFramebufferOES</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
         </command>
         <command>
@@ -10004,8 +9143,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>access</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
         </command>
         <command>
             <proto>void <name>glBindImageTextureEXT</name></proto>
@@ -10014,8 +9153,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>access</name></param>
+            <param><ptype>GLint</ptype> <name>format</name></param>
         </command>
         <command>
             <proto>void <name>glBindImageTextures</name></proto>
@@ -10078,7 +9217,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindRenderbufferOES</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
@@ -10129,7 +9268,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindTransformFeedback</name></proto>
-            <param group="BindTransformFeedbackTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
@@ -10305,7 +9444,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <glx type="render" opcode="4097"/>
         </command>
         <command>
@@ -10346,57 +9485,57 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateOES</name></proto>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparatei</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationi</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
@@ -10449,71 +9588,71 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateOES</name></proto>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparatei</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFunci</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>src</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dst</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param><ptype>GLenum</ptype> <name>dst</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFunciARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>src</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dst</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
             <proto>void <name>glBlendFunciEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>src</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dst</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
             <proto>void <name>glBlendFunciOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>src</name></param>
-            <param group="ColorScaleFactor"><ptype>GLenum</ptype> <name>dst</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
@@ -10532,7 +9671,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
             <glx type="render" opcode="4330"/>
         </command>
         <command>
@@ -10546,7 +9685,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
         </command>
         <command>
             <proto>void <name>glBlitFramebufferEXT</name></proto>
@@ -10559,7 +9698,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
             <alias name="glBlitFramebuffer"/>
             <glx type="render" opcode="4330"/>
         </command>
@@ -10574,7 +9713,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
             <alias name="glBlitFramebuffer"/>
         </command>
         <command>
@@ -10590,7 +9729,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
         </command>
         <command>
             <proto>void <name>glBufferAddressRangeNV</name></proto>
@@ -10629,14 +9768,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBufferStorage</name></proto>
-            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glBufferStorageEXT</name></proto>
-            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
@@ -10674,24 +9813,24 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="2"/>
         </command>
         <command>
-            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatus</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatus</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="vendor" opcode="1427"/>
         </command>
         <command>
-            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatusEXT</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatusEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glCheckFramebufferStatus"/>
             <glx type="vendor" opcode="1427"/>
         </command>
         <command>
-            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatusOES</name></proto>
-            <param group="CheckFramebufferStatusTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatusOES</name></proto>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatus</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatus</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="CheckFramebufferStatusTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatusEXT</name></proto>
@@ -10733,44 +9872,44 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
-            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferSubData</name></proto>
-            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferfi</name></proto>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferfv</name></proto>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferiv</name></proto>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferuiv</name></proto>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
@@ -10848,15 +9987,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedBufferData</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedBufferDataEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
@@ -10864,17 +10003,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedBufferSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedBufferSubDataEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -10884,7 +10023,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedFramebufferfi</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
@@ -10892,21 +10031,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
@@ -10925,16 +10064,16 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearTexImage</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearTexImageEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
             <alias name="glClearTexImage"/>
         </command>
@@ -10948,8 +10087,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
@@ -10962,8 +10101,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
             <alias name="glClearTexSubImage"/>
         </command>
@@ -10985,13 +10124,13 @@ typedef unsigned int GLhandleARB;
             <param group="ClientAttribMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
         </command>
         <command>
-            <proto group="SyncStatus"><ptype>GLenum</ptype> <name>glClientWaitSync</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glClientWaitSync</name></proto>
             <param group="sync"><ptype>GLsync</ptype> <name>sync</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
             <param><ptype>GLuint64</ptype> <name>timeout</name></param>
         </command>
         <command>
-            <proto group="SyncStatus"><ptype>GLenum</ptype> <name>glClientWaitSyncAPPLE</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glClientWaitSyncAPPLE</name></proto>
             <param><ptype>GLsync</ptype> <name>sync</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
             <param><ptype>GLuint64</ptype> <name>timeout</name></param>
@@ -10999,8 +10138,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClipControl</name></proto>
-            <param group="ClipControlOrigin"><ptype>GLenum</ptype> <name>origin</name></param>
-            <param group="ClipControlDepth"><ptype>GLenum</ptype> <name>depth</name></param>
+            <param><ptype>GLenum</ptype> <name>origin</name></param>
+            <param><ptype>GLenum</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlane</name></proto>
@@ -11010,33 +10149,33 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClipPlanef</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
+            <param><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanefIMG</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
+            <param><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanefOES</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>equation</name></param>
             <glx type="render" opcode="4312"/>
         </command>
         <command>
             <proto>void <name>glClipPlanex</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanexIMG</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
+            <param><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanexOES</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
@@ -11450,22 +10589,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
@@ -11521,7 +10660,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTable</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -11532,7 +10671,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -11572,7 +10711,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -11664,7 +10803,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -11675,7 +10814,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -11687,7 +10826,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11738,7 +10877,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -11750,7 +10889,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -11762,7 +10901,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -11775,7 +10914,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -11788,7 +10927,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11802,7 +10941,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11814,9 +10953,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCompressedTexImage3DOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11911,15 +11050,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage3DOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexSubImage3D"/>
@@ -11929,7 +11068,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -11940,7 +11079,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -11952,7 +11091,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11966,7 +11105,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -11989,7 +11128,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -12016,7 +11155,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -12048,7 +11187,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter1D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -12059,7 +11198,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter1DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -12070,7 +11209,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter2D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -12082,7 +11221,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter2DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -12153,28 +11292,28 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glConvolutionParameterxOES</name></proto>
-            <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterxvOES</name></proto>
-            <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glCopyBufferSubData</name></proto>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>readTarget</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>writeTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>readTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>writeTarget</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>readOffset</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>writeOffset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
         </command>
         <command>
             <proto>void <name>glCopyBufferSubDataNV</name></proto>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>readTarget</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>writeTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>readTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>writeTarget</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>readOffset</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>writeOffset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -12201,7 +11340,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyColorTable</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12210,7 +11349,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyColorTableSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12220,7 +11359,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter1D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12229,7 +11368,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter1DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12239,7 +11378,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter2D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12249,7 +11388,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter2DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12260,13 +11399,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -12278,13 +11417,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -12297,13 +11436,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataNV</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -12316,13 +11455,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataOES</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -12337,7 +11476,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12348,7 +11487,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12416,7 +11555,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12427,7 +11566,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12439,7 +11578,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12451,7 +11590,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12535,7 +11674,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCopyTexSubImage3DOES</name></proto>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
@@ -12551,7 +11690,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12562,7 +11701,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12724,7 +11863,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCreateQueries</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param><ptype>GLuint</ptype> *<name>ids</name></param>
         </command>
@@ -12740,27 +11879,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShader</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
         </command>
         <command>
             <proto group="handleARB"><ptype>GLhandleARB</ptype> <name>glCreateShaderObjectARB</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shaderType</name></param>
+            <param><ptype>GLenum</ptype> <name>shaderType</name></param>
             <alias name="glCreateShader"/>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramEXT</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const <ptype>GLchar</ptype> *<name>string</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramv</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLchar</ptype> *const*<name>strings</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramvEXT</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLchar</ptype> **<name>strings</name></param>
         </command>
@@ -12777,7 +11916,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCreateTextures</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param><ptype>GLuint</ptype> *<name>textures</name></param>
         </command>
@@ -12839,18 +11978,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDebugMessageControl</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
-            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageControlARB</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
-            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
@@ -12858,9 +11997,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDebugMessageControlKHR</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
-            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param>const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param><ptype>GLboolean</ptype> <name>enabled</name></param>
@@ -12869,24 +12008,24 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDebugMessageEnableAMD</name></proto>
             <param><ptype>GLenum</ptype> <name>category</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsert</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
-            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(buf,length)">const <ptype>GLchar</ptype> *<name>buf</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsertAMD</name></proto>
             <param><ptype>GLenum</ptype> <name>category</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="length">const <ptype>GLchar</ptype> *<name>buf</name></param>
@@ -12906,7 +12045,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>source</name></param>
             <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
+            <param><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>buf</name></param>
             <alias name="glDebugMessageInsert"/>
@@ -13352,24 +12491,24 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDisablei</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto>void <name>glDisableiEXT</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
         <command>
             <proto>void <name>glDisableiNV</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
         <command>
             <proto>void <name>glDisableiOES</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
@@ -13594,7 +12733,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDrawElementsIndirect</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
         </command>
         <command>
@@ -13609,7 +12748,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedANGLE</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(count,type)">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glDrawElementsInstanced"/>
@@ -13627,7 +12766,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseInstance</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLuint</ptype> <name>baseinstance</name></param>
@@ -13636,7 +12775,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseInstanceEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLuint</ptype> <name>baseinstance</name></param>
@@ -13655,7 +12794,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseVertexBaseInstance</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLint</ptype> <name>basevertex</name></param>
@@ -13665,7 +12804,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseVertexBaseInstanceEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLint</ptype> <name>basevertex</name></param>
@@ -13705,7 +12844,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedNV</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(count,type)">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glDrawElementsInstanced"/>
@@ -14013,24 +13152,24 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEnablei</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto>void <name>glEnableiEXT</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
         <command>
             <proto>void <name>glEnableiNV</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
         <command>
             <proto>void <name>glEnableiOES</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
@@ -14070,21 +13209,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEndQuery</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="232"/>
         </command>
         <command>
             <proto>void <name>glEndQueryARB</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glEndQuery"/>
         </command>
         <command>
             <proto>void <name>glEndQueryEXT</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glEndQueryIndexed</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
@@ -14270,8 +13409,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>void *<name>texels</name></param>
         </command>
         <command>
@@ -14311,12 +13450,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="sync"><ptype>GLsync</ptype> <name>glFenceSync</name></proto>
-            <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
+            <param><ptype>GLenum</ptype> <name>condition</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto><ptype>GLsync</ptype> <name>glFenceSyncAPPLE</name></proto>
-            <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
+            <param><ptype>GLenum</ptype> <name>condition</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
             <alias name="glFenceSync"/>
         </command>
@@ -14365,14 +13504,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFlushMappedBufferRangeAPPLE</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <alias name="glFlushMappedBufferRange"/>
         </command>
         <command>
             <proto>void <name>glFlushMappedBufferRangeEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>length</name></param>
             <alias name="glFlushMappedBufferRange"/>
@@ -14520,22 +13659,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogx</name></proto>
-            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxOES</name></proto>
-            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxv</name></proto>
-            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxvOES</name></proto>
-            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -14655,8 +13794,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferParameteri</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -14688,9 +13827,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferRenderbufferOES</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
@@ -14716,8 +13855,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -14725,7 +13864,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture1D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <glx type="render" opcode="4321"/>
@@ -14734,7 +13873,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture1DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture1D"/>
@@ -14744,7 +13883,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture2D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <glx type="render" opcode="4322"/>
@@ -14753,7 +13892,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture2DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture2D"/>
@@ -14761,9 +13900,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DDownsampleIMG</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xscale</name></param>
@@ -14771,27 +13910,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleEXT</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleIMG</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DOES</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -14799,7 +13938,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture3D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -14809,7 +13948,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture3DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -14818,9 +13957,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture3DOES</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -15169,18 +14308,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGenerateMipmap</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="4325"/>
         </command>
         <command>
             <proto>void <name>glGenerateMipmapEXT</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glGenerateMipmap"/>
             <glx type="render" opcode="4325"/>
         </command>
         <command>
             <proto>void <name>glGenerateMipmapOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glGenerateMultiTexMipmapEXT</name></proto>
@@ -15200,7 +14339,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetActiveAtomicCounterBufferiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLuint</ptype> <name>bufferIndex</name></param>
-            <param group="AtomicCounterBufferPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15210,7 +14349,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1" group="AttributeType"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
@@ -15220,14 +14359,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>maxLength</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1" group="AttributeType"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="maxLength"><ptype>GLcharARB</ptype> *<name>name</name></param>
             <alias name="glGetActiveAttrib"/>
         </command>
         <command>
             <proto>void <name>glGetActiveSubroutineName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -15236,7 +14375,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetActiveSubroutineUniformName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -15245,9 +14384,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetActiveSubroutineUniformiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="SubroutineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>values</name></param>
         </command>
         <command>
@@ -15257,7 +14396,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1" group="AttributeType"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
@@ -15267,7 +14406,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>maxLength</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1" group="AttributeType"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="maxLength"><ptype>GLcharARB</ptype> *<name>name</name></param>
             <alias name="glGetActiveUniform"/>
         </command>
@@ -15283,7 +14422,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetActiveUniformBlockiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLuint</ptype> <name>uniformBlockIndex</name></param>
-            <param group="UniformBlockPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(program,uniformBlockIndex,pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15299,7 +14438,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLsizei</ptype> <name>uniformCount</name></param>
             <param len="uniformCount">const <ptype>GLuint</ptype> *<name>uniformIndices</name></param>
-            <param group="UniformPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(uniformCount,pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15351,14 +14490,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBooleanIndexedvEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
             <alias name="glGetBooleani_v"/>
         </command>
         <command>
             <proto>void <name>glGetBooleani_v</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
@@ -15389,7 +14528,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBufferParameterui64vNV</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
@@ -15408,8 +14547,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBufferPointervOES</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="BufferPointerNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>params</name></param>
             <alias name="glGetBufferPointerv"/>
         </command>
@@ -15436,23 +14575,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetClipPlanef</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfloat</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glGetClipPlanefOES</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfloat</ptype> *<name>equation</name></param>
             <glx type="vendor" opcode="1421"/>
         </command>
         <command>
             <proto>void <name>glGetClipPlanex</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glGetClipPlanexOES</name></proto>
-            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
+            <param><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
@@ -15475,42 +14614,42 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetColorTableParameterfv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="148"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterfvEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glGetColorTableParameterfv"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterfvSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="4099"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameteriv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="149"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterivEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetColorTableParameteriv"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterivSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="4100"/>
         </command>
@@ -15637,7 +14776,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetConvolutionParameterfv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetConvolutionParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="151"/>
         </command>
@@ -15651,7 +14790,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetConvolutionParameteriv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetConvolutionParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="152"/>
         </command>
@@ -15677,10 +14816,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLog</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
         </command>
@@ -15689,7 +14828,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="count"><ptype>GLenum</ptype> *<name>categories</name></param>
-            <param len="count" group="DebugSeverity"><ptype>GLuint</ptype> *<name>severities</name></param>
+            <param len="count"><ptype>GLuint</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufsize"><ptype>GLchar</ptype> *<name>message</name></param>
@@ -15698,10 +14837,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLogARB</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
             <alias name="glGetDebugMessageLog"/>
@@ -15710,10 +14849,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLogKHR</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
             <alias name="glGetDebugMessageLog"/>
@@ -15733,7 +14872,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetDoublei_v</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLdouble</ptype> *<name>data</name></param>
         </command>
@@ -15794,12 +14933,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetFixedv</name></proto>
-            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFixedvOES</name></proto>
-            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15896,7 +15035,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetFramebufferAttachmentParameteriv</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1428"/>
         </command>
@@ -15904,21 +15043,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetFramebufferAttachmentParameterivEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetFramebufferAttachmentParameteriv"/>
             <glx type="vendor" opcode="1428"/>
         </command>
         <command>
             <proto>void <name>glGetFramebufferAttachmentParameterivOES</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFramebufferParameterfvAMD</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>numsamples</name></param>
             <param><ptype>GLuint</ptype> <name>pixelindex</name></param>
@@ -15927,31 +15066,31 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetFramebufferParameteriv</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="FramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFramebufferParameterivEXT</name></proto>
             <param group="Framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetFramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto><ptype>GLsizei</ptype> <name>glGetFramebufferPixelLocalStorageSizeEXT</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatus</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatus</name></proto>
         </command>
         <command>
-            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusARB</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusARB</name></proto>
         </command>
         <command>
-            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusEXT</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusEXT</name></proto>
         </command>
         <command>
-            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusKHR</name></proto>
+            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusKHR</name></proto>
             <alias name="glGetGraphicsResetStatus"/>
         </command>
         <command>
@@ -15980,35 +15119,35 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetHistogramParameterfv</name></proto>
             <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="HistogramParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetHistogramParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="155"/>
         </command>
         <command>
             <proto>void <name>glGetHistogramParameterfvEXT</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="HistogramParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetHistogramParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="6"/>
         </command>
         <command>
             <proto>void <name>glGetHistogramParameteriv</name></proto>
             <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="HistogramParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetHistogramParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="156"/>
         </command>
         <command>
             <proto>void <name>glGetHistogramParameterivEXT</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="HistogramParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetHistogramParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="7"/>
         </command>
         <command>
             <proto>void <name>glGetHistogramParameterxvOES</name></proto>
-            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="HistogramParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16052,37 +15191,37 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetInteger64i_v</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLint64</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetInteger64v</name></proto>
-            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetInteger64vAPPLE</name></proto>
-            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>params</name></param>
             <alias name="glGetInteger64v"/>
         </command>
         <command>
             <proto>void <name>glGetIntegerIndexedvEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLint</ptype> *<name>data</name></param>
             <alias name="glGetIntegeri_v"/>
         </command>
         <command>
             <proto>void <name>glGetIntegeri_v</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLint</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetIntegeri_vEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> *<name>data</name></param>
         </command>
@@ -16105,26 +15244,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetInternalformatSampleivNV</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetInternalformati64v</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetInternalformativ</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -16162,20 +15301,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetLightxOES</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLightxv</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLightxvOES</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16267,8 +15406,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMapxvOES</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetMapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param len="COMPSIZE(query)"><ptype>GLfixed</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -16287,20 +15426,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMaterialxOES</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetMaterialxv</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMaterialxvOES</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16325,7 +15464,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetMinmaxParameterfv</name></proto>
             <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MinmaxParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetMinmaxParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="158"/>
         </command>
@@ -16339,7 +15478,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetMinmaxParameteriv</name></proto>
             <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MinmaxParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetMinmaxParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="159"/>
         </command>
@@ -16399,7 +15538,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16407,40 +15546,40 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMultiTexParameterIivEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMultiTexParameterIuivEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMultiTexParameterfvEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMultiTexParameterivEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMultisamplefv</name></proto>
-            <param group="GetMultisamplePNameNV"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>val</name></param>
         </command>
@@ -16454,13 +15593,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedBufferParameteri64v</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedBufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16478,7 +15617,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedBufferPointerv</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>params</name></param>
         </command>
         <command>
@@ -16513,8 +15652,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedFramebufferAttachmentParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16527,13 +15666,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedFramebufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedFramebufferParameterivEXT</name></proto>
             <param group="Framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetFramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16581,7 +15720,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedRenderbufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16884,7 +16023,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetPixelMapxv</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param len="size"><ptype>GLfixed</ptype> *<name>values</name></param>
         </command>
@@ -16900,14 +16039,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetPixelTransformParameterfvEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="2051"/>
         </command>
         <command>
             <proto>void <name>glGetPixelTransformParameterivEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="2052"/>
@@ -17000,8 +16139,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramInterfaceiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
-            <param group="ProgramInterfacePName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17077,43 +16216,43 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramPipelineiv</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param group="PipelineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetProgramPipelineivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param group="PipelineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetProgramResourceIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocation</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocationIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocationIndexEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetProgramResourceName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -17122,7 +16261,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramResourcefvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>propCount</name></param>
             <param>const <ptype>GLenum</ptype> *<name>props</name></param>
@@ -17133,7 +16272,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramResourceiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>propCount</name></param>
             <param len="propCount">const <ptype>GLenum</ptype> *<name>props</name></param>
@@ -17144,8 +16283,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramStageiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
-            <param group="ProgramStagePName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>values</name></param>
         </command>
         <command>
@@ -17170,7 +16309,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ProgramPropertyARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="199"/>
         </command>
@@ -17191,47 +16330,47 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetQueryBufferObjecti64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectui64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryIndexediv</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjecti64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjecti64vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1328"/>
             <alias name="glGetQueryObjecti64v"/>
@@ -17239,34 +16378,34 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetQueryObjectiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="165"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectivARB</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectui64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectui64vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1329"/>
             <alias name="glGetQueryObjectui64v"/>
@@ -17274,54 +16413,54 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetQueryObjectuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <glx type="single" opcode="166"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectuivARB</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectuiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryiv</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="164"/>
         </command>
         <command>
             <proto>void <name>glGetQueryivARB</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryivEXT</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetRenderbufferParameteriv</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1424"/>
         </command>
         <command>
             <proto>void <name>glGetRenderbufferParameterivEXT</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetRenderbufferParameteriv"/>
             <glx type="vendor" opcode="1424"/>
@@ -17329,59 +16468,59 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetRenderbufferParameterivOES</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17415,8 +16554,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetShaderPrecisionFormat</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
-            <param group="PrecisionType"><ptype>GLenum</ptype> <name>precisiontype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>precisiontype</name></param>
             <param len="2"><ptype>GLint</ptype> *<name>range</name></param>
             <param len="2"><ptype>GLint</ptype> *<name>precision</name></param>
         </command>
@@ -17438,7 +16577,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetShaderiv</name></proto>
             <param><ptype>GLuint</ptype> <name>shader</name></param>
-            <param group="ShaderParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="198"/>
         </command>
@@ -17459,25 +16598,25 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="String">const <ptype>GLubyte</ptype> *<name>glGetStringi</name></proto>
-            <param group="StringName"><ptype>GLenum</ptype> <name>name</name></param>
+            <param><ptype>GLenum</ptype> <name>name</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetSubroutineIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param>const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetSubroutineUniformLocation</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param>const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetSynciv</name></proto>
             <param group="sync"><ptype>GLsync</ptype> <name>sync</name></param>
-            <param group="SyncParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>values</name></param>
@@ -17485,7 +16624,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetSyncivAPPLE</name></proto>
             <param><ptype>GLsync</ptype> <name>sync</name></param>
-            <param group="SyncParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>values</name></param>
@@ -17517,14 +16656,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexEnvxv</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexEnvxvOES</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17550,8 +16689,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexGenfvOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17563,14 +16702,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexGenivOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexGenxvOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17587,7 +16726,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTexLevelParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="138"/>
         </command>
@@ -17595,56 +16734,56 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTexLevelParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="139"/>
         </command>
         <command>
             <proto>void <name>glGetTexLevelParameterxvOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIiv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="203"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIivEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetTexParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIivOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetTexParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIuiv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <glx type="single" opcode="204"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIuivEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetTexParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterIuivOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetTexParameterIuiv"/>
         </command>
@@ -17657,27 +16796,27 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="136"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="137"/>
         </command>
         <command>
             <proto>void <name>glGetTexParameterxv</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexParameterxvOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17695,10 +16834,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTextureImage</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
@@ -17713,9 +16852,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTextureLevelParameterfv</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17723,14 +16862,14 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureLevelParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17738,59 +16877,59 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterIivEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterIuivEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterfvEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureParameterivEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17819,8 +16958,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
@@ -17862,21 +17001,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTransformFeedbacki64_v</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint64</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetTransformFeedbacki_v</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetTransformFeedbackiv</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -17921,7 +17060,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetUniformSubroutineuiv</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param len="1"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
@@ -18039,46 +17178,46 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetVertexArrayIndexed64iv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIndexediv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIntegeri_vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIntegervEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayPointeri_vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayPointervEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="1">void **<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayiv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -18122,32 +17261,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetVertexAttribLdv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLdouble</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLdvEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLdouble</ptype> *<name>params</name></param>
             <alias name="glGetVertexAttribLdv"/>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLi64vNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLui64vARB</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLui64vNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -18293,161 +17432,161 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnColorTable</name></proto>
-            <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>table</name></param>
         </command>
         <command>
             <proto>void <name>glGetnColorTableARB</name></proto>
-            <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>table</name></param>
         </command>
         <command>
             <proto>void <name>glGetnCompressedTexImage</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>lod</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetnCompressedTexImageARB</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>lod</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetnConvolutionFilter</name></proto>
-            <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>image</name></param>
         </command>
         <command>
             <proto>void <name>glGetnConvolutionFilterARB</name></proto>
-            <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>image</name></param>
         </command>
         <command>
             <proto>void <name>glGetnHistogram</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnHistogramARB</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapdv</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapdvARB</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapfv</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapfvARB</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapiv</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapivARB</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMinmax</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMinmaxARB</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapfv</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapfvARB</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapuiv</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLuint</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapuivARB</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLuint</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapusv</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLushort</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapusvARB</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLushort</ptype> *<name>values</name></param>
         </command>
@@ -18463,9 +17602,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnSeparableFilter</name></proto>
-            <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>rowBufSize</name></param>
             <param>void *<name>row</name></param>
             <param><ptype>GLsizei</ptype> <name>columnBufSize</name></param>
@@ -18474,9 +17613,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnSeparableFilterARB</name></proto>
-            <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>rowBufSize</name></param>
             <param len="rowBufSize">void *<name>row</name></param>
             <param><ptype>GLsizei</ptype> <name>columnBufSize</name></param>
@@ -18485,19 +17624,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnTexImage</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetnTexImageARB</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>img</name></param>
         </command>
@@ -18656,7 +17795,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glHistogram</name></proto>
             <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4110"/>
         </command>
@@ -18664,7 +17803,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glHistogramEXT</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glHistogram"/>
             <glx type="render" opcode="4110"/>
@@ -18849,21 +17988,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glInvalidateFramebuffer</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param len="numAttachments" group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
         </command>
         <command>
             <proto>void <name>glInvalidateNamedFramebufferData</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param>const <ptype>GLenum</ptype> *<name>attachments</name></param>
         </command>
         <command>
             <proto>void <name>glInvalidateNamedFramebufferSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param>const <ptype>GLenum</ptype> *<name>attachments</name></param>
             <param><ptype>GLint</ptype> <name>x</name></param>
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -18871,9 +18010,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glInvalidateSubFramebuffer</name></proto>
-            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param len="numAttachments" group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
             <param><ptype>GLint</ptype> <name>x</name></param>
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -18929,24 +18068,24 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabledi</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediEXT</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediNV</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediOES</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
@@ -19222,22 +18361,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLightModelx</name></proto>
-            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxOES</name></proto>
-            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxv</name></proto>
-            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxvOES</name></proto>
-            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -19270,26 +18409,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLightx</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightxOES</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightxv</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glLightxvOES</name></proto>
-            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
-            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>light</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -19512,7 +18651,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMap1xOES</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLfixed</ptype> <name>u1</name></param>
             <param><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
@@ -19549,7 +18688,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMap2xOES</name></proto>
-            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLfixed</ptype> <name>u1</name></param>
             <param><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
@@ -19573,8 +18712,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void *<name>glMapBufferOES</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>access</name></param>
             <alias name="glMapBuffer"/>
         </command>
         <command>
@@ -19587,7 +18726,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void *<name>glMapBufferRangeEXT</name></proto>
-            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>length</name></param>
             <param><ptype>GLbitfield</ptype> <name>access</name></param>
@@ -19656,12 +18795,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void *<name>glMapNamedBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
+            <param><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapNamedBufferEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="VertexBufferObjectAccess"><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapNamedBufferRange</name></proto>
@@ -19779,26 +18918,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMaterialx</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxOES</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxv</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxvOES</name></proto>
-            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
-            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>face</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -19821,7 +18960,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMatrixIndexPointerOES</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="MatrixIndexPointerTypeARB"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
         </command>
@@ -20018,14 +19157,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMinmax</name></proto>
             <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4111"/>
         </command>
         <command>
             <proto>void <name>glMinmaxEXT</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glMinmax"/>
             <glx type="render" opcode="4111"/>
@@ -20189,7 +19328,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirect</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -20197,7 +19336,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirectAMD</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -20206,7 +19345,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirectBindlessCountNV</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxDrawCount</name></param>
@@ -20216,7 +19355,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirectBindlessNV</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -20225,7 +19364,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirectCountARB</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLintptr</ptype> <name>indirect</name></param>
             <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
@@ -20234,7 +19373,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElementsIndirectEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -20275,12 +19414,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1bOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1bvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="1">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20401,23 +19540,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1xOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1xvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="1">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2bOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2bvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="2">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20547,25 +19686,25 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2xOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2xvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="2">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3bOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
             <param><ptype>GLbyte</ptype> <name>r</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3bvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="3">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20704,19 +19843,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3xOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3xvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="3">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4bOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
             <param><ptype>GLbyte</ptype> <name>r</name></param>
@@ -20724,7 +19863,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4bvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="4">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20872,7 +20011,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4x</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
@@ -20880,7 +20019,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4xOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
@@ -20888,55 +20027,55 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4xvOES</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP1ui</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP1uiv</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP2ui</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP2uiv</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP3ui</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP3uiv</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP4ui</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP4uiv</name></proto>
-            <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -21252,7 +20391,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param>const void *<name>data</name></param>
-            <param group="VertexBufferObjectUsage"><ptype>GLenum</ptype> <name>usage</name></param>
+            <param><ptype>GLenum</ptype> <name>usage</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferDataEXT</name></proto>
@@ -21316,18 +20455,18 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferDrawBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="ColorBuffer"><ptype>GLenum</ptype> <name>buf</name></param>
+            <param><ptype>GLenum</ptype> <name>buf</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferDrawBuffers</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param group="ColorBuffer">const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param>const <ptype>GLenum</ptype> *<name>bufs</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -21339,13 +20478,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferReadBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="ColorBuffer"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferRenderbuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
@@ -21372,7 +20511,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferTexture</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -21426,7 +20565,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferTextureLayer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
@@ -21546,14 +20685,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedRenderbufferStorage</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glNamedRenderbufferStorageEXT</name></proto>
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -21561,7 +20700,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedRenderbufferStorageMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -21570,7 +20709,7 @@ typedef unsigned int GLhandleARB;
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -21578,7 +20717,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedRenderbufferStorageMultisampleEXT</name></proto>
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -21711,12 +20850,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormalP3ui</name></proto>
-            <param group="NormalPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glNormalP3uiv</name></proto>
-            <param group="NormalPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -21806,14 +20945,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glObjectLabel</name></proto>
-            <param group="ObjectIdentifier"><ptype>GLenum</ptype> <name>identifier</name></param>
+            <param><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(label,length)">const <ptype>GLchar</ptype> *<name>label</name></param>
         </command>
         <command>
             <proto>void <name>glObjectLabelKHR</name></proto>
-            <param group="ObjectIdentifier"><ptype>GLenum</ptype> <name>identifier</name></param>
+            <param><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>label</name></param>
@@ -21918,23 +21057,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPatchParameterfv</name></proto>
-            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glPatchParameteri</name></proto>
-            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glPatchParameteriEXT</name></proto>
-            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
             <alias name="glPatchParameteri"/>
         </command>
         <command>
             <proto>void <name>glPatchParameteriOES</name></proto>
-            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
             <alias name="glPatchParameteri"/>
         </command>
@@ -22139,7 +21278,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelMapx</name></proto>
-            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
+            <param><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param len="size">const <ptype>GLfixed</ptype> *<name>values</name></param>
         </command>
@@ -22157,7 +21296,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelStorex</name></proto>
-            <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
@@ -22199,7 +21338,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelTransferxOES</name></proto>
-            <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
@@ -22328,22 +21467,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPointParameterx</name></proto>
-            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxOES</name></proto>
-            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxv</name></proto>
-            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxvOES</name></proto>
-            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -23973,11 +23112,11 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glProvokingVertex</name></proto>
-            <param group="VertexProvokingMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glProvokingVertexEXT</name></proto>
-            <param group="VertexProvokingMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glProvokingVertex"/>
         </command>
         <command>
@@ -23995,14 +23134,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPushDebugGroup</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(message,length)">const <ptype>GLchar</ptype> *<name>message</name></param>
         </command>
         <command>
             <proto>void <name>glPushDebugGroupKHR</name></proto>
-            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param><ptype>GLenum</ptype> <name>source</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>message</name></param>
@@ -24025,12 +23164,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glQueryCounter</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glQueryCounterEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glQueryCounter"/>
         </command>
         <command>
@@ -24040,7 +23179,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glQueryObjectParameteruiAMD</name></proto>
-            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="OcclusionQueryEventMaskAMD"><ptype>GLuint</ptype> <name>param</name></param>
@@ -24231,7 +23370,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReadBufferIndexedEXT</name></proto>
-            <param group="ReadBufferMode"><ptype>GLenum</ptype> <name>src</name></param>
+            <param><ptype>GLenum</ptype> <name>src</name></param>
             <param><ptype>GLint</ptype> <name>index</name></param>
         </command>
         <command>
@@ -24261,8 +23400,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>data</name></param>
         </command>
@@ -24272,8 +23411,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>data</name></param>
             <alias name="glReadnPixels"/>
@@ -24284,8 +23423,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>data</name></param>
             <alias name="glReadnPixels"/>
@@ -24390,7 +23529,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glRenderbufferStorage</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <glx type="render" opcode="4318"/>
@@ -24398,7 +23537,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glRenderbufferStorageEXT</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorage"/>
@@ -24406,26 +23545,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisample</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <glx type="render" opcode="4331"/>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleANGLE</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleAPPLE</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -24434,15 +23573,15 @@ typedef unsigned int GLhandleARB;
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleEXT</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorageMultisample"/>
@@ -24450,25 +23589,25 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleIMG</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleNV</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorageMultisample"/>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageOES</name></proto>
-            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -24779,65 +23918,65 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSamplerParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterf</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param group="SamplerParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -25160,17 +24299,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSecondaryColorFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
@@ -25213,7 +24352,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSeparableFilter2D</name></proto>
             <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25226,7 +24365,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSeparableFilter2DEXT</name></proto>
             <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25637,42 +24776,42 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexBuffer</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTexBufferARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
         </command>
         <command>
             <proto>void <name>glTexBufferEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
         </command>
         <command>
             <proto>void <name>glTexBufferOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
         </command>
         <command>
             <proto>void <name>glTexBufferRange</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
         </command>
         <command>
             <proto>void <name>glTexBufferRangeEXT</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -25680,8 +24819,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexBufferRangeOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -26139,42 +25278,42 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoordP1ui</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP1uiv</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP2ui</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP2uiv</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP3ui</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP3uiv</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP4ui</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP4uiv</name></proto>
-            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -26236,26 +25375,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexEnvx</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxOES</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxv</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxvOES</name></proto>
-            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -26289,8 +25428,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenfOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
@@ -26302,8 +25441,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenfvOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -26315,8 +25454,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGeniOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -26328,27 +25467,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenivOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexGenxOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexGenxvOES</name></proto>
-            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
-            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>coord</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -26361,7 +25500,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -26373,19 +25512,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage2DMultisample</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage2DMultisampleCoverageNV</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
@@ -26394,7 +25533,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26409,7 +25548,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26422,9 +25561,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DMultisample</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26432,10 +25571,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DMultisampleCoverageNV</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26443,15 +25582,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>border</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
             <alias name="glTexImage3D"/>
         </command>
@@ -26459,7 +25598,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26567,26 +25706,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexParameterx</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxv</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxvOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -26596,59 +25735,59 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage1D</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage1DEXT</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <alias name="glTexStorage1D"/>
         </command>
         <command>
             <proto>void <name>glTexStorage2D</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage2DEXT</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glTexStorage2D"/>
         </command>
         <command>
             <proto>void <name>glTexStorage2DMultisample</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3D</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3DEXT</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26656,9 +25795,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage3DMultisample</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26666,9 +25805,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage3DMultisampleOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26677,8 +25816,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorageSparseAMD</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26771,16 +25910,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexSubImage3DOES</name></proto>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param group="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
             <alias name="glTexSubImage3D"/>
         </command>
@@ -26810,21 +25949,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureBuffer</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTextureBufferEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTextureBufferRange</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -26833,7 +25972,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureBufferRangeEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -26873,8 +26012,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureImage2DMultisampleCoverageNV</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -26884,8 +26023,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureImage2DMultisampleNV</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -26908,8 +26047,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureImage3DMultisampleCoverageNV</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -26920,8 +26059,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureImage3DMultisampleNV</name></proto>
-            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -26957,7 +26096,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -26970,7 +26109,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -26983,7 +26122,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterf</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
@@ -26997,7 +26136,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -27010,7 +26149,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -27024,7 +26163,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -27036,7 +26175,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureRangeAPPLE</name></proto>
-            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="length">const void *<name>pointer</name></param>
         </command>
@@ -27050,7 +26189,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage1D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
@@ -27058,14 +26197,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage2D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -27074,7 +26213,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -27082,7 +26221,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
@@ -27092,7 +26231,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
@@ -27101,7 +26240,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -27111,7 +26250,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -27120,7 +26259,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -27131,7 +26270,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -27141,7 +26280,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorageSparseAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -27154,8 +26293,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -27177,8 +26316,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -27204,8 +26343,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
-            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -27226,9 +26365,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureView</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -27237,9 +26376,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureViewEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -27249,9 +26388,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureViewOES</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -28176,7 +27315,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glUniformSubroutinesuiv</name></proto>
-            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>indices</name></param>
         </command>
@@ -28632,7 +27771,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
@@ -28641,7 +27780,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -28649,7 +27788,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -29647,7 +28786,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
@@ -29655,7 +28794,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
@@ -29923,14 +29062,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribIFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribIFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
@@ -30156,21 +29295,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribLFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribLFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribLPointer</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="size">const void *<name>pointer</name></param>
         </command>
@@ -30178,7 +29317,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribLPointerEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="size">const void *<name>pointer</name></param>
             <alias name="glVertexAttribLPointer"/>
@@ -30186,63 +29325,63 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttribP1ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP1uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribParameteriAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -30414,37 +29553,37 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP2ui</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP2uiv</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP3ui</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP3uiv</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP4ui</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP4uiv</name></proto>
-            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>


### PR DESCRIPTION
Unfortunately this didn't *just* add enum group information, it changed some parameter names and
types incorrectly.

Fixes #46.