### PR TITLE
Fixed param lengths for glDeleteSemaphoresEXT and glGenSemaphoresEXT.

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -13693,7 +13693,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeleteSemaphoresEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param len="count">const <ptype>GLuint</ptype> *<name>semaphores</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>semaphores</name></param>
         </command>
         <command>
             <proto>void <name>glDeleteShader</name></proto>
@@ -15709,7 +15709,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGenSemaphoresEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param len="count"><ptype>GLuint</ptype> *<name>semaphores</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>semaphores</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGenSymbolsEXT</name></proto>


### PR DESCRIPTION
Length of _semaphores_ parameters changed from _count_, which doesn't exist in the commands, to _n_.