### PR TITLE
Add GL_MESA_EGL_sync extension

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -4026,6 +4026,10 @@ GLAPI void APIENTRY glEGLImageTargetTextureStorageEXT (GLuint texture, GLeglImag
 #endif
 #endif /* GL_EXT_EGL_image_storage */
 
+#ifndef GL_EXT_EGL_sync
+#define GL_EXT_EGL_sync 1
+#endif /* GL_EXT_EGL_sync */
+
 #ifndef GL_EXT_debug_label
 #define GL_EXT_debug_label 1
 #define GL_PROGRAM_PIPELINE_OBJECT_EXT    0x8A4F

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20190805
+#define GL_GLEXT_VERSION 20190911
 
 #include <KHR/khrplatform.h>
 
@@ -6480,6 +6480,10 @@ GLAPI void APIENTRY glEGLImageTargetTexStorageEXT (GLenum target, GLeglImageOES 
 GLAPI void APIENTRY glEGLImageTargetTextureStorageEXT (GLuint texture, GLeglImageOES image, const GLint* attrib_list);
 #endif
 #endif /* GL_EXT_EGL_image_storage */
+
+#ifndef GL_EXT_EGL_sync
+#define GL_EXT_EGL_sync 1
+#endif /* GL_EXT_EGL_sync */
 
 #ifndef GL_EXT_abgr
 #define GL_EXT_abgr 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20190822
+#define GLX_GLXEXT_VERSION 20190911
 
 /* Generated C header for:
  * API: glx

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20190805 */
+/* Generated on date 20190911 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190805 */
+/* Generated on date 20190911 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190805 */
+/* Generated on date 20190911 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190805 */
+/* Generated on date 20190911 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190805 */
+/* Generated on date 20190911 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/EXT/EXT_EGL_sync.txt
+++ b/extensions/EXT/EXT_EGL_sync.txt
@@ -1,0 +1,85 @@
+Name
+
+    EXT_EGL_sync
+
+Name Strings
+
+    GL_EXT_EGL_sync
+
+Contact
+
+    Heinrich Fink, DAQRI (heinrich.fink 'at' daqri.com)
+
+Contributors
+
+    Heinrich Fink, DAQRI
+    Daniel Stone, Collabora
+    Marek Olšák, AMD
+
+Status
+
+    Proposal
+
+Version
+
+    Version 4, Sept 11, 2019
+
+Number
+
+    OpenGL Extension #546
+
+Dependencies
+
+    EGL_KHR_fence_sync is required.
+
+    This extension is written against the EGL 1.2 Specification, as modified by
+    the EGL_KHR_fence_sync extension.
+
+Overview
+
+    This extension extends EGL_KHR_fence_sync with client API support for
+    OpenGL (compatibility or core profiles) as an EXT extension.
+
+    The "GL_EXT_EGL_sync" string indicates that a fence sync object can be
+    created in association with a fence command placed in the command stream
+    of a bound OpenGL context.
+
+IP Status
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    None
+
+Additions to Chapter 3 of the EGL 1.2 Specification (EGL Functions and Errors)
+
+    Modify Section 3.8.1 Sync Objects, page 43
+
+    After "Each client API which supports..." add a new paragraph:
+
+    If the GL_EXT_EGL_sync extension is supported by OpenGL (compatibility or
+    core profile), a fence sync object may be created when the currently bound API
+    is OpenGL.
+
+Errors
+
+    None
+
+Revision History
+
+    Version 4, Sept 11th, 2019
+        Change scope from MESA to EXT on request by James Jones (NVIDIA)
+
+    Version 3, Sept 6th, 2019
+        Update extension no
+
+    Version 2, July 29th, 2019
+        Update extension no in draft
+
+    Version 1, June 5th, 2019
+        Initial draft (Heinrich Fink)

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1029,4 +1029,6 @@
 </li>
 <li value=545><a href="extensions/NV/GLX_NV_multigpu_context.txt">GLX_NV_multigpu_context</a>
 </li>
+<li value=546><a href="extensions/EXT/EXT_EGL_sync.txt">GL_EXT_EGL_sync</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -1801,6 +1801,12 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/EXT/EXT_EGL_image_storage.txt',
     },
+    'GL_EXT_EGL_sync' : {
+        'number' : 546,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/EXT/EXT_EGL_sync.txt',
+    },
     'GL_EXT_memory_object' : {
         'number' : 503,
         'esnumber' : 280,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -44158,6 +44158,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glEGLImageTargetTextureStorageEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_EGL_sync" supported="gl|glcore"/>
         <extension name="GL_EXT_YUV_target" supported="gles2">
             <require>
                 <enum name="GL_SAMPLER_EXTERNAL_2D_Y2Y_EXT"/>


### PR DESCRIPTION
This PR adds the `GL_MESA_EGL_sync` OpenGL extension to extend
`EGL_KHR_fence_sync` with OpenGL client API support.

While arguably OpenGL already has `GL_ARB_sync`, there are platform
extensions that are layered on top `EGL_KHR_fence_sync` rather than
`GL_ARB_sync`. Without OpenGL support of `EGL_KHR_fence_sync`, these
extension can't be used with an OpenGL command stream. One notable
example is the `EGL_ANDROID_native_fence_sync` extension, which enables
`linux_sync_file` objects to be used as the backend of EGL sync objects.
Linux sync file objects can be used to synchronize buffer access between
processes dispatching OpenGL drawing commands, or to synchronize with
the Linux KMS display subsystem (aka 'explicit fencing').

There is a corresponding Mesa merge-request [here](https://gitlab.freedesktop.org/mesa/mesa/merge_requests/624). An implemented use-case is demonstrated by the public [kms-quads](https://gitlab.freedesktop.org/daniels/kms-quads) sample code. Note that the Mesa MR originally attempted to directly expose `OES_EGL_sync` to GL core. As pointed out by feedback in the Mesa MR, this is not a viable path, since exposing another OpenGL ES extension in GL compat/core is breaking the CTS (`OES_EGL_image` being the only exception). In this pull request, we instead propose to add a simple Mesa extension that explicitly adds EGL fence sync support to OpenGL in a similar way as `OES_EGL_sync` does for OpenGL ES and `VG_KHR_EGL_sync` does for OpenVG.

Once the approach of this pull request is approved to be viable, I'll make sure the Mesa MR and the kms-quads sample code gets adapted accordingly.