### PR TITLE
ARB_internalformat_query2 revision 19

### DIFF
--- a/extensions/ARB/ARB_internalformat_query2.txt
+++ b/extensions/ARB/ARB_internalformat_query2.txt
@@ -8,7 +8,7 @@ Name Strings
 
 Contact
 
-    Daniel Koch (daniel 'at' transgaming 'dot' com)
+    Daniel Koch (dkoch 'at' nvidia 'dot' com)
 
 Contributors
 
@@ -17,6 +17,7 @@ Contributors
     Yuan Wang, IMG
     Pat Brown, NVIDIA
     Piers Daniel, NVIDIA
+    Daniel Koch, TransGaming
     Jon Leech, Khronos
     Members of the ARB Working group.
 
@@ -32,8 +33,8 @@ Status
 
 Version
 
-    Last Modified Date: July 15, 2013
-    Revision: 18
+    Last Modified Date: February 14, 2018
+    Revision: 19
 
 Number
 
@@ -445,7 +446,8 @@ Additions to Chapter 6 of the OpenGL 4.2 (Core Profile) Specification
       component resolution of an uncompressed internal format that produces
       an image of roughly the same quality as the compressed algorithm.
       For textures this query will return the same information as querying
-      GetTexLevelParameter{if}v for TEXTURE_*_SIZE would return.
+      GetTexLevelParameter{if}v for TEXTURE_*_SIZE would return (except in
+      such cases where GetTexLevelParameter{if}v doesn't support such a query).
       If the internal format is unsupported, or if a particular component is
       not present in the format, 0 is written to <params>.
 
@@ -460,8 +462,9 @@ Additions to Chapter 6 of the OpenGL 4.2 (Core Profile) Specification
       For compressed internal formats the types returned specify how components
       are interpreted after decompression. 
       For textures this query returns the same information as querying
-      GetTexLevelParameter{if}v for TEXTURE_*TYPE would return.
-      Possible values return include, NONE, SIGNED_NORMALIZED,
+      GetTexLevelParameter{if}v for TEXTURE_*_TYPE would return (except in
+      such cases where GetTexLevelParameter{if}v doesn't support such a
+      query). Possible values return include, NONE, SIGNED_NORMALIZED,
       UNSIGNED_NORMALIZED, FLOAT, INT, UNSIGNED_INT, representing missing,
       signed normalized fixed point, unsigned normalized fixed point, 
       floating-point, signed unnormalized integer and unsigned unnormalized
@@ -1321,10 +1324,23 @@ Issues
     filtering is directly supported. We don't expect implmentations to
     be able to support it for MIN filters but not for MAG, or vice versa.
 
+   16) What should we do in cases where a command is defined in terms of
+    GetTexLevelParameter, but GetTexLevelParameter doesn't support the target
+    (eg TEXTURE_BUFFER in versions of GL prior to 3.1) or there is no
+    corresponding pname (such as TEXTURE_STENCIL_TYPE)?
+
+    RESOLVED: GetInternalFormat* should return the correct information for the
+    specific query, it shouldn't be limited by the set of tokens that happen to
+    be legal for GetTexLevelParameter. This was just used a method of
+    reducing specification language duplication, and noting that the queries
+    are effectively the same.
+
 Revision History
 
     Rev.  Date        Author    Changes
     ----  ----------  --------  --------------------------------------------
+     19   02/14/2018  dgkoch    Add issue 16, clarify references to
+                                GetTexLevelParameter (gitlab/opengl/api/65)
      18   07/15/2013  Jon Leech Remove redundant list of VIEW_CLASS_* tokens 
                                 (Bug 10518).
      17   07/11/2013  Jon Leech Clarify relationship between VIEW_CLASS_*


### PR DESCRIPTION
Add issue 16.
Clarify that GetInternalFormat* commands shouldn't be restricted
by GetTexLevelParameter valid parameters.

Gitlab opengl/API Issue: 65