### PR TITLE
OVR_multiview/2 clarifications

### DIFF
--- a/extensions/OVR/OVR_multiview.txt
+++ b/extensions/OVR/OVR_multiview.txt
@@ -36,8 +36,8 @@ Status
 
 Version
 
-    Last Modified Date: July 25, 2018
-    Revision: 5
+    Last Modified Date: October 19, 2018
+    Revision: 6
 
 Number
 
@@ -48,8 +48,11 @@ Dependencies
 
     OpenGL 3.0 or OpenGL ES 3.0 is required.
 
-    This extensions is written against the OpenGL ES 3.2 (November 3, 2016)
+    This extension is written against the OpenGL ES 3.2 (November 3, 2016)
     specification and the OpenGL 4.6 (Core Profile) (July 30, 2017)
+
+    This extension is written against the OpenGL ES Shading Language 3.00.04
+    specification.
 
     This extension interacts with OpenGL 3.3, ARB_timer_query, and
     EXT_disjoint_timer_query.
@@ -340,6 +343,13 @@ Modifications to The OpenGL ES Shading Language Specification, Version 3.00.04
     language features described in this extension:
 
       #extension GL_OVR_multiview : <behavior>
+
+    where <behavior> is as specified in section 3.5.
+
+    A new preprocessor #define is added to the OpenGL ES Shading Language:
+
+      #define GL_OVR_multiview 1
+
 
     In section 4.3.8.1 "Input Layout Qualifiers":
 
@@ -779,4 +789,5 @@ Revision History
                                 of OES_geometry_shader and OES_tessellation_shader to interop.
                                 Clarify what happens when transform feedback is paused.
       5     07/25/18  oetuaho   Fix off-by-one issue in baseViewIndex + numViews check.
+      6     10/19/18  dgkoch    Add standard boiler plate shader extension language.
 

--- a/extensions/OVR/OVR_multiview2.txt
+++ b/extensions/OVR/OVR_multiview2.txt
@@ -16,6 +16,7 @@ Contributors
     Jan Paul van Waveren, Oculus
     Jan-Harald Fredriksen, ARM
     Sam Holmes, Qualcomm
+    Daniel Koch, NVIDIA
 
 Status
 
@@ -23,8 +24,8 @@ Status
 
 Version
 
-    Last Modified Date:  Mar 18, 2015
-    Author Revision: 0.4
+    Last Modified Date:  October 19, 2018
+    Author Revision: 0.5
 
 Number
 
@@ -35,7 +36,10 @@ Dependencies
 
     OpenGL 3.0 or OpenGL ES 3.0 is required.
 
-    Requires extension OVR_multiview to be implemented.
+    This extension is written against the OpenGL ES Shading Language 3.00.04
+    specification.
+
+    This extension requires OVR_multiview.
 
 Overview
 
@@ -57,14 +61,43 @@ Modifications to The OpenGL ES Shading Language Specification, Version 3.00.04
 	Including the following line in a shader can be used to control the language
 	features described in this extension:
 
-      #extension GL_OVR_multiview2
+      #extension GL_OVR_multiview2 : <behavior>
+
+    where <behavior> is as specified in section 3.5.
+
+    A new preprocessor #define is added to the OpenGL ES Shading Language:
+
+      #define GL_OVR_multiview2 1
+
+    If the OVR_multiview2 extension is enabled, the OVR_multiview extension
+    is also implicitly enabled.
+
+    Modifications to Section 7.1 "Built-in Language Variables" (as modified by
+    OVR_multiview):
+
+    Delete the paragraph which states:
+
+    It is a compile- or link-time error if any output variable other
+    than gl_Position is statically dependent on gl_ViewID_OVR. If an
+    output variable other than gl_Position is dynamically dependent on
+    gl_ViewID_OVR, the values are undefined.
 
 Errors
 
+    None.
+
 Issues
+
+    (1) Does enabling GL_OVR_multiview2 automatically enable GL_OVR_multiview?
+
+    RESOLVED: Yes. This was not specified in early drafts of the extension,
+    but this is the behavior of multiple implementations.
 
 Revision History
 
       Rev.    Date    Author    Changes
       ----  --------  --------  -----------------------------------------
       0.1   03/18/15  cass      Initial draft
+      0.5   10/19/18  dgkoch    Add standard boiler plate shader extension language.
+                                Add issue 1 and clarify that this extension
+                                implicitly enables OVR_multiview.


### PR DESCRIPTION
Per internal gitlab issue
https://gitlab.khronos.org/opengl/API/issues/96

- add boiler plate shading language text about #define
- clarify that OVR_multiview2 implicitly enables OVR_multiview