### PR TITLE
Register new GL_NV_conservative_raster* extensions

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -4923,6 +4923,11 @@ GLAPI void APIENTRY glConservativeRasterParameterfNV (GLenum pname, GLfloat valu
 #endif
 #endif /* GL_NV_conservative_raster_dilate */
 
+#ifndef GL_NV_conservative_raster_pre_snap
+#define GL_NV_conservative_raster_pre_snap 1
+#define GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV 0x9550
+#endif /* GL_NV_conservative_raster_pre_snap */
+
 #ifndef GL_NV_conservative_raster_pre_snap_triangles
 #define GL_NV_conservative_raster_pre_snap_triangles 1
 #define GL_CONSERVATIVE_RASTER_MODE_NV    0x954D
@@ -4933,6 +4938,10 @@ typedef void (APIENTRYP PFNGLCONSERVATIVERASTERPARAMETERINVPROC) (GLenum pname, 
 GLAPI void APIENTRY glConservativeRasterParameteriNV (GLenum pname, GLint param);
 #endif
 #endif /* GL_NV_conservative_raster_pre_snap_triangles */
+
+#ifndef GL_NV_conservative_raster_underestimation
+#define GL_NV_conservative_raster_underestimation 1
+#endif /* GL_NV_conservative_raster_underestimation */
 
 #ifndef GL_NV_draw_vulkan_image
 #define GL_NV_draw_vulkan_image 1

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20171125
+#define GL_GLEXT_VERSION 20171212
 
 /* Generated C header for:
  * API: gl
@@ -9580,6 +9580,11 @@ GLAPI void APIENTRY glConservativeRasterParameterfNV (GLenum pname, GLfloat valu
 #endif
 #endif /* GL_NV_conservative_raster_dilate */
 
+#ifndef GL_NV_conservative_raster_pre_snap
+#define GL_NV_conservative_raster_pre_snap 1
+#define GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV 0x9550
+#endif /* GL_NV_conservative_raster_pre_snap */
+
 #ifndef GL_NV_conservative_raster_pre_snap_triangles
 #define GL_NV_conservative_raster_pre_snap_triangles 1
 #define GL_CONSERVATIVE_RASTER_MODE_NV    0x954D
@@ -9590,6 +9595,10 @@ typedef void (APIENTRYP PFNGLCONSERVATIVERASTERPARAMETERINVPROC) (GLenum pname, 
 GLAPI void APIENTRY glConservativeRasterParameteriNV (GLenum pname, GLint param);
 #endif
 #endif /* GL_NV_conservative_raster_pre_snap_triangles */
+
+#ifndef GL_NV_conservative_raster_underestimation
+#define GL_NV_conservative_raster_underestimation 1
+#endif /* GL_NV_conservative_raster_underestimation */
 
 #ifndef GL_NV_copy_depth_to_color
 #define GL_NV_copy_depth_to_color 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20171125
+#define GLX_GLXEXT_VERSION 20171212
 
 /* Generated C header for:
  * API: glx

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20171125 */
+/* Generated on date 20171212 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171125 */
+/* Generated on date 20171212 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171125 */
+/* Generated on date 20171212 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20171125 */
+/* Generated on date 20171212 */
 
 /* Generated C header for:
  * API: gles2
@@ -2516,6 +2516,11 @@ typedef void (GL_APIENTRYP PFNGLSUBPIXELPRECISIONBIASNVPROC) (GLuint xbits, GLui
 GL_APICALL void GL_APIENTRY glSubpixelPrecisionBiasNV (GLuint xbits, GLuint ybits);
 #endif
 #endif /* GL_NV_conservative_raster */
+
+#ifndef GL_NV_conservative_raster_pre_snap
+#define GL_NV_conservative_raster_pre_snap 1
+#define GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV 0x9550
+#endif /* GL_NV_conservative_raster_pre_snap */
 
 #ifndef GL_NV_conservative_raster_pre_snap_triangles
 #define GL_NV_conservative_raster_pre_snap_triangles 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20171125 */
+/* Generated on date 20171212 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/NV/NV_conservative_raster_pre_snap.txt
+++ b/extensions/NV/NV_conservative_raster_pre_snap.txt
@@ -1,0 +1,151 @@
+Name
+
+    NV_conservative_raster_pre_snap
+
+Name Strings
+
+    GL_NV_conservative_raster_pre_snap
+
+Contact
+
+    Kedarnath Thangudu, NVIDIA Corporation (kthangudu 'at' nvidia.com)
+
+Contributors
+
+    Eric Werness, NVIDIA Corporation
+
+Status
+
+    Shipping in NVIDIA release 388.XX drivers and up
+
+Version
+
+    Last Modified Date:         November 15, 2017
+    Revision:                   1
+
+Number
+
+    OpenGL Extension #517
+    OpenGL ES Extension #297
+
+Dependencies
+
+    This extension is written against the NV_conservative_raster_pre_snap-
+    _triangles extension as applied to OpenGL 4.3 specification 
+    (Compatibility Profile) but may be used with the Core profile or OpenGL ES 
+    2.0 or later.
+    
+Overview
+
+    NV_conservative_raster_pre_snap_triangles provides a new mode to achieve
+    rasterization of triangles that is conservative w.r.t the triangle at 
+    infinite precision i.e. before it is snapped to the sub-pixel grid.  This
+    extension provides a new mode that expands this functionality to lines and 
+    points.
+
+New Procedures and Functions
+
+    None.
+    
+New Tokens
+
+    Accepted by the <param> parameter of ConservativeRasterParameteriNV:
+        CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV            0x9550
+    
+Additions to Chapter 14 of the OpenGL 4.3 (Compatibility Profile) Specification
+(Fixed-Function Primitive Assembly and Rasterization)
+
+    Modify the paragraph describing ConservativeRasterParameteriNV in the 
+    subsection 14.6.X "Conservative Rasterization" added by NV_conservative_-
+    raster_pre_snap_triangles
+
+    ... The <param> parameter specifies the conservative raster mode to be 
+    used. If the mode is set to CONSERVATIVE_RASTER_MODE_POST_SNAP_NV, the 
+    generated fragments are conservative w.r.t the primitive after it is 
+    snapped to sub-pixel grid.  If the mode is set to CONSERVATIVE_RASTER_MODE_-
+    PRE_SNAP_NV the fragments generated for a primitive will be conservative 
+    w.r.t the primitive at infinite precision. Since non-degenerate 
+    primitives may become degenerate due to vertex snapping, this mode will 
+    generate fragments for zero length lines and zero area triangles which are 
+    otherwise culled in the CONSERVATIVE_RASTER_MODE_POST_SNAP_NV. This mode 
+    may also generate fragments for pixels that are within half a sub-pixel 
+    distance away from the primitive at infinite precision.  If the mode is 
+    set to CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV, the pre-snap 
+    conservative raster behavior described would apply only to triangles.  The 
+    default mode is set to CONSERVATIVE_RASTER_MODE_POST_SNAP_NV.
+
+    Modify the paragraphs describing conservative rasterization behavior for
+    points, lines and polygons added by NV_conservative_raster as follows:
+
+    If CONSERVATIVE_RASTERIZATION_NV is enabled, points are rasterized 
+    according to point rasterization rules (section 14.4), except that a 
+    fragment will be generated for a framebuffer pixel if the point's region 
+    (a circle when MULTISAMPLING is enabled and POINT_SPRITE is disabled, or a 
+    square otherwise) covers any portion of the pixel, including its edges or 
+    points.  While conservative raster mode PRE_SNAP_NV respects the 
+    MULTISAMPLE state, modes POST_SNAP_NV and PRE_SNAP_TRIANGLES_NV always use 
+    point multisample rasterization rules (section 14.4.3), whether or not 
+    MULTISAMPLE is actually enabled.  When performing conservative 
+    rasterization of points, the POINT_SMOOTH enable is ignored and treated as
+    disabled.
+
+    If CONSERVATIVE_RASTERIZATION_NV is enabled, lines are rasterized 
+    according to line rasterization rules (section 14.5), except that the 
+    LINE_STIPPLE and LINE_SMOOTH enables are ignored and treated as disabled.  
+    When the conservative raster mode is POST_SNAP or PRE_SNAP_TRIANGLES, 
+    lines with zero length generate no fragments, while a fragment for the 
+    pixel that contains the end points will be generated when the mode is 
+    PRE_SNAP_NV.  Also, conservative raster mode PRE_SNAP_NV respects the 
+    MULTISAMPLE state, while modes POST_SNAP_NV and PRE_SNAP_TRIANGLES_NV 
+    always use line multisample rasterization rules (section 14.5.4), whether 
+    or not MULTISAMPLE is actually enabled.
+
+    If CONSERVATIVE_RASTERIZATION_NV is enabled, polygons are rasterized 
+    according to polygon rasterization rules (section 14.6), except that 
+    the POLYGON_SMOOTH enable is ignored and treated as disabled. 
+    When the conservative raster mode is POST_SNAP_NV, polygons with 
+    an area of zero generate no fragments, even for pixels that contain a 
+    vertex or edge of the zero-area polygon, while modes PRE_SNAP_TRIANGLES 
+    and PRE_SNAP_NV generate them.  Also, conservative raster mode PRE_SNAP_NV 
+    respects the MULTISAMPLE state, while modes POST_SNAP_NV and 
+    PRE_SNAP_TRIANGLES_NV always use polygon multisample rasterization rules 
+    (section 14.6.6), whether or not MULTISAMPLE is actually enabled.
+
+New State
+
+    None.
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None.
+
+GLX Protocol
+
+    None.
+    
+Modifications to the OpenGL Shading Language Specification, Version 4.30
+
+    None.
+
+Errors
+
+    INVALID_ENUM is generated by ConservativeRasterParameteriNV if <pname> is
+    not CONSERVATIVE_RASTER_MODE_NV, or if <param> is not CONSERVATIVE_RASTER_-
+    MODE_POST_SNAP_NV, CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV or CONSERVATIVE_-
+    RASTER_MODE_PRE_SNAP_TRIANGLES_NV.
+
+Issues
+
+    (1) Would MODE_PRE_SNAP_NV generate fragments for zero width lines and
+    zero diameter points?
+
+    RESOLVED. No. Vertex snapping to the sub-pixel grid may cause in a line 
+    to become zero length, so, MODE_PRE_SNAP will generate fragments for 
+    zero length lines. Zero width lines and zero diameter points are culled as
+    normal in both MODE_PRE_SNAP or MODE_POST_SNAP modes.
+
+Revision History
+
+    Revision 1
+      - Internal revisions.
+

--- a/extensions/NV/NV_conservative_raster_underestimation.txt
+++ b/extensions/NV/NV_conservative_raster_underestimation.txt
@@ -1,0 +1,186 @@
+Name
+
+    NV_conservative_raster_underestimation
+
+Name Strings
+
+    GL_NV_conservative_raster_underestimation
+
+Contact
+
+    Kedarnath Thangudu, NVIDIA Corporation (kthangudu 'at' nvidia.com)
+
+Contributors
+
+    Mark Kilgard, NVIDIA
+
+Status
+
+    Shipping in NVIDIA release 388.XX drivers and up
+
+Version
+
+    Last Modified Date:         November 15, 2017
+    Revision:                   1
+
+Number
+
+    OpenGL Extension #518
+
+Dependencies
+
+    This extension is written against NV_conservative_raster as applied to
+    OpenGL 4.3 specification (Core Profile).
+
+    This extension interacts with NV_gpu_program4 and NV_gpu_program5.
+    
+Overview
+    
+    The extension NV_conservative_raster provides a new rasterization mode 
+    known as "Overestimated Conservative Rasterization", where any pixel that 
+    is partially covered, even if no sample location is covered, is treated as 
+    fully covered and a corresponding fragment will be shaded.  There is also 
+    an "Underestimated Conservative Rasterization" variant, where only the 
+    pixels that are completely covered by the primitive are rasterized. 
+
+    This extension provides the underestimated conservative rasterization 
+    information for each fragment in the fragment shader through a new
+    built-in gl_FragFullyCoveredNV.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    None.
+
+Additions to Chapter 14 of the OpenGL 4.3 (Compatibility Profile) Specification
+(Fixed-Function Primitive Assembly and Rasterization)
+
+    Add a new paragraph at the end of subsection 14.6.X "Conservative 
+    Rasterization" (added by NV_conservative_raster)
+
+    When CONSERVATIVE_RASTERIZATION_NV is enabled, the fragment shader built-in
+    input boolean variable gl_FragFullyCoveredNV will indicate if the fragment 
+    being shaded is completely covered by the primitive.
+
+Additions to Chapter 15 of the OpenGL 4.3 (Compatibility Profile) Specification
+(Programmable Fragment Processing)
+
+    Add to the Section 15.2.2 (Shader Inputs)
+
+    When CONSERVATIVE_RASTERIZATION_NV is enabled, the built-in read-only 
+    variable gl_FragFullyCoveredNV is set to TRUE if the fragment is fully 
+    covered by the generating primitive, and FALSE otherwise.
+
+New State
+
+    None.
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None.
+
+GLX Protocol
+
+    None.
+    
+Modifications to the OpenGL Shading Language Specification, Version 4.30
+
+    Including the following line in a shader can be used to control the 
+    language features described in this extension:
+
+        #extension GL_NV_conservative_raster_underestimation : <behavior>
+
+    where <behavior> is as specified in section 3.3.
+
+    New preprocessor #defines are added to the OpenGL Shading Language:
+
+        #define GL_NV_conservative_raster_underestimation     1
+
+    Modify Section 7.1 (Built-In Language Variables), p. 113
+
+    Add to the list of fragment shader built-ins:
+
+        in bool gl_FragFullyCoveredNV;
+
+    Add the following descriptions for gl_FragFullyCoveredNV:
+
+    The built-in variable gl_FragFullyCoveredNV is a fragment-shader input 
+    variable which is set to TRUE, when CONSERVATIVE_RASTERIZATION_NV is 
+    enabled and the fragment is fully covered by the generating primitive, and 
+    FALSE otherwise. 
+
+Errors
+
+    None.
+
+Interactions with NV_gpu_program4 and NV_gpu_program5
+
+    If NV_gpu_program4 or NV_gpu_program5 is supported and the 
+    "NV_conservative_raster_underestimation" program option is specified, 
+    fragment programs can read the "fragment.fullycovered" attribute to 
+    determine if the fragment is fully covered by the primitive.
+
+    (Add the following rule to the NV_fragment_program4 grammar)
+
+    <attribBasic>   ::= ...
+                      | <fragPrefix> "fullycovered"
+
+    (Add the following to the Table X.X Fragment Attribute Bindings)
+
+    Fragment Attribute Binding  Components  Underlying State
+    --------------------------  ----------  ----------------------------
+    * fragment.fullycovered     (c,-,-,-)   fragment fully covered.
+
+    (Add the following to the Section 2.X.2, Program Grammar)
+
+    If a fragment attribute binding matches "fragment.fullycovered", the "x"
+    component of the fragment attribute variable is set to either 0 or 1,
+    depending on how the fragment is covered by the primitive.  If 
+    CONSERVATIVE_RASTERIZATION is enabled and the fragment is completely 
+    covered by the primitive, the fullycovered attribute is set to 1; 
+    otherwise, it is set to 0.  The "y", "z", and "w" coordinates are 
+    undefined.
+
+    If the "NV_conservative_raster_underestimation" program option is not 
+    specified, "fragment.fullycovered" binding is unavailable.
+
+Issues
+
+    (1) Do you need a new rasterization mode for underestimated conservative 
+    rasterization?
+
+    RESOLVED: Enabling CONSERVATIVE_RASTERIZATION will compute both 
+    overestimated and underestimated coverage for a primitive. A fragment will 
+    be shaded for each pixel that is covered under overestimation and the 
+    underestimation information is provided as a fragment shader input.  By 
+    simply discarding fragments that are not fully covered in the fragment 
+    shader, an application can achieve underestimated rasterization of a 
+    primitive in the final image.
+
+    (2) Should the y, z, and w components of the fragment.fullycovered
+    state for NV_gpu_program4 and NV_gpu_program5 be undefined?
+
+    RESOLVED: Yes.
+
+    The (c,-,-,-) is consistent with all the other scalar attributes in
+    NV_gpu_program*.
+
+    This undefined behavior is limited to the assembly interface and
+    not exposed in GLSL.
+
+    (3) How does having CONSERVATIVE_RASTERIZATION enabled affect the sample 
+    mask (gl_SampleMask) visible in the fragment shader?
+
+    RESOLVED: When you have CONSERVATIVE_RASTERIZATION enabled on, the 
+    gl_SampleMask will unconditionally show all 1's for valid samples.
+
+    Even with all 1's in gl_SampleMask doesn't imply that a fragment is
+    fully covered.
+    
+Revision History
+
+    Revision 1
+      - Internal revisions.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -617,6 +617,4 @@
 </li>
 <li value=297><a href="extensions/NV/NV_conservative_raster_pre_snap.txt">GL_NV_conservative_raster_pre_snap</a>
 </li>
-<li value=298><a href="extensions/NV/NV_conservative_raster_underestimation.txt">GL_NV_conservative_raster_underestimation</a>
-</li>
 </ol>

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -615,4 +615,8 @@
 </li>
 <li value=296><a href="extensions/NV/NV_stereo_view_rendering.txt">GL_NV_stereo_view_rendering</a>
 </li>
+<li value=297><a href="extensions/NV/NV_conservative_raster_pre_snap.txt">GL_NV_conservative_raster_pre_snap</a>
+</li>
+<li value=298><a href="extensions/NV/NV_conservative_raster_underestimation.txt">GL_NV_conservative_raster_underestimation</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -969,4 +969,8 @@
 </li>
 <li value=516><a href="extensions/MESA/MESA_program_binary_formats.txt">GL_MESA_program_binary_formats</a>
 </li>
+<li value=517><a href="extensions/NV/NV_conservative_raster_pre_snap.txt">GL_NV_conservative_raster_pre_snap</a>
+</li>
+<li value=518><a href="extensions/NV/NV_conservative_raster_underestimation.txt">GL_NV_conservative_raster_underestimation</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3082,11 +3082,22 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/NV/NV_conservative_raster_dilate.txt',
     },
+    'GL_NV_conservative_raster_pre_snap' : {
+        'number' : 517,
+        'esnumber' : 297,
+        'flags' : { 'public' },
+        'url' : 'extensions/NV/NV_conservative_raster_pre_snap.txt',
+    },
     'GL_NV_conservative_raster_pre_snap_triangles' : {
         'number' : 487,
         'esnumber' : 262,
         'flags' : { 'public' },
         'url' : 'extensions/NV/NV_conservative_raster_pre_snap_triangles.txt',
+    },
+    'GL_NV_conservative_raster_underestimation' : {
+        'number' : 518,
+        'flags' : { 'public' },
+        'url' : 'extensions/NV/NV_conservative_raster_underestimation.txt',
     },
     'GLX_NV_copy_buffer' : {
         'number' : 457,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9979,7 +9979,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x954D" name="GL_CONSERVATIVE_RASTER_MODE_NV"/>
         <enum value="0x954E" name="GL_CONSERVATIVE_RASTER_MODE_POST_SNAP_NV"/>
         <enum value="0x954F" name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV"/>
-            <unused start="0x9550" vendor="NV"/>
+        <enum value="0x9550" name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV"/>
         <enum value="0x9551" name="GL_SHADER_BINARY_FORMAT_SPIR_V"/>
         <enum value="0x9551" name="GL_SHADER_BINARY_FORMAT_SPIR_V_ARB" alias="GL_SHADER_BINARY_FORMAT_SPIR_V"/>
         <enum value="0x9552" name="GL_SPIR_V_BINARY"/>
@@ -46030,6 +46030,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glConservativeRasterParameterfNV"/>
             </require>
         </extension>
+        <extension name="GL_NV_conservative_raster_pre_snap" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV"/>
+            </require>
+        </extension>
         <extension name="GL_NV_conservative_raster_pre_snap_triangles" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_CONSERVATIVE_RASTER_MODE_NV"/>
@@ -46039,6 +46044,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glConservativeRasterParameteriNV"/>
             </require>
         </extension>
+        <extension name="GL_NV_conservative_raster_underestimation" supported="gl|glcore"/>
         <extension name="GL_NV_copy_buffer" supported="gles2">
             <require>
                 <enum name="GL_COPY_READ_BUFFER_NV"/>


### PR DESCRIPTION
This PR registers the following new extensions:
- GL_NV_conservative_raster_pre_snap (GL and ES)
- GL_NV_conservative_raster_underestimation (GL only)
