### PR TITLE
Added EXT_texture_mirror_clamp_to_edge extension

### DIFF
--- a/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
+++ b/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
@@ -25,8 +25,8 @@ Status
 
 Version
 
-    Last Modified Date: September 4, 2017
-    Revision 1
+    Last Modified Date: September 7, 2017
+    Revision 2
 
 Number
 
@@ -34,7 +34,7 @@ Number
 
 Dependencies
 
-    OpenGL ES 3.0 is required.
+    OpenGL ES 2.0 is required.
 
     This extension is written against the OpenGL ES 3.2 Specification.
 
@@ -103,6 +103,17 @@ Errors
     TEXTURE_WRAP_T, or TEXTURE_WRAP_R parameter is set to REPEAT,
     MIRRORED_REPEAT, or MIRROR_CLAMP_TO_EDGE.
 
+Dependencies on EXT_texture3D or equivalent
+
+    If EXT_texture3D or equivalent functionality is not implemented,
+    then the references to clamping of 3D textures in this file are
+    invalid, and references to TEXTURE_WRAP_R should be ignored.
+
+Dependencies on OpenGL ES 3.0 or equivalent
+
+    If OpenGL ES 3.0 or equivalent is not supported, then ignore all
+    references to sampler objects and SamplerParameter* functions.
+
 New State
 
     Only the type information changes for these parameters:
@@ -138,7 +149,10 @@ Issues
 
 Revision History
 
-    Revision 1, September 5, 2017 (criccio)
+    Revision 2 - September 7, 2017 (criccio)
+    - Require OpenGL ES 2.0 instead of OpenGL ES 3.0
+
+    Revision 1 - September 5, 2017 (criccio)
     - Initial EXT version based on ARB_texture_mirror_clamp_to_edge
 
 

--- a/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
+++ b/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
@@ -138,14 +138,7 @@ New Implementation Dependent State
 
 Issues
 
