### PR TITLE
Changed GLvoid to void in the rest of commands.

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17451,7 +17451,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>queryHandle</name></param>
             <param><ptype>GLuint</ptype> <name>flags</name></param>
             <param><ptype>GLsizei</ptype> <name>dataSize</name></param>
-            <param><ptype>GLvoid</ptype> *<name>data</name></param>
+            <param><ptype>void</ptype> *<name>data</name></param>
             <param><ptype>GLuint</ptype> *<name>bytesWritten</name></param>
         </command>
         <command>
@@ -21873,7 +21873,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param>const <ptype>GLvoid</ptype> *<name>data</name></param>
+            <param>const <ptype>void</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glMulticastCopyBufferSubDataNV</name></proto>


### PR DESCRIPTION
_GLvoid_ was still being used in two extention commands.