### PR TITLE
Register two NVIDIA extensions for OpenGL ES.

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20171124
+#define GL_GLEXT_VERSION 20171125
 
 /* Generated C header for:
  * API: gl

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20171115
+#define GLX_GLXEXT_VERSION 20171125
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20171012
+#define WGL_WGLEXT_VERSION 20171125
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20171124 */
+/* Generated on date 20171125 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171124 */
+/* Generated on date 20171125 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171124 */
+/* Generated on date 20171125 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171124 */
+/* Generated on date 20171125 */
 
 /* Generated C header for:
  * API: gles2
@@ -2480,6 +2480,17 @@ GL_APICALL void GL_APIENTRY glBlendBarrierNV (void);
 #define GL_FACTOR_MAX_AMD                 0x901D
 #endif /* GL_NV_blend_minmax_factor */
 
+#ifndef GL_NV_clip_space_w_scaling
+#define GL_NV_clip_space_w_scaling 1
+#define GL_VIEWPORT_POSITION_W_SCALE_NV   0x937C
+#define GL_VIEWPORT_POSITION_W_SCALE_X_COEFF_NV 0x937D
+#define GL_VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV 0x937E
+typedef void (GL_APIENTRYP PFNGLVIEWPORTPOSITIONWSCALENVPROC) (GLuint index, GLfloat xcoeff, GLfloat ycoeff);
+#ifdef GL_GLEXT_PROTOTYPES
+GL_APICALL void GL_APIENTRY glViewportPositionWScaleNV (GLuint index, GLfloat xcoeff, GLfloat ycoeff);
+#endif
+#endif /* GL_NV_clip_space_w_scaling */
+
 #ifndef GL_NV_conditional_render
 #define GL_NV_conditional_render 1
 #define GL_QUERY_WAIT_NV                  0x8E13
@@ -3294,6 +3305,10 @@ GL_APICALL void GL_APIENTRY glResolveDepthValuesNV (void);
 #define GL_NV_shadow_samplers_cube 1
 #define GL_SAMPLER_CUBE_SHADOW_NV         0x8DC5
 #endif /* GL_NV_shadow_samplers_cube */
+
+#ifndef GL_NV_stereo_view_rendering
+#define GL_NV_stereo_view_rendering 1
+#endif /* GL_NV_stereo_view_rendering */
 
 #ifndef GL_NV_texture_border_clamp
 #define GL_NV_texture_border_clamp 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171124 */
