### PR TITLE
Fixed docs links on the repository front page.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,14 +78,14 @@ There are some documents under the docs/ directory describing some of the
 processes for making extensions, but they are largely out of date. They may
 be updated or removed over time:
 
-* link:doc/rules.html[How to create extensions]
-* link:doc/enums.html[Enumerant allocation policies]
-* link:doc/template.txt[Extension specification template]
-* link:doc/promoting.html[Extension promotion guidelines]
-* link:doc/reserved.txt[GLX opcode registry (rarely updated)]
-* link:doc/syntaxrules.txt[OpenGL Syntax Rules (updated 2006/12/13)]
-* link:doc/GLSLExtensionRules.txt[OpenGL Shading Language Extension Conventions (updated 2006/12/18)]
-* link:doc/fog_coord.txt[Extension Specification Example]
+* link:docs/rules.html[How to create extensions]
+* link:docs/enums.html[Enumerant allocation policies]
+* link:docs/template.txt[Extension specification template]
+* link:docs/promoting.html[Extension promotion guidelines]
+* link:docs/reserved.txt[GLX opcode registry (rarely updated)]
+* link:docs/syntaxrules.txt[OpenGL Syntax Rules (updated 2006/12/13)]
+* link:docs/GLSLExtensionRules.txt[OpenGL Shading Language Extension Conventions (updated 2006/12/18)]
+* link:docs/fog_coord.txt[Extension Specification Example]
 
 
 === Repository Contents


### PR DESCRIPTION
The links on the front page of the github repository are brokens because the directory is /docs and not /doc.

This PR fix this issue.