### PR TITLE
Extend GL_MESA_framebuffer_flip_y to GL 4.3+

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -4744,6 +4744,11 @@ GLAPI void APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint queryNameLen
 #endif
 #endif /* GL_INTEL_performance_query */
 
+#ifndef GL_MESA_framebuffer_flip_y
+#define GL_MESA_framebuffer_flip_y 1
+#define GL_FRAMEBUFFER_FLIP_Y_MESA        0x8BBB
+#endif /* GL_MESA_framebuffer_flip_y */
+
 #ifndef GL_NV_bindless_multi_draw_indirect
 #define GL_NV_bindless_multi_draw_indirect 1
 typedef void (APIENTRYP PFNGLMULTIDRAWARRAYSINDIRECTBINDLESSNVPROC) (GLenum mode, const void *indirect, GLsizei drawCount, GLsizei stride, GLint vertexBufferCount);

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20190524
+#define GL_GLEXT_VERSION 20190605
 
 #include <KHR/khrplatform.h>
 
@@ -9258,6 +9258,11 @@ GLAPI void APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint queryNameLen
 #define GL_TEXTURE_1D_STACK_BINDING_MESAX 0x875D
 #define GL_TEXTURE_2D_STACK_BINDING_MESAX 0x875E
 #endif /* GL_MESAX_texture_stack */
+
+#ifndef GL_MESA_framebuffer_flip_y
+#define GL_MESA_framebuffer_flip_y 1
+#define GL_FRAMEBUFFER_FLIP_Y_MESA        0x8BBB
+#endif /* GL_MESA_framebuffer_flip_y */
 
 #ifndef GL_MESA_pack_invert
 #define GL_MESA_pack_invert 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20190524
+#define GLX_GLXEXT_VERSION 20190605
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20190524
+#define WGL_WGLEXT_VERSION 20190605
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190524 */
+/* Generated on date 20190605 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/MESA/MESA_framebuffer_flip_y.txt
+++ b/extensions/MESA/MESA_framebuffer_flip_y.txt
@@ -15,6 +15,7 @@ Contributors
     Fritz Koenig, Google
     Kristian Høgsberg, Google
     Chad Versace, Google
+    Heinrich Fink, DAQRI
 
 Status
 
@@ -22,15 +23,16 @@ Status
 
 Version
 
-    Version 1, June 7, 2018
+    Version 2, June 4, 2019
 
 Number
 
+    OpenGL Extension #540
     OpenGL ES Extension #302
 
 Dependencies
 
-    OpenGL ES 3.1 is required, for FramebufferParameteri.
+    OpenGL ES 3.1 or OpenGL 4.3 is required, for FramebufferParameteri.
 
 Overview
 
@@ -78,6 +80,9 @@ Errors
 
 
 Revision History
+
+    Version 2, June, 2019
+        Enable extension for OpenGL 4.3 and beyond
 
     Version 1, June, 2018
         Initial draft (Fritz Koenig)

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1017,4 +1017,6 @@
 </li>
 <li value=539><a href="extensions/EXT/EXT_texture_shadow_lod.txt">GL_EXT_texture_shadow_lod</a>
 </li>
+<li value=540><a href="extensions/MESA/MESA_framebuffer_flip_y.txt">GL_MESA_framebuffer_flip_y</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2968,6 +2968,7 @@ registry = {
         'url' : 'extensions/MESA/GLX_MESA_copy_sub_buffer.txt',
     },
     'GL_MESA_framebuffer_flip_y' : {
+        'number' : 540,
         'esnumber' : 302,
         'flags' : { 'public' },
         'supporters' : { 'MESA' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -46618,7 +46618,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
             </require>
         </extension>
-        <extension name="GL_MESA_framebuffer_flip_y" supported="gles2">
+        <extension name="GL_MESA_framebuffer_flip_y" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_FRAMEBUFFER_FLIP_Y_MESA"/>
             </require>


### PR DESCRIPTION
This commit extends `GL_MESA_framebuffer_flip` to also work with GL 4.3, in
addition to GLES 3.1. We add a GL extension number, modify the XML
registry and rebuild generated sources.

GL 4.3 is needed for `FrameBufferParameteri` to be available.

I created a related merge request in Mesa [here](https://gitlab.freedesktop.org/mesa/mesa/merge_requests/1002). The Mesa MR will be updated after this pull request has been approved. Testing has been done as described in the Mesa MR.

The use case here is to use framebuffer objects to render into externally managed swap-chain images, which are directly scanned out by the display subsystem. Since framebuffer objects by default have their origin in the lower-left corner, but scan-out happens from top to bottom, content would appear upside-down. This extension helps to work around this problem, by providing the driver with a hint to flip the coordinate system for operations associated with the FBO. The existing extension already allows to do that via GLES. In our software, however, we need this functionality for GL core, for which I created this PR.