### PR TITLE
Add a new MESA_tile_raster_order extension.

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -9219,6 +9219,13 @@ GLAPI void APIENTRY glResizeBuffersMESA (void);
 #define GL_MESA_shader_integer_functions 1
 #endif /* GL_MESA_shader_integer_functions */
 
+#ifndef GL_MESA_tile_raster_order
+#define GL_MESA_tile_raster_order 1
+#define GL_TILE_RASTER_ORDER_FIXED_MESA   0x8BB8
+#define GL_TILE_RASTER_ORDER_INCREASING_X_MESA 0x8BB9
+#define GL_TILE_RASTER_ORDER_INCREASING_Y_MESA 0x8BBA
+#endif /* GL_MESA_tile_raster_order */
+
 #ifndef GL_MESA_window_pos
 #define GL_MESA_window_pos 1
 typedef void (APIENTRYP PFNGLWINDOWPOS2DMESAPROC) (GLdouble x, GLdouble y);

--- a/extensions/MESA/MESA_tile_raster_order.txt
+++ b/extensions/MESA/MESA_tile_raster_order.txt
@@ -1,0 +1,127 @@
+Name
+
+    MESA_tile_raster_order
+
+Name Strings
+
+    GL_MESA_tile_raster_order
+
+Contact
+
+    Eric Anholt, Broadcom (eric@anholt.net)
+
+Status
+
+    Proposal
+
+Version
+
+    Last modified date: 24 September 2017
+
+Number
+
+    OpenGL Extension #515
+    OpenGL ES Extension #292
+
+Dependencies
+
+    GL_ARB_texture_barrier or GL_NV_texture_barrier is required.
+
+    This extension is written against the OpenGL 4.4 (Compatibility
+    Profile) specification, as modified by the GL_ARB_texture_barrier
+    extension.
+
+Overview
+
+    This extension extends the sampling-from-the-framebuffer behavior provided
+    by GL_ARB_texture_barrier to allow setting the rasterization order of the
+    scene, so that overlapping blits can be implemented.  This can be used for
+    scrolling or window movement within in 2D scenes, without first copying to
+    a temporary.
+
+IP Status
+
+    None
+
+Issues
+
+    1.  Should this extension also affect BlitFramebuffer?
+
+        NOT RESOLVED: BlitFramebuffer could use the same underlying
+        functionality to provide defined results for 1:1 overlapping blits,
+        but one could use the coordinates being copied to just produce the
+        right result automatically, rather than requiring the state flags to
+        be adjusted.
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    None
+
+Additions to Chapter 9 of the OpenGL 4.4 Specification (Per-Fragment
+Operations and the Frame Buffer)
+
+    Modify Section 9.3.1 Rendering Feedback Loops, p. 289
+
+    Replace the bullet point "If a texel has been written..." with:
+
+      - A texel has been written, but it has been separated from this
+        Draw call by the command:
+
+          void TextureBarrier(void);
+
+        TextureBarrier() will guarantee that writes have completed and
+        caches have been invalidated before subsequent Draws are
+        executed."
+
+      - TILE_RASTER_ORDER_FIXED_MESA is enabled, and there is only a
+        single write of each texel, and primitives are emitted in the
+        order of TILE_RASTER_ORDER_INCREASING_X/Y_MESA (where those
+        being disabled mean negative texel offsets), and reads are
+        only performed from texels offset from the current fragment
+        shader invocation in the direction specified by
+        TILE_RASTER_ORDER_INCREASING_X/Y_MESA, e.g. using
+        "texelFetch2D(sampler, ivec2(gl_FragCoord.xy + vec2(dx, dy)),
+        0);".
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None
+
+GLX Protocol
+
+    None
+
+Errors
+
+    None
+
+New State
+
+    Get Value                            Type    Get Command    Initial Value Description                  Section   Attribute
+    -----------------------------------  ------  -------------  ------------- ---------------------------  --------  ------------
+    TILE_RASTER_ORDER_FIXED_MESA         B       IsEnabled      True          Tile rasterization order is  9.3.1     enable
+                                                                              defined by
+                                                                              TILE_RASTER_ORDER_INCREASING_*_MESA.
+                                                                              in increasing X direction
+    TILE_RASTER_ORDER_INCREASING_X_MESA  B       IsEnabled      True          Tiles are rasterized         9.3.1     enable
+                                                                              in increasing X direction
+    TILE_RASTER_ORDER_INCREASING_Y_MESA  B       IsEnabled      True          Tiles are rasterized         9.3.1     enable
+                                                                              in increasing Y direction
+
+Revision History
+
+    26 July 2017 - Initial draft
+
+    24 September 2017 - Improved wording of the new specification
+                        paragraph.  Adjust the ARB_texture_barrier
+                        paragraph, to make it clear that it's not
+                        required when in tile raster order mode.
+
+    2 October 2017 - Give it an ES extension number, mention
+                     NV_texture_barrier for ES.
+
+    5 October 2017 - Mention what spec it's written against.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -605,4 +605,6 @@
 </li>
 <li value=291><a href="extensions/EXT/EXT_texture_mirror_clamp_to_edge.txt">GL_EXT_texture_mirror_clamp_to_edge</a>
 </li>
