### PR TITLE
MESA_swap_interval: Fix typo of the return value in the XML

### DIFF
--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -506,10 +506,10 @@ Bool glXSet3DfxModeMESA (int mode);
 #ifndef GLX_MESA_swap_control
 #define GLX_MESA_swap_control 1
 typedef int ( *PFNGLXGETSWAPINTERVALMESAPROC) (void);
-typedef void ( *PFNGLXSWAPINTERVALMESAPROC) (unsigned int interval);
+typedef int ( *PFNGLXSWAPINTERVALMESAPROC) (unsigned int interval);
 #ifdef GLX_GLXEXT_PROTOTYPES
 int glXGetSwapIntervalMESA (void);
-void glXSwapIntervalMESA (unsigned int interval);
+int glXSwapIntervalMESA (unsigned int interval);
 #endif
 #endif /* GLX_MESA_swap_control */
 

--- a/xml/glx.xml
+++ b/xml/glx.xml
@@ -1411,7 +1411,7 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>int64_t</ptype> <name>remainder</name></param>
         </command>
         <command>
-            <proto>void <name>glXSwapIntervalMESA</name></proto>
+            <proto>int <name>glXSwapIntervalMESA</name></proto>
             <param>unsigned int <name>interval</name></param>
         </command>
         <command>


### PR DESCRIPTION
The spec text and the Mesa implementation both had an int return here.
Found when updating the GL headers in Mesa broke the build of the
piglit test suite.