### PR TITLE
GL_EXT_clip_control: New extension

### DIFF
--- a/extensions/EXT/EXT_clip_control.txt
+++ b/extensions/EXT/EXT_clip_control.txt
@@ -1,0 +1,186 @@
+Name
+
+    EXT_clip_control
+
+Name Strings
+
+    GL_EXT_clip_control
+
+Contact
+
+    Chad Versace, Google <chadversary@google.com>
+
+Contributors
+
+    David Reveman, Google <reveman@google.com>
+    See also GL_ARB_clip_control.
+
+Notice
+
+    Copyright (c) 2017 The Khronos Group Inc. Copyright terms at
+        http://www.khronos.org/registry/speccopyright.html
+
+Status
+
+    Complete
+
+Version
+
+    Last Modified Date: 2017-08-08
+
+Number
+
+    OpenGL ES Extension #290
+
+Dependencies
+
+    Requires OpenGL ES 2.0.
+
+    This extension is written against the OpenGL ES 3.2 Specification.
+
+Overview
+
+    This extension provides additional clip control modes to configure how
+    clip space is mapped to window space.  This extension's goal is to 1)
+    allow OpenGL to effectively match Direct3D's coordinate system
+    conventions, and 2) potentially improve the numerical precision of the Z
+    coordinate mapping.
+
+    This extension is a port of GL_ARB_clip_control to OpenGL ES. For the
+    complete overview of this extension, refer to the "Overview" section of
+    GL_ARB_clip_control.
+
+Differences from GL_ARB_clip_control
+
+    Append the EXT suffix to all new symbols.
+
+    Remove references to features not found in OpenGL ES 3.2: DEPTH_CLAMP and
+    and Begin/End,
+
+    Renumber sections to match the OpenGL ES 3.2 Specification.
+
+New Procedures and Functions
+
+    void ClipControlEXT(enum origin, enum depth);
+
+New Tokens
+
+    Accepted by the <origin> parameter of ClipControl:
+
+        LOWER_LEFT_EXT                              0x8CA1
+        UPPER_LEFT_EXT                              0x8CA2
+
+    Accepted by the <depth> parameter of ClipControl:
+
+        NEGATIVE_ONE_TO_ONE_EXT                     0x935E
+        ZERO_TO_ONE_EXT                             0x935F
+
+    Accepted by the <pname> parameter of GetBooleanv, GetIntegerv,
+    GetFloatv, and GetDoublev:
+
+        CLIP_ORIGIN_EXT                             0x935C
+        CLIP_DEPTH_MODE_EXT                         0x935D
+
+Additions to the OpenGL ES 3.2 Specification, Chapter 12 (Fixed-Function Vertex
+Post-Processing):
+
+ -- Modify section 12.3 "Primitive Clipping"
+
+    Insert before the 1st paragraph:
+
+    "The command
+
+        ClipControl(enum origin, enum depth);
+
+    controls the clipping volume behavior.  /origin/ must be either
+    LOWER_LEFT_EXT or UPPER_LEFT_EXT, otherwise the error INVALID_ENUM is
+    generated.  /depth/ must be either NEGATIVE_ONE_TO_ONE_EXT or
+    ZERO_TO_ONE_EXT, otherwise the error INVALID_ENUM is generated.
+
+      These parameters update the clip control origin and
+    depth mode respectively.  The state required for clip control is one
+    bit for clip control origin and one bit for clip control depth mode.
+    The initial value of the clip control origin is LOWER_LEFT_EXT and the
+    initial value of the depth mode is NEGATIVE_ONE_TO_ONE_EXT.
+
+    Replace the first paragraph with:
+
+    "Primitives are clipped to the clip volume. In clip coordinates,
+    the view volume is defined by
+
+        -w_c <= x_c <= w_c
+        -w_c <= y_c <= w_c
+         z_m <= z_c <= w_c
+
+     where z_m is -w_c when the clip control depth mode is
+     NEGATIVE_ONE_TO_ONE_EXT and z_m is 0 when the mode is ZERO_TO_ONE_EXT."
+
+ -- Modify section 12.5 "Coordinate Transformations"
+
+    Replace the 3rd paragraph with (where ^T means transpose):
+
+    "If a vertex in clip coordinates is given by (x_c y_c z_c w_c)^T
+    then the vertex's normalized device coordinates are (x_d y_d z_d)^T =
+    (x_c/w_c f*y_c/w_c z_c/w_c)^T where /f/ is +1 when the clip control
+    origin is LOWER_LEFT_EXT and -1 when the origin is UPPER_LEFT_EXT."
+
+ -- Modify section 12.5.1 "Controlling the Viewport"
+
+    Replace the 2nd sentence of the 1st paragraph with (where ^T means
+    transpose):
+
+    "The vertex's window coordinates, (x_w y_w z_w)^T are given by:
+
+        ( x_w )     ( p_x/2 x_d + o_x )
+        ( y_w )  =  ( p_y/2 y_d + o_y )
+        ( z_w )     (     s z_d + b   )
+
+    where s is (f-n)/2 and b is (n+f)/2 when the clip control depth mode
+    is NEGATIVE_ONE_TO_ONE_EXT; or s is (f-n) and b is n when the mode
+    is ZERO_TO_ONE_EXT."
+
+Additions to the OpenGL ES 3.2 Specification, Chapter 13 (Fixed-Function
+Primitive Assembly and Rasterization):
+
+ -- Modify section 13.7.1 "Basic Polygon Rasterization"
+
+    Replace the 3rd sentence of the 1st paragraph with:
+
+    "One way to compute this area is
+
+               n-1
+               ___
+               \
+      a = 1/2 f \  x^i_w * y^i(+)1_w - x^i(+)1_w * y^i_w
+                /
+               /__
+
+    where f is +1 when the clip control origin is LOWER_LEFT_EXT and -1 when
+    the origin is UPPER_LEFT_EXT, x^i_w and y^i_w are the x and y window
+    coordinates of the ith vertex of the n-vertex polygon (vertices
+    are numbered starting at zero for purposes of this computation),
+    and i(+)1 is (i+1) mod n."
+
+Errors
+
+    The error INVALID_ENUM is generated by ClipControl if origin is not
+    LOWER_LEFT_EXT or UPPER_LEFT_EXT.
+
+    The error INVALID_ENUM is generated by ClipControl if depth is not
+    NEGATIVE_ONE_TO_ONE_EXT or ZERO_TO_ONE_EXT.
+
+New State
+
+    Get Value            Type  Get Command  Initial Value            Description      Sec   Attribute
+    -------------------  ----  -----------  -----------------------  ---------------  ----  ---------
+    CLIP_ORIGIN_EXT        Z2  GetIntegerv  LOWER_LEFT_EXT           Clip origin      12.4  xform
+    CLIP_DEPTH_MODE_EXT    Z2  GetIntegerv  NEGATIVE_ONE_TO_ONE_EXT  Clip depth mode  12.4  xform
+
+Issues
+
+    See the issue list in GL_ARB_clip_control.
+
+Revision History
+
+    1. 2017-08-08 (Chad Versace)
+        - First draft. Port of GL_ARB_clip_control to OpenGL ES.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -601,4 +601,6 @@
 </li>
 <li value=289><a href="extensions/EXT/EXT_texture_compression_s3tc_srgb.txt">GL_EXT_texture_compression_s3tc_srgb</a>
 </li>
