### PR TITLE
Fix HSL ClipColor() equation in the blend_equation_advanced extensions

### DIFF
--- a/extensions/KHR/KHR_blend_equation_advanced.txt
+++ b/extensions/KHR/KHR_blend_equation_advanced.txt
@@ -985,7 +985,7 @@ Revision History
 
       Fix ClipColor() equation where in the "if (maxcol > 1.0)" body the
       "(color-lum)*lum" term should have been "(color-lum)*(1-lum)". Also
-      add a new issue for the case where the inputs to SetLum() are outside
+      add new issue 11 for the case where the inputs to SetLum() are outside
       the range [0..1] and could cause a divide-by-zero in ClipColor().
 
     Revision 16, April 16, 2016 (from a September 30, 2014 edit that wasn't

--- a/extensions/KHR/KHR_blend_equation_advanced.txt
+++ b/extensions/KHR/KHR_blend_equation_advanced.txt
@@ -33,8 +33,8 @@ Status
 
 Version
 
-    Last Modified Date:         April 16, 2016
-    Revision:                   16
+    Last Modified Date:         February 14, 2018
+    Revision:                   17
 
 Number
 
@@ -312,8 +312,10 @@ Operations and the Frame Buffer)
     destination colors to the HSL (hue, saturation, luminosity) color space,
     generating a new HSL color by selecting H, S, and L components from the
     source or destination according to the blend equation, and then converting
-    the result back to RGB.  In the equations below, a blended RGB color is
-    produced according to the following pseudocode:
+    the result back to RGB.  The HSL blend equations are only well defined
+    when the values of the input color components are in the range [0..1].
+    In the equations below, a blended RGB color is produced according to the
+    following pseudocode:
 
       float minv3(vec3 c) {
         return min(min(c.r, c.g), c.b);
@@ -338,7 +340,7 @@ Operations and the Frame Buffer)
           color = lum + ((color-lum)*lum) / (lum-mincol);
         }
         if (maxcol > 1.0) {
-          color = lum + ((color-lum)*lum) / (maxcol-lum);
+          color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
         }
         return color;
       }
@@ -959,7 +961,26 @@ Issues
       optimizations or include logic to check for zero alpha values for each
       input.
 
+    (35) How should ClipColor() behave if the inputs cause a divide-by-zero,
+         which may happen when all color components are the same value and
+         outside the range [0..1]?
+         
+         For example, if the color parameter to ClipColor() has all color
+         components as equal and above 1.0 then maxcol==lum and the term:
+           color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
+         will be a divide-by-zero.
+
+      RESOLVED: The HSL blend equations are not well defined when used with
+      ill-conditioned inputs. The inputs must be in the range [0..1].
+
 Revision History
+
+    Revision 17, February 14, 2018
+
+      Fix ClipColor() equation where in the "if (maxcol > 1.0)" body the
+      "(color-lum)*lum" term should have been "(color-lum)*(1-lum)". Also
+      add a new issue for the case where the inputs to SetLum() are outside
+      the range [0..1] and could cause a divide-by-zero in ClipColor().
 
     Revision 16, April 16, 2016 (from a September 30, 2014 edit that wasn't
                                  published)

--- a/extensions/KHR/KHR_blend_equation_advanced.txt
+++ b/extensions/KHR/KHR_blend_equation_advanced.txt
@@ -961,17 +961,23 @@ Issues
       optimizations or include logic to check for zero alpha values for each
       input.
 
-    (35) How should ClipColor() behave if the inputs cause a divide-by-zero,
-         which may happen when all color components are the same value and
-         outside the range [0..1]?
+    (11) For "HSL" blend equations, the blend equation involves a clipping
+         step where colors may be "clipped" if the blend would produce
+         components are outside the range [0,1]. Are there inputs where this
+         blend could produce ill-defined or nonsensical results?
          
