### PR TITLE
Clarify arrays of arrays is allowed for resources

### DIFF
--- a/extensions/ARB/ARB_gl_spirv.txt
+++ b/extensions/ARB/ARB_gl_spirv.txt
@@ -429,6 +429,10 @@ Overview
         differently for SPIR-V used in Vulkan and OpenGL
       . gl_FragColor can be written to, but it won't broadcast, for versions of
         OpenGL that support gl_FragColor
+      . Vulkan does not allow multi-dimensional arrays of resources like
+        UBOs and SSBOs in its SPIR-V environment spec. SPIR-V supports
+        it and OpenGL already allows this for GLSL shaders. SPIR-V
+        for OpenGL also allows it.
 
     Additions to the SPIR-V specification:
       + *Offset* can also apply to an object, for transform feedback.


### PR DESCRIPTION
This resolves internal issue https://gitlab.khronos.org/opengl/API/issues/70.

This clarifies that OpenGL allows SPIR-V shaders to use multi-dimensional arrays for resources like UBOs and SSBOs, in that same way that OpenGL allows this for GLSL shaders. This is a difference to the SPIR-V environment for Vulkan, which only allows single-dimension arrays for these resources.
