### PR TITLE
WIP: Add KHR_EGL_image_storage extension.

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -3858,6 +3858,17 @@ GLAPI void APIENTRY glTexBufferARB (GLenum target, GLenum internalformat, GLuint
 #define GL_ARB_viewport_array 1
 #endif /* GL_ARB_viewport_array */
 
+#ifndef GL_KHR_EGL_image_storage
+#define GL_KHR_EGL_image_storage 1
+typedef void *GLeglImageOES;
+typedef void (APIENTRYP PFNGLEGLIMAGETARGETTEXSTORAGEKHRPROC) (GLenum target, GLeglImageOES image);
+typedef void (APIENTRYP PFNGLEGLIMAGETARGETTEXTURESTORAGEKHRPROC) (GLuint texture, GLeglImageOES image);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glEGLImageTargetTexStorageKHR (GLenum target, GLeglImageOES image);
+GLAPI void APIENTRY glEGLImageTargetTextureStorageKHR (GLuint texture, GLeglImageOES image);
+#endif
+#endif /* GL_KHR_EGL_image_storage */
+
 #ifndef GL_KHR_blend_equation_advanced
 #define GL_KHR_blend_equation_advanced 1
 #define GL_MULTIPLY_KHR                   0x9294

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20171115
+#define GL_GLEXT_VERSION 20171120
 
 /* Generated C header for:
  * API: gl
@@ -4948,6 +4948,17 @@ GLAPI void APIENTRY glWindowPos3sARB (GLshort x, GLshort y, GLshort z);
 GLAPI void APIENTRY glWindowPos3svARB (const GLshort *v);
 #endif
 #endif /* GL_ARB_window_pos */
+
+#ifndef GL_KHR_EGL_image_storage
+#define GL_KHR_EGL_image_storage 1
+typedef void *GLeglImageOES;
+typedef void (APIENTRYP PFNGLEGLIMAGETARGETTEXSTORAGEKHRPROC) (GLenum target, GLeglImageOES image);
+typedef void (APIENTRYP PFNGLEGLIMAGETARGETTEXTURESTORAGEKHRPROC) (GLuint texture, GLeglImageOES image);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glEGLImageTargetTexStorageKHR (GLenum target, GLeglImageOES image);
+GLAPI void APIENTRY glEGLImageTargetTextureStorageKHR (GLuint texture, GLeglImageOES image);
+#endif
+#endif /* GL_KHR_EGL_image_storage */
 
 #ifndef GL_KHR_blend_equation_advanced
 #define GL_KHR_blend_equation_advanced 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20171115
+#define GLX_GLXEXT_VERSION 20171120
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20171012
+#define WGL_WGLEXT_VERSION 20171120
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20171115 */
+/* Generated on date 20171120 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171115 */
+/* Generated on date 20171120 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171115 */
+/* Generated on date 20171120 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171115 */
+/* Generated on date 20171120 */
 
 /* Generated C header for:
  * API: gles2
@@ -49,6 +49,17 @@ extern "C" {
  * Additional extensions included: _nomatch_^
  * Extensions removed: _nomatch_^
  */
+
+#ifndef GL_KHR_EGL_image_storage
+#define GL_KHR_EGL_image_storage 1
+typedef void *GLeglImageOES;
+typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETTEXSTORAGEKHRPROC) (GLenum target, GLeglImageOES image);
+typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETTEXTURESTORAGEKHRPROC) (GLuint texture, GLeglImageOES image);
+#ifdef GL_GLEXT_PROTOTYPES
+GL_APICALL void GL_APIENTRY glEGLImageTargetTexStorageKHR (GLenum target, GLeglImageOES image);
+GL_APICALL void GL_APIENTRY glEGLImageTargetTextureStorageKHR (GLuint texture, GLeglImageOES image);
+#endif
+#endif /* GL_KHR_EGL_image_storage */
 
 #ifndef GL_KHR_blend_equation_advanced
 #define GL_KHR_blend_equation_advanced 1
