### PR TITLE
Proposed fix for #103.

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -578,15 +578,17 @@ GLAPI void APIENTRY glGetCompressedTexImage (GLenum target, GLint level, void *i
 #define GL_TEXTURE_DEPTH_SIZE             0x884A
 #define GL_TEXTURE_COMPARE_MODE           0x884C
 #define GL_TEXTURE_COMPARE_FUNC           0x884D
-#define GL_FUNC_ADD                       0x8006
-#define GL_FUNC_SUBTRACT                  0x800A
-#define GL_FUNC_REVERSE_SUBTRACT          0x800B
-#define GL_MIN                            0x8007
-#define GL_MAX                            0x8008
+#define GL_BLEND_COLOR                    0x8005
+#define GL_BLEND_EQUATION                 0x8009
 #define GL_CONSTANT_COLOR                 0x8001
 #define GL_ONE_MINUS_CONSTANT_COLOR       0x8002
 #define GL_CONSTANT_ALPHA                 0x8003
 #define GL_ONE_MINUS_CONSTANT_ALPHA       0x8004
+#define GL_FUNC_ADD                       0x8006
+#define GL_FUNC_REVERSE_SUBTRACT          0x800B
+#define GL_FUNC_SUBTRACT                  0x800A
+#define GL_MIN                            0x8007
+#define GL_MAX                            0x8008
 typedef void (APIENTRYP PFNGLBLENDFUNCSEPARATEPROC) (GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha);
 typedef void (APIENTRYP PFNGLMULTIDRAWARRAYSPROC) (GLenum mode, const GLint *first, const GLsizei *count, GLsizei drawcount);
 typedef void (APIENTRYP PFNGLMULTIDRAWELEMENTSPROC) (GLenum mode, const GLsizei *count, GLenum type, const void *const*indices, GLsizei drawcount);
@@ -3342,8 +3344,6 @@ GLAPI void APIENTRY glProgramUniform4ui64vARB (GLuint program, GLint location, G
 
 #ifndef GL_ARB_imaging
 #define GL_ARB_imaging 1
-#define GL_BLEND_COLOR                    0x8005
-#define GL_BLEND_EQUATION                 0x8009
 #endif /* GL_ARB_imaging */
 
 #ifndef GL_ARB_indirect_parameters

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20170910
+#define GL_GLEXT_VERSION 20170924
 
 /* Generated C header for:
  * API: gl
@@ -353,15 +353,17 @@ GLAPI void APIENTRY glMultTransposeMatrixd (const GLdouble *m);
 #define GL_TEXTURE_FILTER_CONTROL         0x8500
 #define GL_DEPTH_TEXTURE_MODE             0x884B
 #define GL_COMPARE_R_TO_TEXTURE           0x884E
-#define GL_FUNC_ADD                       0x8006
-#define GL_FUNC_SUBTRACT                  0x800A
-#define GL_FUNC_REVERSE_SUBTRACT          0x800B
-#define GL_MIN                            0x8007
-#define GL_MAX                            0x8008
+#define GL_BLEND_COLOR                    0x8005
+#define GL_BLEND_EQUATION                 0x8009
 #define GL_CONSTANT_COLOR                 0x8001
 #define GL_ONE_MINUS_CONSTANT_COLOR       0x8002
 #define GL_CONSTANT_ALPHA                 0x8003
 #define GL_ONE_MINUS_CONSTANT_ALPHA       0x8004
+#define GL_FUNC_ADD                       0x8006
+#define GL_FUNC_REVERSE_SUBTRACT          0x800B
+#define GL_FUNC_SUBTRACT                  0x800A
+#define GL_MIN                            0x8007
+#define GL_MAX                            0x8008
 typedef void (APIENTRYP PFNGLBLENDFUNCSEPARATEPROC) (GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha);
 typedef void (APIENTRYP PFNGLMULTIDRAWARRAYSPROC) (GLenum mode, const GLint *first, const GLsizei *count, GLsizei drawcount);
 typedef void (APIENTRYP PFNGLMULTIDRAWELEMENTSPROC) (GLenum mode, const GLsizei *count, GLenum type, const void *const*indices, GLsizei drawcount);
@@ -3504,8 +3506,6 @@ typedef unsigned short GLhalfARB;
 
 #ifndef GL_ARB_imaging
 #define GL_ARB_imaging 1
-#define GL_BLEND_COLOR                    0x8005
-#define GL_BLEND_EQUATION                 0x8009
 #define GL_CONVOLUTION_1D                 0x8010
 #define GL_CONVOLUTION_2D                 0x8011
 #define GL_SEPARABLE_2D                   0x8012

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20170817
+#define GLX_GLXEXT_VERSION 20170926
 
 /* Generated C header for:
  * API: glx
@@ -502,6 +502,16 @@ typedef Bool ( *PFNGLXSET3DFXMODEMESAPROC) (int mode);
 Bool glXSet3DfxModeMESA (int mode);
 #endif
 #endif /* GLX_MESA_set_3dfx_mode */
+
+#ifndef GLX_MESA_swap_control
+#define GLX_MESA_swap_control 1
+typedef int ( *PFNGLXGETSWAPINTERVALMESAPROC) (void);
+typedef void ( *PFNGLXSWAPINTERVALMESAPROC) (unsigned int interval);
+#ifdef GLX_GLXEXT_PROTOTYPES
+int glXGetSwapIntervalMESA (void);
+void glXSwapIntervalMESA (unsigned int interval);
+#endif
+#endif /* GLX_MESA_swap_control */
 
 #ifndef GLX_NV_copy_buffer
 #define GLX_NV_copy_buffer 1

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20170910 */
+/* Generated on date 20170926 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20170910 */
+/* Generated on date 20170926 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20170910 */
+/* Generated on date 20170926 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20170910 */
+/* Generated on date 20170926 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20170910 */
+/* Generated on date 20170926 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/MESA/GLX_MESA_swap_control.txt
+++ b/extensions/MESA/GLX_MESA_swap_control.txt
@@ -1,0 +1,131 @@
+Name
+
+    MESA_swap_control
+
+Name Strings
+
+    GLX_MESA_swap_control
+
+Contact
+
+    Ian Romanick, IBM, idr at us.ibm.com
+
+Status
+
+    Deployed in DRI drivers post-XFree86 4.3.
+
+Version
+
+    Date: 5/1/2003   Revision: 1.1
+
+Number
+
+    OpenGL Extension #514
+
+Dependencies
+
+    None
+
+    Based on GLX_SGI_swap_control version 1.9 and WGL_EXT_swap_control
+    version 1.5.
+
+Overview
+
+    This extension allows an application to specify a minimum periodicity
+    of color buffer swaps, measured in video frame periods.
+
+Issues
+
+    * Should implementations that export GLX_MESA_swap_control also export
+      GL_EXT_swap_control for compatibility with WGL_EXT_swap_control?
+
+    UNRESOLVED.
+
+New Procedures and Functions
+
+    int glXSwapIntervalMESA(unsigned int interval)
+    int glXGetSwapIntervalMESA(void)
+
+New Tokens
+
+    None
+
+Additions to Chapter 2 of the 1.4 GL Specification (OpenGL Operation)
+
+    None
+
+Additions to Chapter 3 of the 1.4 GL Specification (Rasterization)
+
+    None
+
+Additions to Chapter 4 of the 1.4 GL Specification (Per-Fragment Operations
+and the Framebuffer)
+
+    None
+
+Additions to Chapter 5 of the 1.4 GL Specification (Special Functions)
+
+    None
+
+Additions to Chapter 6 of the 1.4 GL Specification (State and State Requests)
+
+    None
+
+Additions to the GLX 1.3 Specification
+
+    [Add the following to Section 3.3.10 of the GLX Specification (Double
+     Buffering)]
+
+    glXSwapIntervalMESA specifies the minimum number of video frame periods
+    per buffer swap.  (e.g. a value of two means that the color buffers
+    will be swapped at most every other video frame.)  A return value
+    of zero indicates success; otherwise an error occurred.  The interval
+    takes effect when glXSwapBuffers is first called subsequent to the
+    glXSwapIntervalMESA call.
+
+    A video frame period is the time required by the monitor to display a
+    full frame of video data.  In the case of an interlaced monitor,
+    this is typically the time required to display both the even and odd
+    fields of a frame of video data.
+
+    If <interval> is set to a value of 0, buffer swaps are not synchro-
+    nized to a video frame.  The <interval> value is silently clamped to
+    the maximum implementation-dependent value supported before being
+    stored.
+
+    The swap interval is not part of the render context state.  It cannot
+    be pushed or popped.  The current swap interval for the window
+    associated with the current context can be obtained by calling
+    glXGetSwapIntervalMESA.  The default swap interval is 0.
+
+    On XFree86, setting the environment variable LIBGL_THROTTLE_REFRESH sets
+    the swap interval to 1.
+
+Errors
+
+    glXSwapIntervalMESA returns GLX_BAD_CONTEXT if there is no current
+    GLXContext or if the current context is not a direct rendering context.
+
+GLX Protocol
+
+    None.  This extension only extends to direct rendering contexts.
+
+New State
+
+    Get Value           Get Command     Type        Initial Value
+    ---------           -----------     ----        -------------
+    [swap interval]     GetSwapInterval Z+          0
+
+New Implementation Dependent State
+
+    None
+
+
+Revision History
+
+          9/26/17  Added extension to OpenGL registry, sourced from
+                   https://cgit.freedesktop.org/mesa/mesa/tree/docs/specs/MESA_swap_control.spec
+    1.1,  5/1/03   Added the issues section and contact information.
+                   Changed the default swap interval to 0.
+    1.0,  3/17/03  Initial version based on GLX_SGI_swap_control and
+                   WGL_EXT_swap_control.

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -963,4 +963,6 @@
 </li>
 <li value=513><a href="extensions/AMD/AMD_shader_image_load_store_lod.txt">GL_AMD_shader_image_load_store_lod</a>
 </li>
+<li value=514><a href="extensions/MESA/GLX_MESA_swap_control.txt">GLX_MESA_swap_control</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2915,6 +2915,12 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/MESA_shader_integer_functions.txt',
     },
+    'GLX_MESA_swap_control' : {
+        'number' : 514,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/GLX_MESA_swap_control.txt',
+    },
     'GL_MESA_window_pos' : {
         'number' : 197,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -33191,15 +33191,17 @@ typedef unsigned int GLhandleARB;
             <command name="glWindowPos3sv"/>
         </require>
         <require comment="Promoted from ARB_imaging subset to core">
-            <enum name="GL_FUNC_ADD"/>
-            <enum name="GL_FUNC_SUBTRACT"/>
-            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
-            <enum name="GL_MIN"/>
-            <enum name="GL_MAX"/>
+            <enum name="GL_BLEND_COLOR"/>
+            <enum name="GL_BLEND_EQUATION"/>
             <enum name="GL_CONSTANT_COLOR"/>
             <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
             <enum name="GL_CONSTANT_ALPHA"/>
             <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
+            <enum name="GL_FUNC_ADD"/>
+            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
+            <enum name="GL_FUNC_SUBTRACT"/>
+            <enum name="GL_MIN"/>
+            <enum name="GL_MAX"/>
             <command name="glBlendColor"/>
             <command name="glBlendEquation"/>
         </require>
@@ -40048,17 +40050,17 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_ARB_imaging" supported="gl|glcore" comment="Now treating ARB_imaging as an extension, not a GL API version">
             <require>
+                <enum name="GL_BLEND_COLOR"/>
+                <enum name="GL_BLEND_EQUATION"/>
                 <enum name="GL_CONSTANT_COLOR"/>
                 <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
                 <enum name="GL_CONSTANT_ALPHA"/>
                 <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
-                <enum name="GL_BLEND_COLOR"/>
                 <enum name="GL_FUNC_ADD"/>
+                <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
+                <enum name="GL_FUNC_SUBTRACT"/>
                 <enum name="GL_MIN"/>
                 <enum name="GL_MAX"/>
-                <enum name="GL_BLEND_EQUATION"/>
-                <enum name="GL_FUNC_SUBTRACT"/>
-                <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
                 <command name="glBlendColor"/>
                 <command name="glBlendEquation"/>
             </require>

--- a/xml/glx.xml
+++ b/xml/glx.xml
@@ -465,7 +465,7 @@ typedef unsigned __int64 uint64_t;
     <enums namespace="GLX" start="0x31B3" end="0x31B3" vendor="ARB" comment="Shared with WGL.">
         <enum value="0x31B3" name="GLX_CONTEXT_OPENGL_NO_ERROR_ARB"/>
     </enums>
-    
+
     <enums namespace="GLX" start="0x8000" end="0x804F" vendor="ARB">
         <enum value="0x8000"        name="GLX_NONE"                                 comment="Attribute value"/>
         <enum value="0x8001"        name="GLX_SLOW_CONFIG"                          comment="CONFIG_CAVEAT attribute value"/>
@@ -1072,6 +1072,9 @@ typedef unsigned __int64 uint64_t;
             <param>unsigned long *<name>mask</name></param>
         </command>
         <command>
+            <proto>int <name>glXGetSwapIntervalMESA</name></proto>
+        </command>
+        <command>
             <proto><ptype>Bool</ptype> <name>glXGetSyncValuesOML</name></proto>
             <param><ptype>Display</ptype> *<name>dpy</name></param>
             <param><ptype>GLXDrawable</ptype> <name>drawable</name></param>
@@ -1406,6 +1409,10 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>int64_t</ptype> <name>target_msc</name></param>
             <param><ptype>int64_t</ptype> <name>divisor</name></param>
             <param><ptype>int64_t</ptype> <name>remainder</name></param>
+        </command>
+        <command>
+            <proto>void <name>glXSwapIntervalMESA</name></proto>
+            <param>unsigned int <name>interval</name></param>
         </command>
         <command>
             <proto>void <name>glXSwapIntervalEXT</name></proto>
@@ -2168,6 +2175,12 @@ typedef unsigned __int64 uint64_t;
         <extension name="GLX_SUN_get_transparent_index" supported="glx">
             <require>
                 <command name="glXGetTransparentIndexSUN"/>
+            </require>
+        </extension>
+        <extension name="GLX_MESA_swap_control" supported="glx">
+            <require>
+                <command name="glXGetSwapIntervalMESA"/>
+                <command name="glXSwapIntervalMESA"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Apparently the state tokens BLEND_COLOR and BLEND_EQUATION weren't
included in the GL 1.4 core interfaces, although the corresponding entry
points were promoted from ARB_imaging to core. Also rearranged the subset of ARB_imaging tokens in both part of the XML to be in the same order, for slight clarity improvement.