### PR TITLE
Add missing include of stddef.h for ptrdiff_t in GL_ARB_vertex_buffer_object

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -4713,6 +4713,7 @@ GLAPI void APIENTRY glVertexBlendARB (GLint count);
 
 #ifndef GL_ARB_vertex_buffer_object
 #define GL_ARB_vertex_buffer_object 1
+#include <stddef.h>
 typedef ptrdiff_t GLsizeiptrARB;
 typedef ptrdiff_t GLintptrARB;
 #define GL_BUFFER_SIZE_ARB                0x8764


### PR DESCRIPTION
Fixes https://www.khronos.org/bugzilla/show_bug.cgi?id=1345

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>