@@ -239,7 +250,6 @@ GL_APICALL void GL_APIENTRY glGetnUniformuivKHR (GLuint program, GLint location,
 
 #ifndef GL_OES_EGL_image
 #define GL_OES_EGL_image 1
-typedef void *GLeglImageOES;
 typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETTEXTURE2DOESPROC) (GLenum target, GLeglImageOES image);
 typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC) (GLenum target, GLeglImageOES image);
 #ifdef GL_GLEXT_PROTOTYPES

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171115 */
+/* Generated on date 20171120 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/KHR/KHR_EGL_image_storage.txt
+++ b/extensions/KHR/KHR_EGL_image_storage.txt
@@ -1,0 +1,191 @@
+Name
+
+    KHR_EGL_image_storage
+
+Name Strings
+
+    GL_KHR_EGL_image_storage
+
+Contact
+
+    Craig Donner (cdonner 'at' google.com)
+
+Contributors
+
+    Krzysztof Kosinski, Google
+    Craig Donner, Google
+    Jesse Hall, Google
+
+Status
+
+    Draft
+
+Version
+
+    November 20, 2017 (version 3)
+
+Number
+
+    ARB Extension #196
+    OpenGL ES Extension #295
+
+Dependencies
+
+    Requires OpenGL 4.2, OpenGL ES 3.0, or ARB_texture_storage.
+
+    Requires EGL 1.4 and either the EGL_KHR_image or EGL_KHR_image_base
+    extensions.
+
+    The EGL_KHR_gl_texture_2D_image, EGL_KHR_gl_texture_cubemap_image,
+    EGL_KHR_gl_texture_3D_image, EGL_KHR_gl_renderbuffer_image,
+    EGL_KHR_vg_parent_image, and EGL_ANDROID_get_native_client_buffer
+    extensions provide additional functionality layered on EGL_KHR_image_base
+    and related to this extension.
+
+    EXT_direct_state_access, ARB_direct_state_access, and OpenGL 4.5 affect
+    the definition of this extension.
+
+    This extension interacts with GL_OES_EGL_image, GL_OES_EGL_image_external
+    and GL_EXT_EGL_image_array.
+
+    This extension is written based on the wording of the OpenGL ES 3.0
+    Specification.
+
+Overview
+
+    The OpenGL ES extension OES_EGL_image provides a mechanism for creating
+    GL textures sharing storage with EGLImage objects (in other words, creating
+    GL texture EGLImage targets).  The extension was written against the
+    OpenGL ES 2.0 specification, which does not have the concept of immutable
+    textures.  As a result, it specifies that respecification of a texture by
+    calling TexImage* on a texture that is an EGLImage target causes it to be
+    implicitly orphaned.  In most cases, this is not the desired behavior, but
+    rather a result of an application error.
+
+    This extension provides a mechanism for creating texture objects that are
+    both EGLImage targets and immutable.  Since immutable textures cannot be
+    respecified, they also cannot accidentally be orphaned, and attempts to do
+    so generate errors instead of resulting in well-defined, but often
+    undesirable and surprising behavior.  It provides a strong guarantee that
+    texture data that is intended to be shared will remain shared.
+
+    The language of the OES_EGL_image extension is also slightly ambiguous on
+    whether calls to glGenerateMipmap always cause respecification, or cause it
+    only when the call would create additional or differently-sized mipmap
+    levels in the texture.  To avoid any ambiguity, this extension explicitly
+    allows calls to glGenerateMipmap on textures that are immutable EGLImage
+    targets.
+
+    EGL extension specifications are located in the EGL Registry at
+
+        http://www.khronos.org/registry/egl/
+
+Glossary
+
+    Please see the EGL_KHR_image specification for a list of terms
+    used by this specification.
+
+New Types
+
+    /*
+     * GLeglImageOES is an opaque handle to an EGLImage
+     */
+    typedef void* GLeglImageOES;
+
+New Procedures and Functions
+
+    void EGLImageTargetTexStorageKHR(enum target, eglImageOES image)
+
+    <If EXT_direct_state_access or an equivalent mechanism is supported:>
+
+    void EGLImageTargetTextureStorageKHR(uint texture, eglImageOES image)
+
+New Tokens
+
+     None.
+
+Additions to Chapter 3 of the OpenGL 3.0 Specification (Rasterization)
+
+    - (3.8.4, p. 138)  Insert the following text before the paragraph starting
+    with "After a successful call to any TexStorage* command":
+
+    The command
+
+        void EGLImageTargetTexStorageKHR(enum target, eglImageOES image);
+
+    specifies all levels and properties of a texture (including dimensionality,
+    width, height, format, mipmap levels of detail, and image data) by taking
+    them from the specified eglImageOES <image>.
+
+    <target> must be one of GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D,
+    GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_EXTERNAL_OES.
+    On OpenGL implementations (non-ES), <target> can also be GL_TEXTURE_1D or
+    GL_TEXTURE_1D_ARRAY.  <target> must match the type of image data stored in
+    <image>.  For instance, if the <image> was created from a GL texture,
+    <target> must match the texture target of the source texture. <image> must
+    be the handle of a valid EGLImage resource, cast into the type eglImageOES.
+    Assuming no errors are generated in EGLImageTargetTexStorageKHR, the newly
+    specified texture object will be an EGLImage target of the specified
+    eglImageOES.
+
+    If <target> is not one of the allowed values, the error INVALID_ENUM is
+    generated.  Note that if an implementation does not support any method of
+    creating EGLImage objects compatible with the specified texture target, but
+    it is one of the allowed values, the error INVALID_OPERATION must be
+    generated instead.
+
+    If <image> does not refer to a valid eglImageOES object, the error
+    INVALID_VALUE is generated.
+
+    If the GL is unable to specify a texture object using the supplied
+    eglImageOES <image> (if, for example, <image> refers to a multisampled
+    eglImageOES, or <target> is GL_TEXTURE_2D but <image> contains a cube map),
+    the error INVALID_OPERATION is generated.
+
+    <If EXT_direct_state_access or an equivalent mechanism is supported:>
+
+    The command
+
+        void EGLImageTargetTextureStorageKHR(uint texture, eglImageOES image);
+
+    is equivalent to EGLImageTargetTexStorageKHR, but the target texture object
+    is directly specified using the <texture> parameter instead of being taken
+    from the active texture unit.
+
+    - (3.8.4, p. 138)  Replace "After a successful call to any TexStorage*
+    command" with "After a successful call to any TexStorage* or
+    EGLImageTarget*StorageKHR command"
+
+    - (3.8.4, p. 138)  Add the following to the list following the sentence
+    "Using any of the following commands with the same texture will result in
+    an INVALID_OPERATION error being generated, even if it does not affect the
+    dimensions or format:"
+
+    EGLImageTarget*StorageKHR
+
+Issues
+
+    1.  Should this extension provide support for renderbuffers?
+
+        RESOLVED:  This seems of limited use, and renderbuffer support specified
+        by OES_EGL_image already uses the immutable storage model, so that would
+        be redundant.
+
+    2.  Should OES_EGL_image be a prerequisite?
+
+        RESOLVED:  Supporting both OES_EGL_image and this extension requires
+        more complexity than supporting only this extension and we did not want
+        to rule out such implementations.  Therefore, this extension does not
+        require OES_EGL_image.
+
+Revision History
+
+
+    #3 (November 20, 2017) - Added direct state access entry point and corrected
+        references to the OpenGL ES 3.0 specification.
+
+    #2 (November 13, 2017) - Specified the allowed texture targets.  Clarified
+        requirements.  Clarified interactions with mipmaps.
+
+    #1 (November 1, 2017) - Initial version.
+