+<li value=290><a href="extensions/EXT/EXT_clip_control.txt">GL_EXT_clip_control</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -5170,6 +5170,12 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/EXT/WGL_EXT_swap_control_tear.txt',
     },
+    'GL_EXT_clip_control' : {
+        'esnumber' : 290,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/EXT/EXT_clip_control.txt',
+    },
     'WGL_I3D_digital_video_control' : {
         'number' : 250,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6804,11 +6804,12 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8C93" name="GL_ATC_RGBA_EXPLICIT_ALPHA_AMD"/>
             <unused start="0x8C94" end="0x8C9F" vendor="QCOM"/>
     </enums>
-
     <enums namespace="GL" start="0x8CA0" end="0x8CAF" vendor="ARB">
         <enum value="0x8CA0" name="GL_POINT_SPRITE_COORD_ORIGIN"/>
         <enum value="0x8CA1" name="GL_LOWER_LEFT"/>
+        <enum value="0x8CA1" name="GL_LOWER_LEFT_EXT" alias="GL_LOWER_LEFT"/>
         <enum value="0x8CA2" name="GL_UPPER_LEFT"/>
+        <enum value="0x8CA2" name="GL_UPPER_LEFT_EXT" alias="GL_UPPER_LEFT"/>
         <enum value="0x8CA3" name="GL_STENCIL_BACK_REF"/>
         <enum value="0x8CA4" name="GL_STENCIL_BACK_VALUE_MASK"/>
         <enum value="0x8CA5" name="GL_STENCIL_BACK_WRITEMASK"/>
@@ -8525,9 +8526,13 @@ typedef unsigned int GLhandleARB;
         <enum value="0x935A" name="GL_VIEWPORT_SWIZZLE_Z_NV"/>
         <enum value="0x935B" name="GL_VIEWPORT_SWIZZLE_W_NV"/>
         <enum value="0x935C" name="GL_CLIP_ORIGIN"/>
+        <enum value="0x935C" name="GL_CLIP_ORIGIN_EXT" alias="GL_CLIP_ORIGIN"/>
         <enum value="0x935D" name="GL_CLIP_DEPTH_MODE"/>
+        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE_EXT" alias="GL_CLIP_DEPTH_MODE"/>
         <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE"/>
+        <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE_EXT" alias="GL_NEGATIVE_ONE_TO_ONE"/>
         <enum value="0x935F" name="GL_ZERO_TO_ONE"/>
+        <enum value="0x935F" name="GL_ZERO_TO_ONE_EXT" alias="GL_ZERO_TO_ONE"/>
             <unused start="0x9360" end="0x9364" vendor="NV"/>
         <enum value="0x9365" name="GL_CLEAR_TEXTURE"/>
         <enum value="0x9366" name="GL_TEXTURE_REDUCTION_MODE_ARB"/>
@@ -10267,6 +10272,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClipControl</name></proto>
             <param><ptype>GLenum</ptype> <name>origin</name></param>
             <param><ptype>GLenum</ptype> <name>depth</name></param>
+        </command>
+        <command>
+            <proto>void <name>glClipControlEXT</name></proto>
+            <param><ptype>GLenum</ptype> <name>origin</name></param>
+            <param><ptype>GLenum</ptype> <name>depth</name></param>
+            <alias name="glClipControlEXT"/>
         </command>
         <command>
             <proto>void <name>glClipPlane</name></proto>
@@ -41300,6 +41311,17 @@ typedef unsigned int GLhandleARB;
             <require>
                 <command name="glClearTexImageEXT"/>
                 <command name="glClearTexSubImageEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_clip_control" supported="gles2">
+            <require comment="Port of GL_ARB_clip_control">
+                <command name="glClipControlEXT"/>
+                <enum name="GL_LOWER_LEFT_EXT"/>
+                <enum name="GL_UPPER_LEFT_EXT"/>
+                <enum name="GL_NEGATIVE_ONE_TO_ONE_EXT"/>
+                <enum name="GL_ZERO_TO_ONE_EXT"/>
+                <enum name="GL_CLIP_ORIGIN_EXT"/>
+                <enum name="GL_CLIP_DEPTH_MODE_EXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_clip_cull_distance" supported="gles2">


### PR DESCRIPTION
This is a direct port of GL_ARB_clip_control to ES. The significant
difference from GL_ARB_clip_control is that this extension drops
language relevant to non-existent features in ES. In particular, it
drops language relevant to depth clamping and begin/end.

The Chrome browser can use this extension to improve the performance of
WebGL surface composition. It enables Chrome to render WebGL surfaces
directly into hardware overlays even when the display controller does
not support flipping the Y-axis at scanout.

Requested-by: David Reveman <reveman@google.com>
See-also: https://chromium-review.googlesource.com/c/603150/