### PR TITLE
Add new VK texture layouts to GL_EXT_semaphore

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20171012
+#define GL_GLEXT_VERSION 20171024
 
 /* Generated C header for:
  * API: gl
@@ -7989,6 +7989,8 @@ GLAPI void APIENTRY glSecondaryColorPointerEXT (GLint size, GLenum type, GLsizei
 #define GL_LAYOUT_SHADER_READ_ONLY_EXT    0x9591
 #define GL_LAYOUT_TRANSFER_SRC_EXT        0x9592
 #define GL_LAYOUT_TRANSFER_DST_EXT        0x9593
+#define GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT 0x9530
+#define GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT 0x9531
 typedef void (APIENTRYP PFNGLGENSEMAPHORESEXTPROC) (GLsizei n, GLuint *semaphores);
 typedef void (APIENTRYP PFNGLDELETESEMAPHORESEXTPROC) (GLsizei n, const GLuint *semaphores);
 typedef GLboolean (APIENTRYP PFNGLISSEMAPHOREEXTPROC) (GLuint semaphore);

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20171012
+#define GLX_GLXEXT_VERSION 20171024
 
 /* Generated C header for:
  * API: glx

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20171012 */
+/* Generated on date 20171024 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171012 */
+/* Generated on date 20171024 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171012 */
+/* Generated on date 20171024 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171012 */
+/* Generated on date 20171024 */
 
 /* Generated C header for:
  * API: gles2
@@ -1704,6 +1704,8 @@ GL_APICALL void GL_APIENTRY glGetnUniformivEXT (GLuint program, GLint location, 
 #define GL_LAYOUT_SHADER_READ_ONLY_EXT    0x9591
 #define GL_LAYOUT_TRANSFER_SRC_EXT        0x9592
 #define GL_LAYOUT_TRANSFER_DST_EXT        0x9593
+#define GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT 0x9530
+#define GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT 0x9531
 typedef void (GL_APIENTRYP PFNGLGENSEMAPHORESEXTPROC) (GLsizei n, GLuint *semaphores);
 typedef void (GL_APIENTRYP PFNGLDELETESEMAPHORESEXTPROC) (GLsizei n, const GLuint *semaphores);
 typedef GLboolean (GL_APIENTRYP PFNGLISSEMAPHOREEXTPROC) (GLuint semaphore);

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171012 */
+/* Generated on date 20171024 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/EXT/EXT_external_objects.txt
+++ b/extensions/EXT/EXT_external_objects.txt
@@ -26,8 +26,8 @@ Status
 
 Version
 
-    Last Modified Date: June 28, 2017
-    Revision: 12
+    Last Modified Date: September 26, 2017
+    Revision: 13
 
 Number
 
@@ -312,13 +312,15 @@ New Tokens
     Accepted by the <dstLayouts> parameter of SignalSemaphoreEXT and the
     <srcLayouts> parameter of WaitSemaphoreEXT:
 
-        LAYOUT_GENERAL_EXT                         0x958D
-        LAYOUT_COLOR_ATTACHMENT_EXT                0x958E
-        LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT        0x958F
-        LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT         0x9590
-        LAYOUT_SHADER_READ_ONLY_EXT                0x9591
-        LAYOUT_TRANSFER_SRC_EXT                    0x9592
-        LAYOUT_TRANSFER_DST_EXT                    0x9593
+        LAYOUT_GENERAL_EXT                            0x958D
+        LAYOUT_COLOR_ATTACHMENT_EXT                   0x958E
+        LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT           0x958F
+        LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT            0x9590
+        LAYOUT_SHADER_READ_ONLY_EXT                   0x9591
+        LAYOUT_TRANSFER_SRC_EXT                       0x9592
+        LAYOUT_TRANSFER_DST_EXT                       0x9593
+        LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT 0x9530
+        LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT 0x9531
 
 Additions to Chapter 2 of the OpenGL 4.5 Specification (OpenGL
 Fundamentals)
@@ -504,17 +506,19 @@ Additions to Chapter 4 of the OpenGL 4.5 Specification (Event Model)
 
         Table 4.4: Texture layouts and corresponding Vulkan Image Layouts
 
-        | Texture Layout                         | Equivalent Vulkan Image Layout                  |
-        +----------------------------------------+-------------------------------------------------+
-        | GL_NONE                                | VK_IMAGE_LAYOUT_UNDEFINED                       |
-        | GL_LAYOUT_GENERAL_EXT                  | VK_IMAGE_LAYOUT_GENERAL                         |
-        | GL_LAYOUT_COLOR_ATTACHMENT_EXT         | VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL        |
-        | GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT | VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT        |
-        | GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT  | VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL |
-        | GL_LAYOUT_SHADER_READ_ONLY_EXT         | VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL        |
-        | GL_LAYOUT_TRANSFER_SRC_EXT             | VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL            |
-        | GL_LAYOUT_TRANSFER_DST_EXT             | VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL            |
-        +------------------------------------------------------------------------------------------+
+        | Texture Layout                                   | Equivalent Vulkan Image Layout                                 |
+        +--------------------------------------------------+----------------------------------------------------------------+
+        | GL_NONE                                          | VK_IMAGE_LAYOUT_UNDEFINED                                      |
+        | GL_LAYOUT_GENERAL_EXT                            | VK_IMAGE_LAYOUT_GENERAL                                        |
+        | GL_LAYOUT_COLOR_ATTACHMENT_EXT                   | VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL                       |
+        | GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT           | VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT                       |
+        | GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT            | VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL                |
+        | GL_LAYOUT_SHADER_READ_ONLY_EXT                   | VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL                       |
+        | GL_LAYOUT_TRANSFER_SRC_EXT                       | VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL                           |
+        | GL_LAYOUT_TRANSFER_DST_EXT                       | VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL                           |
+        | GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT | VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL_KHR |
+        | GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT | VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL_KHR |
+        +-------------------------------------------------------------------------------------------------------------------+
 
         4.2.4 Signaling Semaphores
 
@@ -1107,7 +1111,21 @@ Issues
         must match the PROTECTED_MEMORY_OBJECT_EXT parameter of the memory
         object.
 
+    23) How do applications detect when the new texture layouts
+        corresponding to the image layouts in VK_KHR_maintenance2 are
+        supported in OpenGL?
+
+        RESOLVED: OpenGL contexts that report the GL_EXT_semaphore extension
+        string and have a DRIVER_UUID_EXT and DEVICE_UUID_EXT corresponding
+        to a Vulkan driver that supports VK_KHR_maintenance2 must support
+        the new OpenGL texture layouts.
+
 Revision History
+
+    Revision 13, 2017-09-26 (James Jones)
+        - Added new image layouts corresponding to those from
+          VK_KHR_maintenance2.
+        - Added issue 23 and resolution.
 
     Revision 12, 2017-06-08 (Andres Rodriguez)
         - Fixed parameter name in MemoryObjectParameterivEXT's description.

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -3296,6 +3296,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_LAYOUT_SHADER_READ_ONLY_EXT"/>
             <enum name="GL_LAYOUT_TRANSFER_SRC_EXT"/>
             <enum name="GL_LAYOUT_TRANSFER_DST_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
         </group>
 
         <group name="PathTransformType">
@@ -9958,7 +9960,9 @@ typedef unsigned int GLhandleARB;
     </enums>
 
     <enums namespace="GL" start="0x9530" end="0x962F" vendor="NV" comment="Khronos bug 12977">
-            <unused start="0x9530" end="0x9539" vendor="NV"/>
+        <enum value="0x9530" name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+        <enum value="0x9531" name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
+            <unused start="0x9532" end="0x953F" vendor="NV"/>
         <enum value="0x9540" name="GL_QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV"/>
             <unused start="0x9541" vendor="NV"/>
         <enum value="0x9542" name="GL_QUERY_RESOURCE_MEMTYPE_VIDMEM_NV"/>
@@ -44010,6 +44014,8 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_LAYOUT_SHADER_READ_ONLY_EXT"/>
                 <enum name="GL_LAYOUT_TRANSFER_SRC_EXT"/>
                 <enum name="GL_LAYOUT_TRANSFER_DST_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
                 <command name="glGetUnsignedBytevEXT"/>
                 <command name="glGetUnsignedBytei_vEXT"/>
                 <command name="glGenSemaphoresEXT"/>


### PR DESCRIPTION
VK_KHR_maintenance2 added two new image layouts
to Vulkan to allow more efficient use of packed
depth_stencil images.  This change adds
corresponding texture layouts to OpenGL.