### PR TITLE
Amend section 12.2 of readme (<alias> and <vecequiv> tags)

### DIFF
--- a/xml/readme.tex
+++ b/xml/readme.tex
@@ -471,14 +471,14 @@ Following these elements, the remaining elements in a \tag{command}
 tag are optional and may be in any order:
 
 \begin{itemize}
-\item \tag{alias} has no attributes and contains a string which is the
+\item \tag{alias} has one attribute, \attr{name}, containing a string which is the
       name of another command this command is an alias of, used when
       promoting a function from extension to ARB or ARB to API status. A
       command alias describes the case where there are two function
       names which resolve to the {\bf same} client library code, so (for
       example) the case where a command is promoted but is also given
       different GLX protocol would {\bf not} be an alias in this sense.
-\item \tag{vecequiv} has no attributes and contains a string which is
+\item \tag{vecequiv} has one attribute, \attr{name}, containing a string which is
       the name of another command which is the {\em vector equivalent}
       of this command. For example, the vector equivalent of
       \code{glVertex3f} is \code{glVertex3fv}.


### PR DESCRIPTION
The description of "alias" and "vecequiv" tags in 12.2
does not reflect what's actually in gl.xml. The readme says
that these tags do not have any attributes and contain strings.
In gl.xml, however, these tags are empty and the relevant values
are contained within their "name" attributes. For example:

```
        <command>
            <proto>void <name>glBinormal3dEXT</name></proto>
            <param group="CoordD"><ptype>GLdouble</ptype> <name>bx</name></param>
            <param group="CoordD"><ptype>GLdouble</ptype> <name>by</name></param>
            <param group="CoordD"><ptype>GLdouble</ptype> <name>bz</name></param>
            **<vecequiv name="glBinormal3dvEXT"/>**
        </command>
```

and

```

        <command>
            <proto>void <name>glBlendColorEXT</name></proto>
            <param group="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
            <param group="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
            <param group="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
            <param group="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
            **<alias name="glBlendColor"/>**
            <glx type="render" opcode="4096"/>
        </command>
```