### PR TITLE
NV_sample_locations void function argument (by formatting conventions)

### DIFF
--- a/extensions/NV/NV_sample_locations.txt
+++ b/extensions/NV/NV_sample_locations.txt
@@ -76,7 +76,7 @@ New Procedures and Functions
     void NamedFramebufferSampleLocationsfvNV(uint framebuffer, uint start,
                                              sizei count, const float *v);
 
-    void ResolveDepthValuesNV();
+    void ResolveDepthValuesNV(void);
 
 New Tokens
 


### PR DESCRIPTION
GLEW is still parsing extension specs, is expecting void argument which is common convention for these.