### PR TITLE
Un-alias functions introduced by OES_texture_3D from the core counter…

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20170613
+#define GL_GLEXT_VERSION 20170628
 
 /* Generated C header for:
  * API: gl

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20170613
+#define GLX_GLXEXT_VERSION 20170628
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20170613
+#define WGL_WGLEXT_VERSION 20170628
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20170613 */
+/* Generated on date 20170628 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20170613 */
+/* Generated on date 20170628 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20170613 */
+/* Generated on date 20170628 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20170613 */
+/* Generated on date 20170628 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20170613 */
+/* Generated on date 20170628 */
 
 /* Generated C header for:
  * API: gles2

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -11057,7 +11057,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
-            <alias name="glCompressedTexImage3D"/>
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage1D</name></proto>
@@ -11156,7 +11155,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
-            <alias name="glCompressedTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glCompressedTextureImage1DEXT</name></proto>
@@ -11778,7 +11776,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <alias name="glCopyTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glCopyTextureImage1DEXT</name></proto>
@@ -14076,7 +14073,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
-            <alias name="glFramebufferTexture3D"/>
         </command>
         <command>
             <proto>void <name>glFramebufferTextureARB</name></proto>
@@ -25824,7 +25820,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
-            <alias name="glTexImage3D"/>
         </command>
         <command>
             <proto>void <name>glTexImage4DSGIS</name></proto>
@@ -26206,7 +26201,6 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
-            <alias name="glTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glTexSubImage4DSGIS</name></proto>


### PR DESCRIPTION
On 2017-06-28 GLES WG agreed to un-alias functions introduced by OES_texture_3D from the core counterparts. 

Ref: internal Opengl/API issues 33