### PR TITLE
GLX_OML_sync_control: Remove spurious GLXFBConfig attribute

### DIFF
--- a/extensions/OML/GLX_OML_sync_control.txt
+++ b/extensions/OML/GLX_OML_sync_control.txt
@@ -262,11 +262,6 @@ Additions to the GLX 1.3 Specification
     and glXWaitForSbcOML will each return TRUE if the function completed
     successfully, FALSE otherwise.
 
-    The following Attribute/Type/Notes triple is added to Table 3.1,
-    GLXFBConfig attributes:
-
-	GLX_SBC     integer    Swap buffer count
-
 Errors
 
     Each of the functions defined by this extension will generate a


### PR DESCRIPTION
This seems to just be an error. GLX_SBC is not in fact a defined token,
and it's not clear what its value would even be, as the SBC is a
property of the drawable not the fbconfig.