### PR TITLE
Fix link name for GLX_EXT_stereo_tree in registry

### DIFF
--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -835,7 +835,7 @@
 </li>
 <li value=451><a href="extensions/AMD/AMD_gpu_shader_int64.txt">GL_AMD_gpu_shader_int64</a>
 </li>
-<li value=452><a href="extensions/EXT/GLX_EXT_stereo_tree.txt">GL_EXT_glx_stereo_tree</a>
+<li value=452><a href="extensions/EXT/GLX_EXT_stereo_tree.txt">GLX_EXT_stereo_tree</a>
 </li>
 <li value=453><a href="extensions/AMD/AMD_gcn_shader.txt">GL_AMD_gcn_shader</a>
 </li>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -1863,7 +1863,7 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/EXT/EXT_geometry_shader4.txt',
     },
-    'GL_EXT_glx_stereo_tree' : {
+    'GLX_EXT_stereo_tree' : {
         'number' : 452,
         'flags' : { 'public' },
         'url' : 'extensions/EXT/GLX_EXT_stereo_tree.txt',


### PR DESCRIPTION
For some reason GLX_EXT_stereo_tree was listed on
the registry page as GL_EXT_glx_stereo_tree.  This
change just corrects it to GLX_EXT_stereo_tree.