+<li value=292><a href="extensions/MESA/MESA_tile_raster_order.txt">GL_MESA_tile_raster_order</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -965,4 +965,6 @@
 </li>
 <li value=514><a href="extensions/MESA/GLX_MESA_swap_control.txt">GLX_MESA_swap_control</a>
 </li>
+<li value=515><a href="extensions/MESA/MESA_tile_raster_order.txt">GL_MESA_tile_raster_order</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2926,6 +2926,13 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_swap_control.txt',
     },
+    'GL_MESA_tile_raster_order' : {
+        'number' : 515,
+        'esnumber' : 292,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_tile_raster_order.txt',
+    },
     'GL_MESA_window_pos' : {
         'number' : 197,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7741,6 +7741,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8BB5" name="GL_VERTEX_PROGRAM_CALLBACK_MESA"/>
         <enum value="0x8BB6" name="GL_VERTEX_PROGRAM_CALLBACK_FUNC_MESA"/>
         <enum value="0x8BB7" name="GL_VERTEX_PROGRAM_CALLBACK_DATA_MESA"/>
+        <enum value="0x8BB8" name="GL_TILE_RASTER_ORDER_FIXED_MESA"/>
+        <enum value="0x8BB9" name="GL_TILE_RASTER_ORDER_INCREASING_X_MESA"/>
+        <enum value="0x8BBA" name="GL_TILE_RASTER_ORDER_INCREASING_Y_MESA"/>
     </enums>
 
     <enums namespace="GL" start="0x8BC0" end="0x8BFF" vendor="QCOM" comment="Reassigned from AMD to QCOM">
@@ -45627,6 +45630,13 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_MESA_shader_integer_functions" supported="gl|gles2"/>
+        <extension name="GL_MESA_tile_raster_order" supported="gl">
+            <require>
+                <enum name="GL_TILE_RASTER_ORDER_FIXED_MESA"/>
+                <enum name="GL_TILE_RASTER_ORDER_INCREASING_X_MESA"/>
+                <enum name="GL_TILE_RASTER_ORDER_INCREASING_Y_MESA"/>
+            </require>
+        </extension>
         <extension name="GL_MESA_window_pos" supported="gl">
             <require>
                 <command name="glWindowPos2dMESA"/>


### PR DESCRIPTION
Some wording is new based on review feedback on the Mesa mailing list
-- version 1 had been looked at by Intel and AMD developers, and the
conclusion was that we needed to clarify TextureBarrier()'s role in
the list of exceptions given the new exception.

Implementation status: Kernel side ABI in place for vc4, piglit test
written and submitted, and Mesa implementation submitted.