-         For example, if the color parameter to ClipColor() has all color
-         components as equal and above 1.0 then maxcol==lum and the term:
-           color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
-         will be a divide-by-zero.
+      RESOLVED: Yes, the results of HSL blend equations are undefined if the
+      input colors have components outside the range [0,1]. Even if the input
+      colors are in-range, the basic color adjustment done in these blends
+      could produce result components outside the range [0,1]. To compensate,
+      the ClipColor() function in the specification interpolates the result
+      color and a greyscale value that matches the luminance of the result.
+      The math for the clipping operation assumes the luminance of the result
+      color is in the range [0,1]. If that isn't the case, the clipping
+      operation could result in a divide by zero (when all result components
+      have the same out-of-bounds value) or perform an otherwise nonsensical
+      computation.
 
-      RESOLVED: The HSL blend equations are not well defined when used with
-      ill-conditioned inputs. The inputs must be in the range [0..1].
 
 Revision History
 

--- a/extensions/NV/NV_blend_equation_advanced.txt
+++ b/extensions/NV/NV_blend_equation_advanced.txt
@@ -26,8 +26,8 @@ Status
 
 Version
 
-    Last Modified Date:         September 30, 2014
-    NVIDIA Revision:            9
+    Last Modified Date:         February 14, 2018
+    NVIDIA Revision:            10
 
 Number
 
@@ -484,8 +484,10 @@ Operations and the Frame Buffer)
     destination colors to the HSL (hue, saturation, luminosity) color space,
     generating a new HSL color by selecting H, S, and L components from the
     source or destination according to the blend equation, and then converting
-    the result back to RGB.  In the equations below, a blended RGB color is
-    produced according to the following pseudocode:
+    the result back to RGB.  The HSL blend equations are only well defined
+    when the values of the input color components are in the range [0..1].
+    In the equations below, a blended RGB color is produced according to the
+    following pseudocode:
 
       float minv3(vec3 c) {
         return min(min(c.r, c.g), c.b);
@@ -510,7 +512,7 @@ Operations and the Frame Buffer)
           color = lum + ((color-lum)*lum) / (lum-mincol);
         }
         if (maxcol > 1.0) {
-          color = lum + ((color-lum)*lum) / (maxcol-lum);
+          color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
         }
         return color;
       }
@@ -1674,10 +1676,30 @@ Issues
       include a special case for Cb==0 while others do not.  We have added a
       special case there as well.
 
+    (35) How should ClipColor() behave if the inputs cause a divide-by-zero,
+         which may happen when all color components are the same value and
+         outside the range [0..1]?
+         
+         For example, if the color parameter to ClipColor() has all color
+         components as equal and above 1.0 then maxcol==lum and the term:
+           color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
+         will be a divide-by-zero.
+
+      RESOLVED: The HSL blend equations are not well defined when used with
+      ill-conditioned inputs. The inputs must be in the range [0..1].
+      
 Revision History
     
     Rev.    Date    Author    Changes
-    ----  --------  --------  -----------------------------------------
+    ----  --------  --------  ----------------------------------------------
+    10    02/14/18  pdaniell  Fix ClipColor() equation where in the
+                              "if (maxcol > 1.0)" body the "(color-lum)*lum"
+                              term should have been "(color-lum)*(1-lum)".
+                              Also add a new issue for the case where the
+                              inputs to SetLum() are outside the range
+                              [0..1] and could cause a divide-by-zero in
+                              ClipColor().
+    
      9    09/30/14  pbrown    Fix incorrectly specified color clamping in
                               the HSL blend modes.
 

--- a/extensions/NV/NV_blend_equation_advanced.txt
+++ b/extensions/NV/NV_blend_equation_advanced.txt
@@ -1688,7 +1688,7 @@ Issues
       RESOLVED: The HSL blend equations are not well defined when used with
       ill-conditioned inputs. The inputs must be in the range [0..1].
       
