### PR TITLE
WIP: Add API's in VDPAU interop to receive frame/field-based surface

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20180919
+#define GL_GLEXT_VERSION 20181017
 
 /* Generated C header for:
  * API: gl
@@ -11295,6 +11295,14 @@ GLAPI void APIENTRY glVDPAUMapSurfacesNV (GLsizei numSurfaces, const GLvdpauSurf
 GLAPI void APIENTRY glVDPAUUnmapSurfacesNV (GLsizei numSurface, const GLvdpauSurfaceNV *surfaces);
 #endif
 #endif /* GL_NV_vdpau_interop */
+
+#ifndef GL_NV_vdpau_interop2
+#define GL_NV_vdpau_interop2 1
+typedef GLvdpauSurfaceNV (APIENTRYP PFNGLVDPAUREGISTERVIDEOSURFACEWITHPICTURESTRUCTURENVPROC) (const void *vdpSurface, GLenum target, GLsizei numTextureNames, const GLuint *textureNames, GLboolean isFrameStructure);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI GLvdpauSurfaceNV APIENTRY glVDPAURegisterVideoSurfaceWithPictureStructureNV (const void *vdpSurface, GLenum target, GLsizei numTextureNames, const GLuint *textureNames, GLboolean isFrameStructure);
+#endif
+#endif /* GL_NV_vdpau_interop2 */
 
 #ifndef GL_NV_vertex_array_range
 #define GL_NV_vertex_array_range 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20180905