--- a/extensions/arbext.php
+++ b/extensions/arbext.php
@@ -419,4 +419,6 @@
 </li>
 <li value=195><a href="extensions/ARB/ARB_texture_filter_anisotropic.txt">GL_ARB_texture_filter_anisotropic</a>
 </li>
+<li value=196><a href="extensions/KHR/KHR_EGL_image_storage.txt">GL_KHR_EGL_image_storage</a>
+</li>
 </ol>

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -609,6 +609,8 @@
 </li>
 <li value=293><a href="extensions/QCOM/QCOM_texture_foveated.txt">GL_QCOM_texture_foveated</a>
 </li>
-<li value=294><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
+<li value=294><a href="extensions/MESA/MESA_program_binary_formats.txt">GLX_MESA_program_binary_formats</a>
+</li>
+<li value=295><a href="extensions/KHR/KHR_EGL_image_storage.txt">GL_KHR_EGL_image_storage</a>
 </li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -967,6 +967,6 @@
 </li>
 <li value=515><a href="extensions/MESA/MESA_tile_raster_order.txt">GL_MESA_tile_raster_order</a>
 </li>
-<li value=516><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
+<li value=516><a href="extensions/MESA/MESA_program_binary_formats.txt">GLX_MESA_program_binary_formats</a>
 </li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2824,6 +2824,12 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/KHR/KHR_debug.txt',
     },
+    'GL_KHR_EGL_image_storage' : {
+        'arbnumber' : 196,
+        'esnumber' : 295,
+        'flags' : { 'public' },
+        'url' : 'extensions/KHR/KHR_EGL_image_storage.txt',
+    },
     'GL_KHR_no_error' : {
         'arbnumber' : 175,
         'esnumber' : 243,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14486,8 +14486,18 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
         </command>
         <command>
+            <proto>void <name>glEGLImageTargetTexStorageKHR</name></proto>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
+        </command>
+        <command>
             <proto>void <name>glEGLImageTargetTexture2DOES</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
+        </command>
+        <command>
+            <proto>void <name>glEGLImageTargetTextureStorageKHR</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
         </command>
         <command>
@@ -45630,6 +45640,15 @@ typedef unsigned int GLhandleARB;
             </require>
             <require api="gl" profile="compatibility">
                 <enum name="GL_DISPLAY_LIST"/>
+            </require>
+        </extension>
+        <extension name="GL_KHR_EGL_image_storage" supported="gl|glcore|gles2">
+            <require>
+                <type name="GLeglImageOES"/>
+                <command name="glEGLImageTargetTexStorageKHR"/>
+            </require>
+            <require comment="Supported only if GL_EXT_direct_state_access, ARB_direct_state_access, or OpenGL 4.5 are supported">
+                <command name="glEGLImageTargetTextureStorageKHR"/>
             </require>
         </extension>
         <extension name="GL_KHR_no_error" supported="gl|glcore|gles2">


### PR DESCRIPTION
This extension allows the creation of immutable texture EGLImage targets. These have much simpler semantics than regular texture EGLImage targets defined by OES_EGL_image and do not exhibit potentially surprising orphaning behavior.

We need this to more easily support new AHardwareBuffer functionality in Android P. Since this extension does contain anything Android-specific and looks like it could be useful to other users of EGLImage, we would like to ratify it as a KHR extension.