-    (35) For "HSL" blend equations, the blend equation involves a clipping
+    (36) For "HSL" blend equations, the blend equation involves a clipping
          step where colors may be "clipped" if the blend would produce
          components are outside the range [0,1]. Are there inputs where this
          blend could produce ill-defined or nonsensical results?
@@ -1713,7 +1713,7 @@ Revision History
     10    02/14/18  pdaniell  Fix ClipColor() equation where in the
                               "if (maxcol > 1.0)" body the "(color-lum)*lum"
                               term should have been "(color-lum)*(1-lum)".
-                              Also add a new issue for the case where the
+                              Also add new issue 36 for the case where the
                               inputs to SetLum() are outside the range
                               [0..1] and could cause a divide-by-zero in
                               ClipColor().

--- a/extensions/NV/NV_blend_equation_advanced.txt
+++ b/extensions/NV/NV_blend_equation_advanced.txt
@@ -1688,6 +1688,24 @@ Issues
       RESOLVED: The HSL blend equations are not well defined when used with
       ill-conditioned inputs. The inputs must be in the range [0..1].
       
+    (35) For "HSL" blend equations, the blend equation involves a clipping
+         step where colors may be "clipped" if the blend would produce
+         components are outside the range [0,1]. Are there inputs where this
+         blend could produce ill-defined or nonsensical results?
+         
+      RESOLVED: Yes, the results of HSL blend equations are undefined if the
+      input colors have components outside the range [0,1]. Even if the input
+      colors are in-range, the basic color adjustment done in these blends
+      could produce result components outside the range [0,1]. To compensate,
+      the ClipColor() function in the specification interpolates the result
+      color and a greyscale value that matches the luminance of the result.
+      The math for the clipping operation assumes the luminance of the result
+      color is in the range [0,1]. If that isn't the case, the clipping
+      operation could result in a divide by zero (when all result components
+      have the same out-of-bounds value) or perform an otherwise nonsensical
+      computation.
+
+
 Revision History
     
     Rev.    Date    Author    Changes

--- a/extensions/NV/NV_blend_equation_advanced.txt
+++ b/extensions/NV/NV_blend_equation_advanced.txt
@@ -1676,19 +1676,7 @@ Issues
       include a special case for Cb==0 while others do not.  We have added a
       special case there as well.
 
-    (35) How should ClipColor() behave if the inputs cause a divide-by-zero,
-         which may happen when all color components are the same value and
-         outside the range [0..1]?
-         
-         For example, if the color parameter to ClipColor() has all color
-         components as equal and above 1.0 then maxcol==lum and the term:
-           color = lum + ((color-lum)*(1-lum)) / (maxcol-lum);
-         will be a divide-by-zero.
-
-      RESOLVED: The HSL blend equations are not well defined when used with
-      ill-conditioned inputs. The inputs must be in the range [0..1].
-      
-    (36) For "HSL" blend equations, the blend equation involves a clipping
+    (35) For "HSL" blend equations, the blend equation involves a clipping
          step where colors may be "clipped" if the blend would produce
          components are outside the range [0,1]. Are there inputs where this
          blend could produce ill-defined or nonsensical results?
@@ -1713,7 +1701,7 @@ Revision History
     10    02/14/18  pdaniell  Fix ClipColor() equation where in the
                               "if (maxcol > 1.0)" body the "(color-lum)*lum"
                               term should have been "(color-lum)*(1-lum)".
-                              Also add new issue 36 for the case where the
+                              Also add new issue 35 for the case where the
                               inputs to SetLum() are outside the range
                               [0..1] and could cause a divide-by-zero in
                               ClipColor().


### PR DESCRIPTION
Fixes https://www.khronos.org/members/login/bugzilla/show_bug.cgi?id=16026 and https://gitlab.khronos.org/opengl/API/issues/60.

Fix the HSL blend equation ClipColor() pseudo-code and modify the spec to say that the HSL blend equations are only well defined when the input color components are in the range [0..1].

Once this is approved we need to update the OpenGL ES 3.2 spec with the same change.