+#define GLX_GLXEXT_VERSION 20181017
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20180927 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20180927
+#define WGL_WGLEXT_VERSION 20181017
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20180919 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20180919 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20180919 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20180919 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20180919 */
+/* Generated on date 20181017 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/NV/NV_vdpau_interop2.txt
+++ b/extensions/NV/NV_vdpau_interop2.txt
@@ -1,0 +1,206 @@
+Name
+
+    NV_vdpau_interop2
+
+Name Strings
+
+    GL_NV_vdpau_interop2
+
+Contributors
+
+    Manoj Gupta Bonda, NVIDIA
+    James Jones, NVIDIA
+
+Contact
+
+    Manoj Gupta Bonda, NVIDIA (mbonda 'at' nvidia.com)
+
+Status
+
+    XXX - Not complete yet!!!
+
+Version
+
+    1 (2 Oct 2018)
+
+Number
+
+    593
+
+Dependencies
+
+    This extension is written against the OpenGL 4.6 Specification
+    (Compatibility Profile), dated July 30, 2017.
+    but can apply to OpenGL 1.1 and up.
+
+    OpenGL 1.1 is required.
+    GL_NV_vdpau_interop is required.
+    GL_EXT_framebuffer_object affects the definition of this extension.
+    GL_ARB_texture_rectangle affects the definition of this extension.
+    GL_ARB_texture_non_power_of_two affects the definition of this
+    extension.
+
+Overview
+
+    This extension allows VDPAU video surfaces to be used
+    either with frame or field structures for texturing and rendering.
+
+IP Status
+
+    There are no known IP issues. 
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+
+    vdpauSurfaceNV VDPAURegisterVideoSurfaceWithPictureStructureNV (const void *vdpSurface,
+                                                                    enum       target,
+                                                                    sizei      numTextureNames,
+                                                                    const uint *textureNames,
+                                                                    boolean    isFrameStructure);
+
+New Tokens
+
+    None
+
+Additions to Chapter 8 of the OpenGL 4.6 (unabridged) Specification
+(Textures and Samplers)
+    
+    Replace the paragraph that begins with 'The command 
+    vdpauSurfaceNV VDPAURegisterVideoSurfaceNV' and the following two paragraphs,
+    including table 3.8.3.1, with the following:
+
+    The commands
+    
+        vdpauSurfaceNV VDPAURegisterVideoSurfaceNV (const void *vdpSurface,
+                                                    enum       target,
+                                                    sizei      numTextureNames,
+                                                    const uint *textureNames);
+
+        vdpauSurfaceNV VDPAURegisterVideoSurfaceWithPictureStructureNV (const void *vdpSurface,
+                                                                        enum       target,
+                                                                        sizei      numTextureNames,
+                                                                        const uint *textureNames,
+                                                                        boolean    isFrameStructure);
+
+    defines a set of two-dimensional textures, where the image data may
+    be taken from the VdpVideoSurface <vdpSurface>. <target> must be
+    one of TEXTURE_2D or TEXTURE_RECTANGLE. <numTextureNames>
+    determines how many textures are defined. <textureNames> contains
+    the names of the textures that are defined. The surface is
+    transitioned into the registered state.
+    
+    VDPAURegisterVideoSurfaceNV is equivalent to calling 
+    VDPAURegisterVideoSurfaceWithPictureStructureNV with <isFrameStructure> 
+    set to FALSE.
+
+    Legal values for <numTextureNames>,<isFrameStructure> are derived from the
+    VdpChromaType of <vdpSurface>, as defined in table 8.7.1.
+
+                                                                                          Internal
+      VdpChromaType              numTextureNames  isFrameStructure      Index  Size       Format    Content
+      -------------              ---------------  ----------------      -----  ----       --------  -------------------
+      VDP_CHROMA_TYPE_420        4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w/2 x h/4  R8G8      Top-field chroma
+                                                                        3      w/2 x h/4  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_422        4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w/2 x h/2  R8G8      Top-field chroma
+                                                                        3      w/2 x h/2  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_444        4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w   x h/2  R8G8      Top-field chroma
+                                                                        3      w   x h/2  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_420        2                        1             0      w   x h    R8        Luma
+                                                                        1      w/2 x h/2  R8G8      Chroma
+      VDP_CHROMA_TYPE_422        2                        1             0      w   x h    R8        Luma
+                                                                        1      w/2 x h    R8G8      Chroma
+      VDP_CHROMA_TYPE_444        2                        1             0      w   x h    R8        Luma
+                                                                        1      w   x h    R8G8      Chroma
+      VDP_CHROMA_TYPE_420_FIELD  4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w/2 x h/4  R8G8      Top-field chroma
+                                                                        3      w/2 x h/4  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_422_FIELD  4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w/2 x h/2  R8G8      Top-field chroma
+                                                                        3      w/2 x h/2  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_444_FIELD  4                        0             0      w   x h/2  R8        Top-field luma
+                                                                        1      w   x h/2  R8        Bottom-field luma
+                                                                        2      w   x h/2  R8G8      Top-field chroma
+                                                                        3      w   x h/2  R8G8      Bottom-field chroma
+      VDP_CHROMA_TYPE_420_FRAME  2                        1             0      w   x h    R8        Luma
+                                                                        1      w/2 x h/2  R8G8      Chroma
+      VDP_CHROMA_TYPE_422_FRAME  2                        1             0      w   x h    R8        Luma
+                                                                        1      w/2 x h    R8G8      Chroma
+      VDP_CHROMA_TYPE_444_FRAME  2                        1             0      w   x h    R8        Luma
+                                                                        1      w   x h    R8G8      Chroma
+
+      Table 8.7.1: Supported VdpChromaType values, and derived values
+      of <numTextureNames>,<isFrameStructure> and texture parameters for 
+      each texture.
+
+    VDPAURegisterVideoSurfaceWithPictureStructureNV's return value is a handle 
+    used by various other commands detailed in NV_vdpau_interop.
+
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None
+
+Additions to the OpenGL Shading Language
+
+    None
+
+GLX Protocol
+
+    VDPAU implementations currently only support direct-rendering.
+    Consequently, no GLX protocol is currently defined for this
+    extension.
+
+Dependencies on GL_ARB_texture_rectangle
+
+    If GL_ARB_texture_rectangle is not supported, TEXTURE_RECTANGLE may
+    not be used as target for VDPAURegisterVideoSurfaceWithPictureStructureNV.
+
+Dependencies on GL_ARB_texture_non_power_of_two
+
+    If GL_ARB_texture_non_power_of_two is not supported, only VDPAU
+    surfaces with power-of-two size may be used with target TEXTURE_2D.
+
+Errors
+
+    INVALID_OPERATION is generated by 
+    VDPAURegisterVideoSurfaceWithPictureStructureNV if the VDPAU driver
+    refuses the request for some reason.
+
+    INVALID_OPERATION is generated if any texture named by an entry
+    within the <textureNames> parameter of 
+    VDPAURegisterVideoSurfaceWithPictureStructureNV is marked as immutable.
+
+    INVALID_VALUE is generated if the VDPAU surface named by the
+    <vdpSurface> parameter of VDPAURegisterVideoSurfaceWithPictureStructureNV
+    does not have a supported format;
+    see table 8.7.1.
+
+New State
+
+    None
+
+New Implementation State
+
+    None
+
+Issues
+
+
+Revision History
+
+    1. 02 Oct 2018 - Manoj Bonda
+        Initial version
+
+

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1001,4 +1001,8 @@
 </li>
 <li value=531><a href="extensions/NV/NV_shading_rate_image.txt">GL_NV_shading_rate_image</a>
 </li>
+<li value=592><a href="extensions/ATI/WGL_ATI_render_texture_rectangle.txt">WGL_ATI_render_texture_rectangle</a>
+</li>
+<li value=593><a href="extensions/NV/NV_vdpau_interop2.txt">GL_NV_vdpau_interop2</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3841,6 +3841,12 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/NV/NV_vdpau_interop.txt',
     },
+    'GL_NV_vdpau_interop2' : {
+        'number' : 593,
+        'flags' : { 'public' },
+        'supporters' : { 'NVIDIA' },
+        'url' : 'extensions/NV/NV_vdpau_interop2.txt',
+    },
     'GL_NV_vertex_array_range' : {
         'number' : 190,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -29603,6 +29603,14 @@ typedef unsigned int GLhandleARB;
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
         </command>
         <command>
+            <proto group="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
+            <param>const void *<name>vdpSurface</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
+            <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
+            <param group="Boolean"><ptype>GLboolean</ptype> <name>isFrameStructure</name></param>
+        </command>
+        <command>
             <proto>void <name>glVDPAUSurfaceAccessNV</name></proto>
             <param group="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
             <param><ptype>GLenum</ptype> <name>access</name></param>
@@ -48041,6 +48049,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glVDPAUSurfaceAccessNV"/>
                 <command name="glVDPAUMapSurfacesNV"/>
                 <command name="glVDPAUUnmapSurfacesNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_vdpau_interop2" supported="gl">
+            <require>
+                <command name="glVDPAURegisterVideoSurfaceWithPictureStructureNV"/>
             </require>
         </extension>
         <extension name="GL_NV_vertex_array_range" supported="gl">


### PR DESCRIPTION
This change adds new extension vdpau_interop2 which
adds API's glVDPAURegisterVideoSurfaceWithPictureStructureNV.
so that applications can specify whether they want to recieve
field-based or frame-based surfaces.This is identical to the
existing VDPAURegisterVideoSurfaceNV(), but will pass additional
field-vs-frame parameter.