### PR TITLE
Revert removal of aliasing between RenderbufferStorageMultisample{,EXT} in #258

### DIFF
--- a/extensions/EXT/EXT_multisampled_render_to_texture.txt
+++ b/extensions/EXT/EXT_multisampled_render_to_texture.txt
@@ -21,8 +21,8 @@ Status
 
 Version
 
-    Last Modified Date: March 15, 2019
-    Revision: 8
+    Last Modified Date: June 28, 2016
+    Revision: 7
 
 Number
 
@@ -280,11 +280,6 @@ Dependencies on GL and ES profiles, versions, and other extensions
            "The maximum number of samples supported can be determined by calling
            GetInternalformativ with a pname of SAMPLES."
 
-       RenderbufferStorageMultisampleEXT is not an alias of the OpenGL ES 3.0
-       core function RenderbufferStorageMultisample as only the former (described
-       by this extension) allows resolving multisample information in an implicit
-       way.
-
 Errors
 
     The error OUT_OF_MEMORY is generated when 
@@ -534,9 +529,6 @@ Issues
 
 
 Revision History
-
-    Revision 9, 2019/03/15
-     - Clarified relation to OpenGL ES 3.0 RenderbufferStorageMultisample.
 
     Revision 8, 2018/04/11
      - Clarified wording around implicit resolves, and added Issue 7.

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -25485,6 +25485,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <glx type="render" opcode="4331"/>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleANGLE</name></proto>
@@ -25527,6 +25528,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <alias name="glRenderbufferStorageMultisample"/>
             <glx type="render" opcode="4331"/>
         </command>
         <command>


### PR DESCRIPTION
@pdaniell-nv review & approve when ready. Perhaps the extension should say something about the confusing nature of the aliasing in practice?

N.b. this has no impact on the headers.