### PR TITLE
Mark vdpau_interop2 to receive frame/field-based surface as complete

### DIFF
--- a/extensions/NV/NV_vdpau_interop2.txt
+++ b/extensions/NV/NV_vdpau_interop2.txt
@@ -17,7 +17,7 @@ Contact
 
 Status
 
-    XXX - Not complete yet!!!
+    Complete
 
 Version
 
@@ -203,4 +203,6 @@ Revision History
     1. 02 Oct 2018 - Manoj Bonda
         Initial version
 
+    2. 21 Nov 2018 - Manoj Bonda
+        Changed status to complete.
 


### PR DESCRIPTION
This change marks the new extension vdpau_interop2 as complete.

Extension vdpau_interop2 adds API
glVDPAURegisterVideoSurfaceWithPictureStructureNV so that applications 
can specify whether they want to receive field-based or frame-based 
surfaces