### PR TITLE
Add MESA_program_binary_formats extension

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -9209,6 +9209,11 @@ GLAPI void APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint queryNameLen
 #define GL_PACK_INVERT_MESA               0x8758
 #endif /* GL_MESA_pack_invert */
 
+#ifndef GL_MESA_program_binary_formats
+#define GL_MESA_program_binary_formats 1
+#define GL_PROGRAM_BINARY_FORMAT_MESA     0x875F
+#endif /* GL_MESA_program_binary_formats */
+
 #ifndef GL_MESA_resize_buffers
 #define GL_MESA_resize_buffers 1
 typedef void (APIENTRYP PFNGLRESIZEBUFFERSMESAPROC) (void);

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -2365,6 +2365,11 @@ GL_APICALL void GL_APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint quer
 #endif
 #endif /* GL_INTEL_performance_query */
 
+#ifndef GL_MESA_program_binary_formats
+#define GL_MESA_program_binary_formats 1
+#define GL_PROGRAM_BINARY_FORMAT_MESA     0x875F
+#endif /* GL_MESA_program_binary_formats */
+
 #ifndef GL_MESA_shader_integer_functions
 #define GL_MESA_shader_integer_functions 1
 #endif /* GL_MESA_shader_integer_functions */

--- a/extensions/MESA/MESA_program_binary_formats.txt
+++ b/extensions/MESA/MESA_program_binary_formats.txt
@@ -1,0 +1,88 @@
+Name
+
+    MESA_program_binary_formats
+
+Name Strings
+
+    GL_MESA_program_binary_formats
+
+Contributors
+
+    Ian Romanick
+    Jordan Justen
+    Timothy Arceri
+
+Contact
+
+    Jordan Justen (jordan.l.justen 'at' intel.com)
+
+Status
+
+    Complete.
+
+Version
+
+    Last Modified Date: November 10, 2017
+    Revision: #2
+
+Number
+
+    OpenGL Extension #516
+    OpenGL ES Extension #294
+
+Dependencies
+
+    For use with the OpenGL ARB_get_program_binary extension, or the
+    OpenGL ES OES_get_program_binary extension.
+
+Overview
+
+    The get_program_binary exensions require a GLenum binaryFormat.
+    This extension documents that format for use with Mesa.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+        GL_PROGRAM_BINARY_FORMAT_MESA           0x875F
+
+    For ARB_get_program_binary, GL_PROGRAM_BINARY_FORMAT_MESA may be
+    returned from GetProgramBinary calls in the <binaryFormat>
+    parameter and when retrieving the value of PROGRAM_BINARY_FORMATS.
+
+    For OES_get_program_binary, GL_PROGRAM_BINARY_FORMAT_MESA may be
+    returned from GetProgramBinaryOES calls in the <binaryFormat>
+    parameter and when retrieving the value of
+    PROGRAM_BINARY_FORMATS_OES.
+
+New State
+
+    None.
+
+Issues
+
+    (1) Should we have a different format for each driver?
+
+      RESOLVED. Since Mesa supports multiple hardware drivers, having
+      a single format may cause separate drivers to have to reject a
+      binary for another type of hardware on the same machine. This
+      could lead to an application having to invalidate and get a new
+      binary more often.
+
+      This extension, at least initially, does not to attempt to
+      define a new token for each driver since systems that run
+      multiple drivers are not the common case.
+
+      Additionally, drivers in Mesa are now gaining the ability to
+      transparently cache shader programs. Therefore, although they
+      may need to provide the application with a new binary more
+      often, they likely can retrieve the program from the cache
+      rather than performing an expensive recompile.
+
+Revision History
+
+    #02    11/10/2017    Jordan Justen       Add Issues (1) suggested by Ian
+
+    #01    10/28/2017    Jordan Justen       First draft.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -609,4 +609,6 @@
 </li>
 <li value=293><a href="extensions/QCOM/QCOM_texture_foveated.txt">GL_QCOM_texture_foveated</a>
 </li>
+<li value=294><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -967,4 +967,6 @@
 </li>
 <li value=515><a href="extensions/MESA/MESA_tile_raster_order.txt">GL_MESA_tile_raster_order</a>
 </li>
+<li value=516><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2891,6 +2891,13 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_pixmap_colormap.txt',
     },
+    'GLX_MESA_program_binary_formats' : {
+        'number' : 516,
+        'esnumber' : 294,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_program_binary_formats.txt',
+    },
     'GLX_MESA_query_renderer' : {
         'number' : 446,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6764,7 +6764,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x875C" name="GL_PROXY_TEXTURE_2D_STACK_MESAX"/>
         <enum value="0x875D" name="GL_TEXTURE_1D_STACK_BINDING_MESAX"/>
         <enum value="0x875E" name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
-            <unused start="0x875F" vendor="MESA"/>
+	<enum value="0x875F" name="GL_PROGRAM_BINARY_FORMAT_MESA"/>
     </enums>
 
     <enums namespace="GL" start="0x8760" end="0x883F" vendor="AMD">
@@ -45755,6 +45755,11 @@ typedef unsigned int GLhandleARB;
         <extension name="GL_MESA_pack_invert" supported="gl">
             <require>
                 <enum name="GL_PACK_INVERT_MESA"/>
+            </require>
+        </extension>
+        <extension name="GL_MESA_program_binary_formats" supported="gl|gles2">
+            <require>
+                <enum name="GL_PROGRAM_BINARY_FORMAT_MESA"/>
             </require>
         </extension>
         <extension name="GL_MESA_resize_buffers" supported="gl">


### PR DESCRIPTION
This extension defines the GL_PROGRAM_BINARY_FORMAT_MESA
enum to be used by the ARB_get_program_binary and
OES_get_program_binary extensions.