### PR TITLE
add QCOM_YUV_texture_gather

### DIFF
--- a/extensions/QCOM/QCOM_YUV_texture_gather.txt
+++ b/extensions/QCOM/QCOM_YUV_texture_gather.txt
@@ -1,0 +1,97 @@
+Name
+    QCOM_YUV_texture_gather
+
+Name Strings
+
+    GL_QCOM_YUV_texture_gather
+
+Contact
+
+    Jeff Leger ( jleger 'at' qti.qualcomm.com)
+
+Contributors
+
+    Jeff Leger, Qualcomm
+
+
+Status
+
+    Complete
+
+Version
+
+    Last Modified Date:         October 18, 2018
+    Revision:                   1
+
+Number
+
+    OpenGL ES Extension #307
+
+
+Dependencies
+
+    Requires OpenGL ES 3.0
+    Requires GL_EXT_YUV_target
+    Requires EXT_gpu_shader5
+
+
+Overview
+
+    Extension EXT_gpu_shader5 introduced the texture gather built-in functions.
+    Extension EXT_YUV_target adds the ability to sample from YUV textures, but
+    does not include gather functions.   This extension allows gather function
+    to be used in combination with the YUV textures exposed in EXT_YUV_target.
+
+IP Status
+
+    No known IP claims.
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    None
+
+Modifications to The OpenGL ES Shading Language Specification, Version 3.00,
+dated 29 January 2016.
+
+    Including the following line in a shader can be used to control the
+    language features described in this extension:
+
+      #extension QCOM_YUV_texture_gather : <behavior>
+
+    where <behavior> is as specified in section 3.4.
+
+    A new preprocessor #define is added to the OpenGL ES Shading Language:
+
+      #define QCOM_YUV_texture_gather       1
+
+
+    Add to the list of texture gather functions as introduced with EXT_gpu_shader5
+    and core functionality in ESSL 3.1 the following additional function:
+
+    vec4 textureGather(__samplerExternal2DY2YEXT sampler, vec2 P [, int comp] )
+
+Errors
+
+    None.
+
+New State
+
+    None.
+
+New Implementation Dependent State
+
+    None
+
+Issues
+
+    None.
+
+Revision History
+
+    Rev.    Date      Author    Changes
+    ----  ----------  --------  -----------------------------------------
+    1     2018-10-18  jleger    initial version

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -4400,6 +4400,11 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/QCOM/QCOM_shader_framebuffer_fetch_noncoherent.txt',
     },
+    'GL_QCOM_YUV_texture_gather' : {
+        'esnumber' : 307,
+        'flags' : { 'public' },
+        'url' : 'extensions/QCOM/QCOM_YUV_texture_gather.txt',
+    },
     'GL_QCOM_shader_framebuffer_fetch_rate' : {
         'esnumber' : 304,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -49495,6 +49495,8 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_WRITEONLY_RENDERING_QCOM"/>
             </require>
         </extension>
+        <extension name="GL_QCOM_YUV_texture_gather" supported="gles2">
+        </extension>
         <extension name="GL_REND_screen_coordinates" supported="gl">
             <require>
                 <enum name="GL_SCREEN_COORDINATES_REND"/>


### PR DESCRIPTION
Adds vendor extension QCOM_YUV_texture_gather as discussed in Khronos-internal [MR17](https://gitlab.khronos.org/opengl/registry/merge_requests/17)