### PR TITLE
Update issue 4 in GL_ARB_texture_filter_anisotropy

### DIFF
--- a/extensions/ARB/ARB_texture_filter_anisotropic.txt
+++ b/extensions/ARB/ARB_texture_filter_anisotropic.txt
@@ -277,7 +277,7 @@ Issues
       and cube texture filtering?
 
       RESOLUTION:  NO. It was decided by the OpenGL working group to leave
-      anisotrpoic filtering for 3D or cube textures as undefined. Anisotrpic
+      anisotropic filtering for 3D or cube textures as undefined. Anisotropic
       filtering is only well-defined for 2D and 2D array textures. For
       defined results with 3D and cube textures isotropic filtering should
       be used by setting the anisotropy level to 1.0.

--- a/extensions/ARB/ARB_texture_filter_anisotropic.txt
+++ b/extensions/ARB/ARB_texture_filter_anisotropic.txt
@@ -23,8 +23,8 @@ Status
 
 Version
 
-    Last Modified Date: June 2, 2017
-    Revision: 5
+    Last Modified Date: February 26, 2019
+    Revision: 6
 
 Number
 
@@ -274,11 +274,13 @@ Issues
       filtering performance or quality.
 
     4) Should anything particular be said about anisotropic 3D texture
-      filtering?
+      and cube texture filtering?
 
-      Not sure.  Does the implementation example shown in the spec for
-      2D anisotropic texture filtering readily extend to 3D anisotropic
-      texture filtering?
+      RESOLUTION:  NO. It was decided by the OpenGL working group to leave
+      anisotrpoic filtering for 3D or cube textures as undefined. Anisotrpic
+      filtering is only well-defined for 2D and 2D array textures. For
+      defined results with 3D and cube textures isotropic filtering should
+      be used by setting the anisotropy level to 1.0.
 
     5) Should the maximum degree of anisotropy be a sampler parameter?
 
@@ -289,6 +291,7 @@ Revision History
 
     Rev.    Date      Author     Changes
     ----  ---------- ---------  -----------------------------------------------
+    6     2019-02-26 pdaniell   Update issue 4 question and resolution.
     5     2017-06-02 Jon Leech  Include anisotropy state in sampler objects
                                 (opengl/API/issues/15).
     4     2017-05-29 dgkoch     Minor typography/gramatical fixes from OpenGL 4.6.


### PR DESCRIPTION
This minor update resolves issue 4 in GL_ARB_texture_filter_anisotropy with what the OpenGL working group agreed in https://gitlab.khronos.org/opengl/API/issues/47.
