### PR TITLE
GLX_MESA_copy_sub_buffer: add language about implicit flush and command completion

### DIFF
--- a/extensions/MESA/GLX_MESA_copy_sub_buffer.txt
+++ b/extensions/MESA/GLX_MESA_copy_sub_buffer.txt
@@ -16,7 +16,7 @@ Status
 
 Version
 
-    Last Modified Date:  8 June 2000
+    Last Modified Date:  12 January 2009
 
 Number
 
@@ -69,9 +69,15 @@ Additions to Chapter 3 of the GLX 1.3 Specification (Functions and Errors)
     <width> and <height> indicate the size in pixels.  Coordinate (0,0)
     corresponds to the lower-left pixel of the window, like glReadPixels.
 
+    If dpy and drawable are the display and drawable for the calling
+    thread's current context, glXCopySubBufferMESA performs an
+    implicit glFlush before it returns.  Subsequent OpenGL commands
+    may be issued immediately after calling glXCopySubBufferMESA, but
+    are not executed until the copy is completed.
+
 GLX Protocol
 
-    None at this time.	The extension is implemented in terms of ordinary
+    None at this time.  The extension is implemented in terms of ordinary
     Xlib protocol inside of Mesa.
 
 Errors
@@ -84,5 +90,7 @@ New State
 
 Revision History
 
-    8 June 2000 - initial specification
+    12 January 2009 Ian Romanick - Added language about implicit flush
+                                   and command completion.
+    8 June 2000     Brian Paul   - initial specification
 


### PR DESCRIPTION
This pulls in the changes from Ian Romanick (@ianromanick) in Mesa commit
https://cgit.freedesktop.org/mesa/mesa/commit/?id=1f47388dfebf15f610993f046e1f945024c8fc3c

From Ian's commit:
> Copied language from the glXSwapBuffers manual page about the implicit
> glFlush and expected command completion.  This just codifies what
> people already expect from glXCopySubBufferMESA.  The intention of
> this command is to work like glXSwapBuffers but on a sub-rectangle of
> the drawable.