### PR TITLE
MESA_pack_invert: fix typo

### DIFF
--- a/extensions/MESA/MESA_pack_invert.txt
+++ b/extensions/MESA/MESA_pack_invert.txt
@@ -48,7 +48,7 @@ IP Status
 
 Issues
 
-    1. Should we also defined UNPACK_INVERT_MESA for glDrawPixels, etc?
+    1. Should we also define UNPACK_INVERT_MESA for glDrawPixels, etc?
 
     Resolved:  No, we're only concerned with pixel packing.  There are other
     solutions for inverting images when using glDrawPixels (negative Y pixel


### PR DESCRIPTION
This pulls in the changes from Nicolas Kaiser (@nikai3d) in Mesa commit
https://cgit.freedesktop.org/mesa/mesa/commit/?id=ae5776c41f12515bb73c07ee2a0aed56cdd1a1ef