+/* Generated on date 20171125 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/NV/NV_clip_space_w_scaling.txt
+++ b/extensions/NV/NV_clip_space_w_scaling.txt
@@ -16,6 +16,7 @@ Contributors
     Ingo Esser, NVIDIA Corporation
     Pat Brown, NVIDIA Corporation
     Mark Kilgard, NVIDIA Corporation
+    Jason Schmidt, NVIDIA Corporation
 
 Status
 
@@ -23,17 +24,25 @@ Status
 
 Version
 
-    Last Modified Date:         June 1, 2016
-    NVIDIA Revision:            2
+    Last Modified Date:         November 25, 2017
+    NVIDIA Revision:            3
 
 Number
 
     OpenGL Extension #486
+    OpenGL ES Extension #295
 
 Dependencies
 
     This extension is written against OpenGL 4.5 Specification
     (Compatibility Profile).
+
+    This extension interacts with the OpenGL ES 3.1 Specification.
+
+    This extension requires NV_viewport_array2.
+
+    If implemented in OpenGL ES, one of NV_viewport_array or OES_viewport_array
+    is required.
 
 Overview
 
@@ -86,13 +95,12 @@ New Tokens
 Additions to Chapter 13 of the OpenGL 4.5 (Compatibility Profile)
 Specification (Fixed-Function Vertex Post-Processing)
 
-    Modify Section 13.2 (Transform Feedback), p. 453
+    Modify Section 13.2 (Transform Feedback), p. 453 [section 12.1 in OpenGL ES]
 
     Modify the first paragraph:
 
     ...The vertices are fed back after vertex color clamping, but before
-    stereo view expansion,  viewport mask expansion, viewport swizzle,
-    w coordinate warping, flat-shading, and clipping. ...
+    viewport mask expansion, w coordinate warping, flat-shading, and clipping...
 
     Add a new Section 13.X (Viewport W Coordinate Scaling)
 
@@ -164,6 +172,14 @@ Errors
 
     None.
 
+Interactions with OpenGL ES 3.1
+
+    If implemented in OpenGL ES, remove all references to GetDoublei_v.
+    If NV_viewport_array is supported, replace all references to MAX_VIEWPORTS
+    and GetFloati_v with MAX_VIEWPORTS_NV and GetFloati_vNV respectively.
+    If OES_viewport_array is supported, replace all references to MAX_VIEWPORTS
+    and GetFloati_v with MAX_VIEWPORTS_OES and GetFloati_vOES respectively.
+
 Issues
 
     (1) Does this extension provide any functionality to convert the w-scaled
@@ -228,3 +244,8 @@ Revision History
       - Internal revisions.
     Revision 2
       - Add _NV suffixes to _COEFF tokens
+    Revision 3
+      - Add ES interactions.
+      - Add requirement for NV_viewport_array2
+    Revision 4, 2017/11/25 (pbrown)
+      - Add to the OpenGL ES Extension Registry

--- a/extensions/NV/NV_stereo_view_rendering.txt
+++ b/extensions/NV/NV_stereo_view_rendering.txt
@@ -14,6 +14,7 @@ Contributors
 
     Mark Kilgard, NVIDIA Corporation
     Pat Brown, NVIDIA Corporation
+    Jason Schmidt, NVIDIA Corporation
 
 Status
 
@@ -21,17 +22,20 @@ Status
 
 Version
 
-    Last Modified Date:         May 09, 2016
-    NVIDIA Revision:            1
+    Last Modified Date:         November 25, 2017
+    NVIDIA Revision:            3
 
 Number
 
     OpenGL Extension #489
+    OpenGL ES Extension #296
 
 Dependencies
 
     This extension is written against OpenGL 4.5 Specification
     (Compatibility Profile).
+
+    This extension interacts with the OpenGL ES 3.1 Specification.
 
     The extension requires NV_viewport_array2.
 
@@ -80,6 +84,11 @@ Additions to Chapter 11 of the OpenGL 4.5 (Compatibility Profile) Specification
     gl_SecondaryViewportMaskNV[] hold the homogeneous vertex position and the
     viewport mask for the secondary view, as described in Section 11.5
     (Stereo Offsetted Rendering).
+
+    [Section 11.2 of the OpenGL 4.5 specification corresponds to
+     Section 11.1ts of the OpenGL ES 3.1 specification, and
+     Section 11.3 of the OpenGL 4.5 specification corresponds to
+     Section 11.1gs of the OpenGL ES 3.1 specification]
 
     In Section 11.2.1.2.2 (Tessellation Control Shader Inputs), modify the
     line describing members of gl_in[] to include gl_SecondaryPositionNV
@@ -154,7 +163,16 @@ Additions to Chapter 11 of the OpenGL 4.5 (Compatibility Profile) Specification
 Additions to Chapter 13 of the OpenGL 4.5 (Compatibility Profile)
 Specification (Fixed-Function Vertex Post-Processing)
 
-    Modify Section 13.6.1 (Controlling the Viewport) to include
+    Modify Section 13.2 (Transform Feedback), p. 453 [section 12.1 in OpenGL ES]
+
+    Modify the first paragraph:
+
+    ...The vertices are fed back after vertex color clamping, but before
+    viewport mask expansion, stereo view expansion, flat-shading, and
+    clipping. ...
+
+    Modify Section 13.6.1 (Controlling the Viewport)
+    [section 12.5.1 in OpenGL ES] to include
     gl_SecondaryViewportMaskNV[] wherever gl_ViewportMask[] is mentioned.
 
 
@@ -399,5 +417,9 @@ Issues
 
 Revision History
 
+    Revision 3 2017/11/25 (pbrown)
+      - Add to the OpenGL ES Extension Registry
+    Revision 2 2017/02/21 (jaschmidt)
+      - Formally add OpenGL ES interactions
     Revision 1
       - Internal revisions.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -611,4 +611,8 @@
 </li>
 <li value=294><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
 </li>
+<li value=295><a href="extensions/NV/NV_clip_space_w_scaling.txt">GL_NV_clip_space_w_scaling</a>
+</li>
+<li value=296><a href="extensions/NV/NV_stereo_view_rendering.txt">GL_NV_stereo_view_rendering</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2891,7 +2891,7 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_pixmap_colormap.txt',
     },
-    'GLX_MESA_program_binary_formats' : {
+    'GL_MESA_program_binary_formats' : {
         'number' : 516,
         'esnumber' : 294,
         'flags' : { 'public' },
@@ -3049,6 +3049,7 @@ registry = {
     },
     'GL_NV_clip_space_w_scaling' : {
         'number' : 486,
+        'esnumber' : 295,
         'flags' : { 'public' },
         'url' : 'extensions/NV/NV_clip_space_w_scaling.txt',
     },
@@ -3589,6 +3590,7 @@ registry = {
     },
     'GL_NV_stereo_view_rendering' : {
         'number' : 489,
+        'esnumber' : 296,
         'flags' : { 'public' },
         'url' : 'extensions/NV/NV_stereo_view_rendering.txt',
     },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -45949,7 +45949,7 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_NV_blend_square" supported="gl"/>
-        <extension name="GL_NV_clip_space_w_scaling" supported="gl|glcore">
+        <extension name="GL_NV_clip_space_w_scaling" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_VIEWPORT_POSITION_W_SCALE_NV"/>
                 <enum name="GL_VIEWPORT_POSITION_W_SCALE_X_COEFF_NV"/>
@@ -47184,7 +47184,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_SAMPLER_CUBE_SHADOW_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_stereo_view_rendering" supported="gl|glcore"/>
+        <extension name="GL_NV_stereo_view_rendering" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_tessellation_program5" supported="gl">
             <require>
                 <enum name="GL_MAX_PROGRAM_PATCH_ATTRIBS_NV"/>


### PR DESCRIPTION
This change updates two NVIDIA extensions and registers them in the OpenGL ES Registry.  I think I followed the directions properly for assigning numbers and updating various headers/XML files, but it would be good to double-check.

Note that this change also includes a fix to "registry.py", which had an incorrect prefix for MESA_program_binary_formats.  See the commit message for more info.