-    1. Should we include MIRROR_CLAMP for compatibility profiles?
-    What about MIRROR_CLAMP_TO_BORDER? (And more importantly can all
-    vendors support it?)
-
-    RESOLVED. No. Some vendors stated that they can't support
-    MIRROR_CLAMP_TO_BORDER and MIRROR_CLAMP (although it's not clear if
-    they'd ever ship a compatibility profile with this extension), but
-    regardless we'll leave them out of this extension.
+    None
 
 Revision History
 

--- a/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
+++ b/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
@@ -13,6 +13,8 @@ Contact
 Contributors
 
     Contributors to ARB_texture_mirror_clamp_to_edge
+    Ian Romanick
+    Daniel Koch
 
 Notice
 
@@ -21,7 +23,7 @@ Notice
 
 Status
 
-    Complete on September 4, 2017.
+    Draft on September 7, 2017.
 
 Version
 
@@ -35,6 +37,12 @@ Number
 Dependencies
 
     OpenGL ES 2.0 is required.
+
+    This extension interacts with OpenGL ES 3.0.
+
+    This extension interacts with OpenGL ES 3.2.
+
+    This extension interacts with OES_texture_3D.
 
     This extension is written against the OpenGL ES 3.2 Specification.
 
@@ -96,16 +104,9 @@ GLX Protocol
 
     None
 
-Errors
+Dependencies on OES_texture_3D or equivalent
 
-    The error INVALID_ENUM is generated when TexParameter* is called
-    with a target of TEXTURE_RECTANGLE and the TEXTURE_WRAP_S,
-    TEXTURE_WRAP_T, or TEXTURE_WRAP_R parameter is set to REPEAT,
-    MIRRORED_REPEAT, or MIRROR_CLAMP_TO_EDGE.
-
-Dependencies on EXT_texture3D or equivalent
-
-    If EXT_texture3D or equivalent functionality is not implemented,
+    If OES_texture_3D or equivalent functionality is not implemented,
     then the references to clamping of 3D textures in this file are
     invalid, and references to TEXTURE_WRAP_R should be ignored.
 
@@ -114,23 +115,28 @@ Dependencies on OpenGL ES 3.0 or equivalent
     If OpenGL ES 3.0 or equivalent is not supported, then ignore all
     references to sampler objects and SamplerParameter* functions.
 
+Dependencies on OpenGL ES 3.2 or equivalent
+
+    If OpenGL ES 3.2 or equivalent is not supported, then ignore all
+    references to the TexParameterI* and SamplerParameterI* functions.
+
 New State
 
     Only the type information changes for these parameters:
 
-    Update Table 23.14 (Textures - state per texture object)
+    Update Table 21.10 (Textures - state per texture object)
     Get Value           Get Command       Type    Initial Value  (...)
     ---------           -----------       ----    -------------
-    TEXTURE_WRAP_S      GetTexParameter   n x Z5  see sec 8.21   (...)
-    TEXTURE_WRAP_T      GetTexParameter   n x Z5  see sec 8.21   (...)
-    TEXTURE_WRAP_R      GetTexParameter   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_S      GetTexParameter   n x Z5  see sec 8.19   (...)
+    TEXTURE_WRAP_T      GetTexParameter   n x Z5  see sec 8.19   (...)
+    TEXTURE_WRAP_R      GetTexParameter   n x Z5  see sec 8.19   (...)
 
-    Update Table 23.18 (Textures - state per sampler object)
+    Update Table 21.12 (Textures - state per sampler object)
     Get Value           Get Command             Type    Initial Value  (...)
     ---------           -----------             ----    -------------
-    TEXTURE_WRAP_S      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
-    TEXTURE_WRAP_T      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
-    TEXTURE_WRAP_R      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_S      GetSamplerParameteriv   n x Z5  see sec 8.19   (...)
+    TEXTURE_WRAP_T      GetSamplerParameteriv   n x Z5  see sec 8.19   (...)
+    TEXTURE_WRAP_R      GetSamplerParameteriv   n x Z5  see sec 8.19   (...)
 
 New Implementation Dependent State
 

--- a/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
+++ b/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
@@ -1,0 +1,144 @@
+Name
+
+    EXT_texture_mirror_clamp_to_edge
+
+Name Strings
+
+    GL_EXT_texture_mirror_clamp_to_edge
+
+Contact
+
+    Christophe Riccio, Unity Technologies (christophe.riccio 'at' unity3d.com)
+
+Contributors
+
+    Contributors to ARB_texture_mirror_clamp_to_edge
+
+Notice
+
+    Copyright (c) 2017 The Khronos Group Inc. Copyright terms at
+        http://www.khronos.org/registry/speccopyright.html
+
+Status
+
+    Complete on September 4, 2017.
+
+Version
+
+    Last Modified Date: September 4, 2017
+    Revision 1
+
+Number
+
+    ES Extension #291
+
+Dependencies
+
+    OpenGL ES 3.0 is required.
+
+    This extension is written against the OpenGL ES 3.2 Specification.
+
+Overview
+
+    EXT_texture_mirror_clamp_to_edge extends the set of texture wrap modes to
+    include an additional mode (GL_MIRROR_CLAMP_TO_EDGE_EXT) that effectively uses
+    a texture map twice as large as the original image in which the additional
+    half of the new image is a mirror image of the original image.
+
+    This new mode relaxes the need to generate images whose opposite edges
+    match by using the original image to generate a matching "mirror image".
+    This mode allows the texture to be mirrored only once in the negative
+    s, t, and r directions.
+
+New Procedure and Functions
+
+    None
+
+New Tokens
+
+    Accepted by the <param> parameter of TexParameter{if}, SamplerParameter{if}
+    and SamplerParameter{if}v, and by the <params> parameter of
+    TexParameter{if}v, TexParameterI{i ui}v and SamplerParameterI{i ui}v when
+    their <pname> parameter is TEXTURE_WRAP_S, TEXTURE_WRAP_T, or
+    TEXTURE_WRAP_R:
+
+        MIRROR_CLAMP_TO_EDGE_EXT      0x8743 (same value as OpenGL core MIRROR_CLAMP_TO_EDGE)
+
+Additions to Chapter 8 if the OpenGL ES 3.2 Specification
+(Textures and Samplers)
+
+  In section 8.10 (Texture Parameters) modify the table entries for Table 8.16
+  (Texture parameters and their values) for TEXTURE_WRAP_S, TEXTURE_WRAP_T,
+  and TEXTURE_WRAP_R and add the following to the "Legal Values" column:
+
+    Name             Type   Legal Values
+    ---------------  ----   ------------
+    TEXTURE_WRAP_S   enum   (.. as before)
+                            MIRROR_CLAMP_TO_EDGE
+    TEXTURE_WRAP_T   enum   (.. as before)
+                            MIRROR_CLAMP_TO_EDGE
+    TEXTURE_WRAP_R   enum   (.. as before)
+                            MIRROR_CLAMP_TO_EDGE
+
+  In section 8.14.2 (Coordinate Wrapping and Texel Selection) add the
+  following row to Table 8.19 (Texel location wrap mode application):
+
+    Wrap mode                Result of wrap(coord)
+    ---------                ---------------------
+    (previous entries..)
+    MIRROR_CLAMP_TO_EDGE     min(1-1/(2*size), max(1/(2*size), abs(coord)))
+
+Additions to the GLX Specification
+
+    None
+
+GLX Protocol
+
+    None
+
+Errors
+
+    The error INVALID_ENUM is generated when TexParameter* is called
+    with a target of TEXTURE_RECTANGLE and the TEXTURE_WRAP_S,
+    TEXTURE_WRAP_T, or TEXTURE_WRAP_R parameter is set to REPEAT,
+    MIRRORED_REPEAT, or MIRROR_CLAMP_TO_EDGE.
+
+New State
+
+    Only the type information changes for these parameters:
+
+    Update Table 23.14 (Textures - state per texture object)
+    Get Value           Get Command       Type    Initial Value  (...)
+    ---------           -----------       ----    -------------
+    TEXTURE_WRAP_S      GetTexParameter   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_T      GetTexParameter   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_R      GetTexParameter   n x Z5  see sec 8.21   (...)
+
+    Update Table 23.18 (Textures - state per sampler object)
+    Get Value           Get Command             Type    Initial Value  (...)
+    ---------           -----------             ----    -------------
+    TEXTURE_WRAP_S      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_T      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
+    TEXTURE_WRAP_R      GetSamplerParameteriv   n x Z5  see sec 8.21   (...)
+
+New Implementation Dependent State
+
+    None
+
+Issues
+
+    1. Should we include MIRROR_CLAMP for compatibility profiles?
+    What about MIRROR_CLAMP_TO_BORDER? (And more importantly can all
+    vendors support it?)
+
+    RESOLVED. No. Some vendors stated that they can't support
+    MIRROR_CLAMP_TO_BORDER and MIRROR_CLAMP (although it's not clear if
+    they'd ever ship a compatibility profile with this extension), but
+    regardless we'll leave them out of this extension.
+
+Revision History
+
+    Revision 1, September 5, 2017 (criccio)
+    - Initial EXT version based on ARB_texture_mirror_clamp_to_edge
+
+

--- a/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
+++ b/extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt
@@ -23,7 +23,7 @@ Notice
 
 Status
 
-    Draft on September 7, 2017.
+    Completed on September 7, 2017.
 
 Version
 

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -17,7 +17,7 @@
 
 # python3 is required. Sorry, python2 dudes.
 
-PYTHON = python
+PYTHON = python3
 SCRIPTS = registry.py makeindex.py
 
 all: arbext.php esext.php glext.php

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -17,7 +17,7 @@
 
 # python3 is required. Sorry, python2 dudes.
 
-PYTHON = python3
+PYTHON = python
 SCRIPTS = registry.py makeindex.py
 
 all: arbext.php esext.php glext.php

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -603,4 +603,6 @@
 </li>
 <li value=290><a href="extensions/EXT/EXT_clip_control.txt">GL_EXT_clip_control</a>
 </li>
+<li value=291><a href="extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt">GL_EXT_texture_mirror_clamp_to_edge</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2427,6 +2427,11 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/EXT/EXT_texture_mirror_clamp.txt',
     },
+    'GL_EXT_texture_mirror_clamp_to_edge' : {
+        'esnumber' : 291,
+        'flags' : { 'public' },
+        'url' : 'extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt',
+    },
     'GL_EXT_texture_norm16' : {
         'esnumber' : 207,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -43378,6 +43378,11 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MIRROR_CLAMP_TO_BORDER_EXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_texture_mirror_clamp_to_edge" supported="gles2">
+            <require>
+                <enum name="GL_MIRROR_CLAMP_TO_EDGE_EXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_texture_norm16" supported="gles2">
             <require>
                 <enum name="GL_R16_EXT"/>


### PR DESCRIPTION
OpenGL ES is missing an extension to expose MIRROR_CLAMP_TO_EDGE texture wrap mode.