### PR TITLE
Add missing enum values to group "GetPName" in file gl.xml

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -976,6 +976,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MAX_CLIP_DISTANCES"/>
             <enum name="GL_MAX_CLIP_PLANES"/>
             <enum name="GL_MAX_COLOR_MATRIX_STACK_DEPTH_SGI"/>
+            <enum name="GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS"/>
             <enum name="GL_MAX_EVAL_ORDER"/>
             <enum name="GL_MAX_FOG_FUNC_POINTS_SGIS"/>
             <enum name="GL_MAX_FRAGMENT_LIGHTS_SGIX"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -778,6 +778,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_ACCUM_CLEAR_VALUE"/>
             <enum name="GL_ACCUM_GREEN_BITS"/>
             <enum name="GL_ACCUM_RED_BITS"/>
+            <enum name="GL_ACTIVE_TEXTURE"/>
             <enum name="GL_ALIASED_LINE_WIDTH_RANGE"/>
             <enum name="GL_ALIASED_POINT_SIZE_RANGE"/>
             <enum name="GL_ALPHA_BIAS"/>


### PR DESCRIPTION
GL_ACTIVE_TEXTURE and GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS were missing from GetPName. This is a valid value for ES2.0. Reference: https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGet.xml