### PR TITLE
Include the API name in the header guard.

### DIFF
--- a/xml/reg.py
+++ b/xml/reg.py
@@ -513,7 +513,7 @@ class COutputGenerator(OutputGenerator):
         #
         # Multiple inclusion protection & C++ wrappers.
         if (genOpts.protectFile and self.genOpts.filename):
-            headerSym = '__' + re.sub('\.h', '_h_', os.path.basename(self.genOpts.filename))
+            headerSym = '__' + self.genOpts.apiname + '_' + re.sub('\.h', '_h_', os.path.basename(self.genOpts.filename))
             write('#ifndef', headerSym, file=self.outFile)
             write('#define', headerSym, '1', file=self.outFile)
             self.newline()


### PR DESCRIPTION
Several headers have the same header guard, making it impossible to
include declarations from both headers. This was complicating the
implementation of a driver with support for both desktop OpenGL and
OpenGL ES.