### PR TITLE
Register new INTEL_blackhole_render extension for OpenGL & OpenGL ES

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -4650,6 +4650,11 @@ GLAPI void APIENTRY glWindowRectanglesEXT (GLenum mode, GLsizei count, const GLi
 #endif
 #endif /* GL_EXT_window_rectangles */
 
+#ifndef GL_INTEL_blackhole_render
+#define GL_INTEL_blackhole_render 1
+#define GL_BLACKHOLE_RENDER_INTEL         0x83FC
+#endif /* GL_INTEL_blackhole_render */
+
 #ifndef GL_INTEL_conservative_rasterization
 #define GL_INTEL_conservative_rasterization 1
 #define GL_CONSERVATIVE_RASTERIZATION_INTEL 0x83FE

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20180221
+#define GL_GLEXT_VERSION 20180302
 
 /* Generated C header for:
  * API: gl
@@ -9114,6 +9114,11 @@ GLAPI void APIENTRY glBlendFuncSeparateINGR (GLenum sfactorRGB, GLenum dfactorRG
 #define GL_INGR_interlace_read 1
 #define GL_INTERLACE_READ_INGR            0x8568
 #endif /* GL_INGR_interlace_read */
+
+#ifndef GL_INTEL_blackhole_render
+#define GL_INTEL_blackhole_render 1
+#define GL_BLACKHOLE_RENDER_INTEL         0x83FC
+#endif /* GL_INTEL_blackhole_render */
 
 #ifndef GL_INTEL_conservative_rasterization
 #define GL_INTEL_conservative_rasterization 1

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20180221 */
+/* Generated on date 20180302 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20180221 */
+/* Generated on date 20180302 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20180221 */
+/* Generated on date 20180302 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20180221 */
+/* Generated on date 20180302 */
 
 /* Generated C header for:
  * API: gles2
@@ -2320,6 +2320,11 @@ GL_APICALL void GL_APIENTRY glFramebufferTexture2DMultisampleIMG (GLenum target,
 #define GL_CUBIC_MIPMAP_NEAREST_IMG       0x913A
 #define GL_CUBIC_MIPMAP_LINEAR_IMG        0x913B
 #endif /* GL_IMG_texture_filter_cubic */
+
+#ifndef GL_INTEL_blackhole_render
+#define GL_INTEL_blackhole_render 1
+#define GL_BLACKHOLE_RENDER_INTEL         0x83FC
+#endif /* GL_INTEL_blackhole_render */
 
 #ifndef GL_INTEL_conservative_rasterization
 #define GL_INTEL_conservative_rasterization 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20180221 */
+/* Generated on date 20180302 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/INTEL/INTEL_blackhole_render.txt
+++ b/extensions/INTEL/INTEL_blackhole_render.txt
@@ -1,0 +1,124 @@
+Name
+
+    INTEL_blackhole_render
+
+Name Strings
+
+    GL_INTEL_blackhole_render
+
+Contact
+
+    Lionel Landwerlin, Intel  (lionel.g.landwerlin 'at' intel.com)
+
+Contributors
+
+    Ben Widawsky (benjamin.widawsky 'at' intel.com)
+
+Status
+
+    Draft.
+
+Version
+
+    Last Modified Date:        03/02/2018
+    INTEL Revision:            1
+
+Number
+
+    OpenGL Extension #521
+    OpenGL ES Extension #300
+
+Dependencies
+
+    OpenGL dependencies:
+
+        OpenGL 3.0 is required.
+
+        The extension is written against the OpenGL 4.6 Specification, Core
+        Profile, July 30, 2017.
+
+    OpenGL ES dependencies:
+
+        This extension is written against the OpenGL ES 3.2 Specification,
+        November 3, 2016.
+
+Overview
+
+    The purpose of this extension is to allow an application to disable all
+    rendering operations emitted to the GPU through the OpenGL rendering
+    commands (Draw*, DispatchCompute*, BlitFramebuffer, etc...). Changes to the
+    OpenGL pipeline are not affected.
+
+    New preprocessor #defines are added to the OpenGL Shading Language:
+
+      #define GL_INTEL_blackhole_render 1
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    Accepted by the <target> parameter of Enable, Disable, IsEnabled:
+
+        BLACKHOLE_RENDER_INTEL  0x83FC
+
+Additions to the OpenGL 4.6 (Core Profile) Specification
+
+    Modify section 2.4 Rendering Commands (add new text at the end of the
+    section)
+
+    The effect of the above commands can be disabled by enabling
+    BLACKHOLE_RENDER_INTEL.
+
+Additions to Chapter 14.2.2, Shader Inputs of the OpenGL ES 3.2 Specification
+
+    Modify section 2.4 Rendering Commands (add new text at the end of the
+    section)
+
+    The effect of the above commands can be disabled by enabling
+    BLACKHOLE_RENDER_INTEL.
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None.
+
+GLX Protocol
+
+    None.
+
+Errors
+
+    None.
+
+New State in OpenGL 4.6 Core Profile
+
+    (add new row to the Table 23.74, Miscellaneous)
+
+                                     Initial
+    Get Value      Type  Get Command  Value  Description                 Sec.
+    -------------  ----  ----------- ------- -------------------------   ------
+    BLACKHOLE_
+    RENDERING_     B     IsEnabled()  FALSE  Disable rendering           2.4
+    INTEL
+
+New State in OpenGL ES 3.2
+
+    (add new row to the Table 21.57, Miscellaneous)
+
+                                     Initial
+    Get Value      Type  Get Command  Value  Description                 Sec.
+    -------------  ----  ----------- ------- -------------------------   ------
+    BLACKHOLE_
+    RENDERING_     B     IsEnabled()  FALSE  Disable rendering           2.4
+    INTEL
+
+Issues
+
+    None.
+
+Revision History
+
+    Rev.     Date       Author       Changes
+    ----  ----------  ----------  -----------------------------------------
+      1    3/2/2018   llandwerlin Initial revision.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -623,4 +623,6 @@
 </li>
 <li value=299><a href="extensions/EXT/EXT_texture_format_sRGB_override.txt">GL_EXT_texture_format_sRGB_override</a>
 </li>
+<li value=300><a href="extensions/INTEL/INTEL_blackhole_render.txt">GL_INTEL_blackhole_render</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -979,4 +979,6 @@
 
     <br> <a href="extensions/EXT/EXT_shader_framebuffer_fetch.txt">GL_EXT_shader_framebuffer_fetch_non_coherent</a>
 </li>
+<li value=521><a href="extensions/INTEL/INTEL_blackhole_render.txt">GL_INTEL_blackhole_render</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2798,6 +2798,13 @@ registry = {
         'supporters' : { 'INTEL' },
         'url' : 'extensions/INTEL/INTEL_map_texture.txt',
     },
+    'GL_INTEL_blackhole_render' : {
+        'number' : 521,
+        'esnumber' : 300,
+        'flags' : { 'public' },
+        'supporters' : { 'INTEL' },
+        'url' : 'extensions/INTEL/INTEL_blackhole_render.txt',
+    },
     'GL_INTEL_parallel_arrays' : {
         'number' : 136,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5779,7 +5779,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x83F9" name="GL_PERFQUERY_DONOT_FLUSH_INTEL"/>
         <enum value="0x83FA" name="GL_PERFQUERY_FLUSH_INTEL"/>
         <enum value="0x83FB" name="GL_PERFQUERY_WAIT_INTEL"/>
-            <unused start="0x83FC" end="0x83FD" vendor="INTEL"/>
+        <enum value="0x83FC" name="GL_BLACKHOLE_RENDER_INTEL"/>
+            <unused start="0x83FD" vendor="INTEL"/>
         <enum value="0x83FE" name="GL_CONSERVATIVE_RASTERIZATION_INTEL"/>
         <enum value="0x83FF" name="GL_TEXTURE_MEMORY_LAYOUT_INTEL"/>
     </enums>
@@ -45446,6 +45447,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glSyncTextureINTEL"/>
                 <command name="glUnmapTexture2DINTEL"/>
                 <command name="glMapTexture2DINTEL"/>
+            </require>
+        </extension>
+        <extension name="GL_INTEL_blackhole_render" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_BLACKHOLE_RENDER_INTEL"/>
             </require>
         </extension>
         <extension name="GL_INTEL_parallel_arrays" supported="gl">


### PR DESCRIPTION
Add INTEL_blackhole_render to t the OpenGL & OpenGL ES extension
registry. Regenerates headers files.