### PR TITLE
Adds ES interactions to NV_shading_rate_image

### DIFF
--- a/extensions/NV/NV_shading_rate_image.txt
+++ b/extensions/NV/NV_shading_rate_image.txt
@@ -16,6 +16,7 @@ Contributors
     Mark Kilgard, NVIDIA
     Jeff Bolz, NVIDIA
     Mathias Schott, NVIDIA
+    Pyarelal Knowles, NVIDIA
 
 Status
 
@@ -23,23 +24,24 @@ Status
 
 Version
 
-    Last Modified:      September 15, 2018
-    Revision:           1
+    Last Modified:      March 15, 2019
+    Revision:           2
 
 Number
 
     OpenGL Extension #531
+    OpenGL ES Extension #315
 
 Dependencies
 
     This extension is written against the OpenGL 4.5 Specification
     (Compatibility Profile), dated October 24, 2016.
 
-    OpenGL 4.5 is required.
+    OpenGL 4.5 or OpenGL ES 3.2 is required.
 
     This extension requires support for the OpenGL Shading Language (GLSL)
-    extension "NV_fragment_shader_barycentric", which can be found at the
-    Khronos Group Github site here:
+    extension "NV_shading_rate_image", which can be found at the Khronos Group
+    Github site here:
 
         https://github.com/KhronosGroup/GLSL
 
@@ -55,6 +57,9 @@ Dependencies
     This extension interacts with EXT_raster_multisample.
 
     NV_framebuffer_mixed_samples is required.
+
+    If implemented in OpenGL ES, at least one of NV_viewport_array or
+    OES_viewport_array is required.
 
 Overview
 
@@ -786,6 +791,23 @@ Dependencies on EXT_raster_multisample
     implementations to reduce the number of fragment shader invocations
     per pixel if RASTER_MULTISAMPLE_EXT is enabled.
 
+Interactions with NV_viewport_array or OES_viewport_array
+
+    If NV_viewport_array is supported, references to MAX_VIEWPORTS and
+    GetFloati_v apply to MAX_VIEWPORTS_NV and GetFloati_vNV respecively.
+
+    If OES_viewport_array is supported, references to MAX_VIEWPORTS and
+    GetFloati_v apply to MAX_VIEWPORTS_OES and GetFloati_vOES respectively.
+
+Interactions with OpenGL ES 3.2
+
+    If implemented in OpenGL ES, remove all references to GetDoublev,
+    GetDoublei_v, EnableIndexedEXT, DisableIndexedEXT, IsEnabledIndexedEXT,
+    GetBooleanIndexedvEXT, GetIntegerIndexedvEXT, GetFloatIndexedvEXT and
+    GetDoubleIndexedv.
+
+    If implemented in OpenGL ES, remove all references to the MULTISAMPLE enable
+    state.
 
 Additions to the AGL/GLX/WGL Specifications
 
@@ -1002,6 +1024,9 @@ Issues
     Also, please refer to issues in the GLSL extension specification.
 
 Revision History
+
+    Revision 2 (pknowles)
+    - ES interactions.
 
     Revision 1 (pbrown)
     - Internal revisions.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -653,4 +653,6 @@
 </li>
 <li value=314><a href="extensions/NV/NV_representative_fragment_test.txt">GL_NV_representative_fragment_test</a>
 </li>
+<li value=315><a href="extensions/NV/NV_shading_rate_image.txt">GL_NV_shading_rate_image</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3700,6 +3700,7 @@ registry = {
     },
     'GL_NV_shading_rate_image' : {
         'number' : 531,
+        'esnumber' : 315,
         'flags' : { 'public' },
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/NV/NV_shading_rate_image.txt',

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -47743,7 +47743,7 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_NV_shader_thread_shuffle" supported="gl|glcore"/>
-        <extension name="GL_NV_shading_rate_image" supported="gl|glcore">
+        <extension name="GL_NV_shading_rate_image" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_SHADING_RATE_IMAGE_NV"/>
                 <enum name="GL_SHADING_RATE_NO_INVOCATIONS_NV"/>


### PR DESCRIPTION
Allows implementing with ES. If so, removes references to MULTISAMPLE
and double and adds MAX_VIEWPORTS and GetFloati_v alternatives.