### PR TITLE
Rename parameters of glDepthRangef to "n" and "f"

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -13785,8 +13785,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRange</name></proto>
-            <param><ptype>GLdouble</ptype> <name>near</name></param>
-            <param><ptype>GLdouble</ptype> <name>far</name></param>
+            <param><ptype>GLdouble</ptype> <name>n</name></param>
+            <param><ptype>GLdouble</ptype> <name>f</name></param>
             <glx type="render" opcode="174"/>
         </command>
         <command>


### PR DESCRIPTION
"near" and "far" conflict with macros defined by windows.h