### PR TITLE
MESA_ycbcr_texture: fix a few typos

### DIFF
--- a/extensions/MESA/MESA_ycbcr_texture.txt
+++ b/extensions/MESA/MESA_ycbcr_texture.txt
@@ -26,7 +26,7 @@ Number
 Dependencies
 
     OpenGL 1.0 or later is required
-    This extensions is written against the OpenGL 1.4 Specification.
+    This extension is written against the OpenGL 1.4 Specification.
     NV_texture_rectangle effects the definition of this extension.
 
 Overview
@@ -75,14 +75,14 @@ Additions to Chapter 2 of the OpenGL 1.4 Specification (OpenGL Operation)
 
 Additions to Chapter 3 of the OpenGL 1.4 Specification (Rasterization)
 
-    In section 3.6.4, Rasterization of Pixel Rectangles, on page 102,
+    In section 3.6.4, Rasterization of Pixel Rectangles, on page 101,
     add the following to Table 3.8 (Packed pixel formats):
     
     type Parameter                GL Data   Number of        Matching
      Token Name                    Type     Components     Pixel Formats
     --------------                -------   ----------     -------------
-    UNSIGNED_SHORT_8_8_MESA       ushort         3         YCBCR_422_MESA
-    UNSIGNED_SHORT_8_8_REV_MESA   ushort         3         YCBCR_422_MESA
+    UNSIGNED_SHORT_8_8_MESA       ushort         2         YCBCR_MESA
+    UNSIGNED_SHORT_8_8_REV_MESA   ushort         2         YCBCR_MESA
 
 
     In section 3.6.4, Rasterization of Pixel Rectangles, on page 102,
@@ -103,13 +103,13 @@ Additions to Chapter 3 of the OpenGL 1.4 Specification (Rasterization)
     +-------------------------------+-------------------------------+
 
 
-    In section 3.6.4, Rasterization of Pixel Rectangles, on page 102,
-    add the following to Table 3.12 (Packed pixel fiedl assignments):
+    In section 3.6.4, Rasterization of Pixel Rectangles, on page 104,
+    add the following to Table 3.12 (Packed pixel field assignments):
 
                        First       Second     Third      Fourth
     Format             Element     Element    Element    Element
     ------             -------     -------    -------    -------
-    YCBCR_422_MESA     luminance   chroma
+    YCBCR_MESA         luminance   chroma
 
 
     In section 3.8.1, Texture Image Specification, on page 125, add
@@ -201,3 +201,4 @@ Revision History
      3 September 2003 - further clarify when YCbCr->RGB conversion takes place
     19 September 2003 - a few more updates prior to submitting to extension
                         registry.
+     3 April 2004 - fix assorted inaccuracies


### PR DESCRIPTION
This pulls in the changes from Brian Paul and Nicolas Kaiser (@nikai3d) in Mesa commits
https://cgit.freedesktop.org/mesa/mesa/commit/?id=29f0190be772bc46ba2ddb4032e112f49d384cf5
https://cgit.freedesktop.org/mesa/mesa/commit/?id=fbb60ede3d5005328cedc9c2fa587e14e6309ed6
https://cgit.freedesktop.org/mesa/mesa/commit/?id=ae5776c41f12515bb73c07ee2a0aed56cdd1a1ef