### PR TITLE
glx: Add GLX_EXT_context_priority

### DIFF
--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20190228
+#define GLX_GLXEXT_VERSION 20190411
 
 /* Generated C header for:
  * API: glx
@@ -279,6 +279,14 @@ void glXBlitContextFramebufferAMD (GLXContext dstCtx, GLint srcX0, GLint srcY0, 
 #define GLX_EXT_buffer_age 1
 #define GLX_BACK_BUFFER_AGE_EXT           0x20F4
 #endif /* GLX_EXT_buffer_age */
+
+#ifndef GLX_EXT_context_priority
+#define GLX_EXT_context_priority 1
+#define GLX_CONTEXT_PRIORITY_LEVEL_EXT    0x3100
+#define GLX_CONTEXT_PRIORITY_HIGH_EXT     0x3101
+#define GLX_CONTEXT_PRIORITY_MEDIUM_EXT   0x3102
+#define GLX_CONTEXT_PRIORITY_LOW_EXT      0x3103
+#endif /* GLX_EXT_context_priority */
 
 #ifndef GLX_EXT_create_context_es2_profile
 #define GLX_EXT_create_context_es2_profile 1

--- a/extensions/EXT/GLX_EXT_context_priority.txt
+++ b/extensions/EXT/GLX_EXT_context_priority.txt
@@ -1,0 +1,108 @@
+Name
+
+    EXT_context_priority
+
+Name Strings
+
+    GLX_EXT_context_priority
+
+Contributors
+
+    Adam Jackson, Red Hat
+
+    Cloned from EGL_IMG_context_priority, whose contributors included:
+
+    Ben Bowman, Imagination Techonologies
+    Graham Connor, Imagination Techonologies
+
+Contacts
+
+    Adam Jackson <ajax@redhat.com>
+
+Status
+
+    Complete
+
+Version
+
+    Version 2, 10 April 2019
+
+Number
+
+    595
+
+Dependencies
+
+    Requires GLX_ARB_create_context.
+
+    This extension is written against the text of the GLX 1.4 specification.
+
+Overview
+
+    This extension allows a GLXContext to be created with a priority
+    hint. It is possible that an implementation will not honour the
+    hint, especially if there are constraints on the number of high
+    priority contexts available in the system, or system policy limits
+    access to high priority contexts to appropriate system privilege
+    level. A query is provided to find the real priority level assigned
+    to the context after creation.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    New attributes accepted by the <attrib_list> argument of
+    glXCreateContextAttribsARB:
+
+        GLX_CONTEXT_PRIORITY_LEVEL_EXT          0x3100
+
+    New attribute values accepted in the <attrib_list> argument
+    of glXCreateContextAttribsARB:
+
+        GLX_CONTEXT_PRIORITY_HIGH_EXT           0x3101
+        GLX_CONTEXT_PRIORITY_MEDIUM_EXT         0x3102
+        GLX_CONTEXT_PRIORITY_LOW_EXT            0x3103
+
+Additions to the GLX_ARB_create_context specification
+
+    Add to the text of attributes supported by glXCreateContextAttribsARB:
+
+        "GLX_CONTEXT_PRIORITY_LEVEL_EXT determines the priority level of
+        the context to be created. This attribute is a hint, as an
+        implementation may not support multiple contexts at some
+        priority levels and system policy may limit access to high
+        priority contexts to appropriate system privilege level. The
+        default value for GLX_CONTEXT_PRIORITY_LEVEL_EXT is
+        GLX_CONTEXT_PRIORITY_MEDIUM_EXT."
+
+Additions to the GLX 1.4 specification
+
+    To Table 3.5 "Context attributes" add the row:
+
+    Attribute                       Type    Description
+    GLX_CONTEXT_PRIORITY_LEVEL_EXT  int     Context priority level
+
+Issues
+
+    Refer to the issues in EGL_IMG_context_priority for further background.
+
+    1) What enumerant values should we use here?
+
+    RESOLVED: Reuse the enums from EGL_IMG_context_priority. The window
+    system binding APIs have trended towards sharing enumerant space. The
+    range is not otherwise assigned for GLX, and Imagination have consented
+    to its reuse in GLX.
+
+Revision History
+
+    Version 2, 10 April 2019 (Adam Jackson)
+    - Resolve enumerant issue.
+
+    Version 1, 20 February 2019 (Adam Jackson)
+    - Clone from EGL_IMG_context_priority

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1007,4 +1007,6 @@
 </li>
 <li value=594><a href="extensions/EXT/EXT_texture_sRGB_R8.txt">GL_EXT_texture_sRGB_R8</a>
 </li>
+<li value=595><a href="extensions/EXT/GLX_EXT_context_priority.txt">GLX_EXT_context_priority</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -1659,6 +1659,11 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/EXT/EXT_conservative_depth.txt',
     },
+    'GLX_EXT_context_priority' : {
+        'number' : 595,
+        'flags' : { 'public' },
+        'url' : 'extensions/EXT/GLX_EXT_context_priority.txt',
+    },
     'GL_EXT_convolution' : {
         'number' : 12,
         'flags' : { 'public' },

--- a/xml/glx.xml
+++ b/xml/glx.xml
@@ -462,6 +462,13 @@ typedef unsigned __int64 uint64_t;
             <unused start="0x21A9" end="0x21AF"/>
     </enums>
 
+    <enums namespace="GLX" start="0x3100" end="0x3103" vendor="EXT" comment="Shared with EGL_IMG_context_priority">
+        <enum value="0x3100"        name="GLX_CONTEXT_PRIORITY_LEVEL_EXT"/>
+        <enum value="0x3101"        name="GLX_CONTEXT_PRIORITY_HIGH_EXT"/>
+        <enum value="0x3102"        name="GLX_CONTEXT_PRIORITY_MEDIUM_EXT"/>
+        <enum value="0x3103"        name="GLX_CONTEXT_PRIORITY_LOW_EXT"/>
+    </enums>
+
     <enums namespace="GLX" start="0x31B3" end="0x31B3" vendor="ARB" comment="Shared with WGL.">
         <enum value="0x31B3" name="GLX_CONTEXT_OPENGL_NO_ERROR_ARB"/>
     </enums>
@@ -1732,6 +1739,14 @@ typedef unsigned __int64 uint64_t;
         <extension name="GLX_EXT_buffer_age" supported="glx">
             <require>
                 <enum name="GLX_BACK_BUFFER_AGE_EXT"/>
+            </require>
+        </extension>
+        <extension name="GLX_EXT_context_priority" supported="glx">
+            <require>
+                <enum name="GLX_CONTEXT_PRIORITY_LEVEL_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_HIGH_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_MEDIUM_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_LOW_EXT"/>
             </require>
         </extension>
         <extension name="GLX_EXT_create_context_es_profile" supported="glx">


### PR DESCRIPTION
Copied from the corresponding EGL extension. This does not yet update
the XML for the new enumerants, pending resolution of the issues
mentioned in the extension spec.