### PR TITLE
Wrong value for the WGL_EXT_colorspace extension

### DIFF
--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -346,7 +346,7 @@ VOID WINAPI wglBlitContextFramebufferAMD (HGLRC dstCtx, GLint srcX0, GLint srcY0
 
 #ifndef WGL_EXT_colorspace
 #define WGL_EXT_colorspace 1
-#define WGL_COLORSPACE_EXT                0x3087
+#define WGL_COLORSPACE_EXT                0x309D
 #define WGL_COLORSPACE_SRGB_EXT           0x3089
 #define WGL_COLORSPACE_LINEAR_EXT         0x308A
 #endif /* WGL_EXT_colorspace */


### PR DESCRIPTION
The value for WGL_COLORSPACE_EXT is 0x309D as per extension's specification, not 0x3087. Also, tested on the newest NVIDIA drivers and only the value 0x309D is correctly recognized.