### PR TITLE
gl.xml: Add len attribute and veequiv tags for DrawTexOES

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14385,10 +14385,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfloat</ptype> <name>z</name></param>
             <param><ptype>GLfloat</ptype> <name>width</name></param>
             <param><ptype>GLfloat</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexfvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexfvOES</name></proto>
-            <param>const <ptype>GLfloat</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLfloat</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTexiOES</name></proto>
@@ -14397,10 +14398,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>z</name></param>
             <param><ptype>GLint</ptype> <name>width</name></param>
             <param><ptype>GLint</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexivOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexivOES</name></proto>
-            <param>const <ptype>GLint</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTexsOES</name></proto>
@@ -14409,10 +14411,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLshort</ptype> <name>z</name></param>
             <param><ptype>GLshort</ptype> <name>width</name></param>
             <param><ptype>GLshort</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexsvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexsvOES</name></proto>
-            <param>const <ptype>GLshort</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLshort</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTextureNV</name></proto>
@@ -14435,10 +14438,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfixed</ptype> <name>z</name></param>
             <param><ptype>GLfixed</ptype> <name>width</name></param>
             <param><ptype>GLfixed</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexxvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexxvOES</name></proto>
-            <param>const <ptype>GLfixed</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTransformFeedback</name></proto>


### PR DESCRIPTION
The vector versions are not properly annotated with the lengths, and the
scalar versions don't reference the vector versions.