### PR TITLE
Add NVX_gpu_multicast2 (revised)

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -3900,6 +3900,22 @@ GLAPI void APIENTRY glMaxShaderCompilerThreadsKHR (GLuint count);
 #define GL_CONTEXT_ROBUST_ACCESS          0x90F3
 #endif /* GL_KHR_robustness */
 
+#ifndef GL_KHR_shader_subgroup
+#define GL_KHR_shader_subgroup 1
+#define GL_SUBGROUP_SIZE_KHR              0x9532
+#define GL_SUBGROUP_SUPPORTED_STAGES_KHR  0x9533
+#define GL_SUBGROUP_SUPPORTED_FEATURES_KHR 0x9534
+#define GL_SUBGROUP_QUAD_ALL_STAGES_KHR   0x9535
+#define GL_SUBGROUP_FEATURE_BASIC_BIT_KHR 0x00000001
+#define GL_SUBGROUP_FEATURE_VOTE_BIT_KHR  0x00000002
+#define GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR 0x00000004
+#define GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR 0x00000008
+#define GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR 0x00000010
+#define GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR 0x00000020
+#define GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR 0x00000040
+#define GL_SUBGROUP_FEATURE_QUAD_BIT_KHR  0x00000080
+#endif /* GL_KHR_shader_subgroup */
+
 #ifndef GL_KHR_texture_compression_astc_hdr
 #define GL_KHR_texture_compression_astc_hdr 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR   0x93B0
@@ -5661,6 +5677,11 @@ GLAPI void APIENTRY glProgramUniformui64vNV (GLuint program, GLint location, GLs
 #define GL_NV_shader_buffer_store 1
 #define GL_SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV 0x00000010
 #endif /* GL_NV_shader_buffer_store */
+
+#ifndef GL_NV_shader_subgroup_partitioned
+#define GL_NV_shader_subgroup_partitioned 1
+#define GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV 0x00000100
+#endif /* GL_NV_shader_subgroup_partitioned */
 
 #ifndef GL_NV_shader_texture_footprint
 #define GL_NV_shader_texture_footprint 1

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20190605
+#define GL_GLEXT_VERSION 20190728
 
 #include <KHR/khrplatform.h>
 
@@ -9377,6 +9377,25 @@ GLAPI void APIENTRY glEndConditionalRenderNVX (void);
 #define GL_GPU_MEMORY_INFO_EVICTED_MEMORY_NVX 0x904B
 #endif /* GL_NVX_gpu_memory_info */
 
+#ifndef GL_NVX_gpu_multicast2
+#define GL_NVX_gpu_multicast2 1
+#define GL_UPLOAD_GPU_MASK_NVX            0x954A
+typedef void (APIENTRYP PFNGLUPLOADGPUMASKNVXPROC) (GLbitfield mask);
+typedef void (APIENTRYP PFNGLMULTICASTVIEWPORTARRAYVNVXPROC) (GLuint gpu, GLuint first, GLsizei count, const GLfloat *v);
+typedef void (APIENTRYP PFNGLMULTICASTVIEWPORTPOSITIONWSCALENVXPROC) (GLuint gpu, GLuint index, GLfloat xcoeff, GLfloat ycoeff);
+typedef void (APIENTRYP PFNGLMULTICASTSCISSORARRAYVNVXPROC) (GLuint gpu, GLuint first, GLsizei count, const GLint *v);
+typedef GLuint (APIENTRYP PFNGLASYNCCOPYBUFFERSUBDATANVXPROC) (GLsizei waitSemaphoreCount, const GLuint *waitSemaphoreArray, const GLuint64 *fenceValueArray, GLuint readGpu, GLbitfield writeGpuMask, GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size, GLsizei signalSemaphoreCount, const GLuint *signalSemaphoreArray, const GLuint64 *signalValueArray);
+typedef GLuint (APIENTRYP PFNGLASYNCCOPYIMAGESUBDATANVXPROC) (GLsizei waitSemaphoreCount, const GLuint *waitSemaphoreArray, const GLuint64 *waitValueArray, GLuint srcGpu, GLbitfield dstGpuMask, GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth, GLsizei signalSemaphoreCount, const GLuint *signalSemaphoreArray, const GLuint64 *signalValueArray);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glUploadGpuMaskNVX (GLbitfield mask);
+GLAPI void APIENTRY glMulticastViewportArrayvNVX (GLuint gpu, GLuint first, GLsizei count, const GLfloat *v);
+GLAPI void APIENTRY glMulticastViewportPositionWScaleNVX (GLuint gpu, GLuint index, GLfloat xcoeff, GLfloat ycoeff);
+GLAPI void APIENTRY glMulticastScissorArrayvNVX (GLuint gpu, GLuint first, GLsizei count, const GLint *v);
+GLAPI GLuint APIENTRY glAsyncCopyBufferSubDataNVX (GLsizei waitSemaphoreCount, const GLuint *waitSemaphoreArray, const GLuint64 *fenceValueArray, GLuint readGpu, GLbitfield writeGpuMask, GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size, GLsizei signalSemaphoreCount, const GLuint *signalSemaphoreArray, const GLuint64 *signalValueArray);
+GLAPI GLuint APIENTRY glAsyncCopyImageSubDataNVX (GLsizei waitSemaphoreCount, const GLuint *waitSemaphoreArray, const GLuint64 *waitValueArray, GLuint srcGpu, GLbitfield dstGpuMask, GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth, GLsizei signalSemaphoreCount, const GLuint *signalSemaphoreArray, const GLuint64 *signalValueArray);
+#endif
+#endif /* GL_NVX_gpu_multicast2 */
+
 #ifndef GL_NVX_linked_gpu_multicast
 #define GL_NVX_linked_gpu_multicast 1
 #define GL_LGPU_SEPARATE_STORAGE_BIT_NVX  0x0800
@@ -9390,6 +9409,20 @@ GLAPI void APIENTRY glLGPUCopyImageSubDataNVX (GLuint sourceGpu, GLbitfield dest
 GLAPI void APIENTRY glLGPUInterlockNVX (void);
 #endif
 #endif /* GL_NVX_linked_gpu_multicast */
+
+#ifndef GL_NVX_progress_fence
+#define GL_NVX_progress_fence 1
+typedef GLuint (APIENTRYP PFNGLCREATEPROGRESSFENCENVXPROC) (void);
+typedef void (APIENTRYP PFNGLSIGNALSEMAPHOREUI64NVXPROC) (GLuint signalGpu, GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+typedef void (APIENTRYP PFNGLWAITSEMAPHOREUI64NVXPROC) (GLuint waitGpu, GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+typedef void (APIENTRYP PFNGLCLIENTWAITSEMAPHOREUI64NVXPROC) (GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI GLuint APIENTRY glCreateProgressFenceNVX (void);
+GLAPI void APIENTRY glSignalSemaphoreui64NVX (GLuint signalGpu, GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+GLAPI void APIENTRY glWaitSemaphoreui64NVX (GLuint waitGpu, GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+GLAPI void APIENTRY glClientWaitSemaphoreui64NVX (GLsizei fenceObjectCount, const GLuint *semaphoreArray, const GLuint64 *fenceValueArray);
+#endif
+#endif /* GL_NVX_progress_fence */
 
 #ifndef GL_NV_alpha_to_coverage_dither_control
 #define GL_NV_alpha_to_coverage_dither_control 1

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -4992,6 +4992,22 @@ GLAPI void APIENTRY glMaxShaderCompilerThreadsKHR (GLuint count);
 #define GL_CONTEXT_ROBUST_ACCESS          0x90F3
 #endif /* GL_KHR_robustness */
 
+#ifndef GL_KHR_shader_subgroup
+#define GL_KHR_shader_subgroup 1
+#define GL_SUBGROUP_SIZE_KHR              0x9532
+#define GL_SUBGROUP_SUPPORTED_STAGES_KHR  0x9533
+#define GL_SUBGROUP_SUPPORTED_FEATURES_KHR 0x9534
+#define GL_SUBGROUP_QUAD_ALL_STAGES_KHR   0x9535
+#define GL_SUBGROUP_FEATURE_BASIC_BIT_KHR 0x00000001
+#define GL_SUBGROUP_FEATURE_VOTE_BIT_KHR  0x00000002
+#define GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR 0x00000004
+#define GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR 0x00000008
+#define GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR 0x00000010
+#define GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR 0x00000020
+#define GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR 0x00000040
+#define GL_SUBGROUP_FEATURE_QUAD_BIT_KHR  0x00000080
+#endif /* GL_KHR_shader_subgroup */
+
 #ifndef GL_KHR_texture_compression_astc_hdr
 #define GL_KHR_texture_compression_astc_hdr 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR   0x93B0
@@ -10970,6 +10986,11 @@ GLAPI void APIENTRY glProgramUniformui64vNV (GLuint program, GLint location, GLs
 #ifndef GL_NV_shader_storage_buffer_object
 #define GL_NV_shader_storage_buffer_object 1
 #endif /* GL_NV_shader_storage_buffer_object */
+
+#ifndef GL_NV_shader_subgroup_partitioned
+#define GL_NV_shader_subgroup_partitioned 1
+#define GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV 0x00000100
+#endif /* GL_NV_shader_subgroup_partitioned */
 
 #ifndef GL_NV_shader_texture_footprint
 #define GL_NV_shader_texture_footprint 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20190605
+#define GLX_GLXEXT_VERSION 20190728
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: wgl
@@ -805,6 +805,15 @@ BOOL WINAPI wglEnumGpusFromAffinityDCNV (HDC hAffinityDC, UINT iGpuIndex, HGPUNV
 BOOL WINAPI wglDeleteDCNV (HDC hdc);
 #endif
 #endif /* WGL_NV_gpu_affinity */
+
+#ifndef WGL_NV_multigpu_context
+#define WGL_NV_multigpu_context 1
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_NV    0x20AA
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV 0x20AB
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV 0x20AC
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV 0x20AD
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV 0x20AE
+#endif /* WGL_NV_multigpu_context */
 
 #ifndef WGL_NV_multisample_coverage
 #define WGL_NV_multisample_coverage 1

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20190605
+#define WGL_WGLEXT_VERSION 20190728
 
 /* Generated C header for:
  * API: wgl
@@ -714,6 +714,15 @@ BOOL WINAPI wglEnumGpusFromAffinityDCNV (HDC hAffinityDC, UINT iGpuIndex, HGPUNV
 BOOL WINAPI wglDeleteDCNV (HDC hdc);
 #endif
 #endif /* WGL_NV_gpu_affinity */
+
+#ifndef WGL_NV_multigpu_context
+#define WGL_NV_multigpu_context 1
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_NV    0x20AA
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV 0x20AB
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV 0x20AC
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV 0x20AD
+#define WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV 0x20AE
+#endif /* WGL_NV_multigpu_context */
 
 #ifndef WGL_NV_multisample_coverage
 #define WGL_NV_multisample_coverage 1

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -197,6 +197,22 @@ GL_APICALL void GL_APIENTRY glGetnUniformuivKHR (GLuint program, GLint location,
 #endif
 #endif /* GL_KHR_robustness */
 
+#ifndef GL_KHR_shader_subgroup
+#define GL_KHR_shader_subgroup 1
+#define GL_SUBGROUP_SIZE_KHR              0x9532
+#define GL_SUBGROUP_SUPPORTED_STAGES_KHR  0x9533
+#define GL_SUBGROUP_SUPPORTED_FEATURES_KHR 0x9534
+#define GL_SUBGROUP_QUAD_ALL_STAGES_KHR   0x9535
+#define GL_SUBGROUP_FEATURE_BASIC_BIT_KHR 0x00000001
+#define GL_SUBGROUP_FEATURE_VOTE_BIT_KHR  0x00000002
+#define GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR 0x00000004
+#define GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR 0x00000008
+#define GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR 0x00000010
+#define GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR 0x00000020
+#define GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR 0x00000040
+#define GL_SUBGROUP_FEATURE_QUAD_BIT_KHR  0x00000080
+#endif /* GL_KHR_shader_subgroup */
+
 #ifndef GL_KHR_texture_compression_astc_hdr
 #define GL_KHR_texture_compression_astc_hdr 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR   0x93B0
@@ -3491,6 +3507,11 @@ GL_APICALL void GL_APIENTRY glScissorExclusiveArrayvNV (GLuint first, GLsizei co
 #ifndef GL_NV_shader_noperspective_interpolation
 #define GL_NV_shader_noperspective_interpolation 1
 #endif /* GL_NV_shader_noperspective_interpolation */
+
+#ifndef GL_NV_shader_subgroup_partitioned
+#define GL_NV_shader_subgroup_partitioned 1
+#define GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV 0x00000100
+#endif /* GL_NV_shader_subgroup_partitioned */
 
 #ifndef GL_NV_shader_texture_footprint
 #define GL_NV_shader_texture_footprint 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190605 */
+/* Generated on date 20190728 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/KHR/KHR_shader_subgroup.txt
+++ b/extensions/KHR/KHR_shader_subgroup.txt
@@ -1,0 +1,635 @@
+Name
+
+    KHR_shader_subgroup
+
+Name Strings
+
+    GL_KHR_shader_subgroup
+
+Contact
+
+    Daniel Koch, NVIDIA Corportation
+
+Contributors
+
+    Neil Henning, Codeplay
+    Contributors to GL_KHR_shader_subgroup (GLSL)
+    James Glanville, Imagination
+    Jan-Harald Fredriksen, Arm
+    Graeme Leese, Broadcom
+    Jesse Hall, Google
+
+Status
+
+    Complete
+    Approved by the OpenGL Working Group on 2019-05-29
+    Approved by the OpenGL ES Working Group on 2019-05-29
+    Approved by the Khronos Promoters on 2019-07-26
+
+Version
+
+    Last Modified:  2019-07-26
+    Revision:       8
+
+Number
+
+    ARB Extension #196
+    OpenGL ES Extension #321
+
+Dependencies
+
+    This extension is written against the OpenGL 4.6 Specification
+    (Core Profile), dated July 30, 2017.
+
+    This extension requires OpenGL 4.3 or OpenGL ES 3.1.
+
+    This extension requires the KHR_shader_subgroup GLSL extension.
+
+    This extension interacts with ARB_gl_spirv and OpenGL 4.6.
+
+    This extension interacts with ARB_spirv_extensions and OpenGL 4.6.
+
+    This extension interacts with OpenGL ES 3.x.
+
+    This extension interacts with ARB_shader_draw_parameters and
+    SPV_KHR_shader_draw_parameters.
+
+    This extension interacts with SPV_KHR_storage_buffer_storage_class.
+
+    This extension requires SPIR-V 1.3 when SPIR-V is supported in OpenGL.
+
+Overview
+
+    This extension enables support for the KHR_shader_subgroup shading
+    language extension in OpenGL and OpenGL ES.
+
+    The extension adds API queries to be able to query
+
+      - the size of subgroups in this implementation (SUBGROUP_SIZE_KHR)
+      - which shader stages support subgroup operations
+        (SUBGROUP_SUPPORTED_STAGES_KHR)
+      - which subgroup features are supported (SUBGROUP_SUPPORTED_FEATURES_KHR)
+      - whether quad subgroup operations are supported in all
+        stages supporting subgroup operations (SUBGROUP_QUAD_ALL_STAGES_KHR)
+
+    In OpenGL implementations supporting SPIR-V, this extension enables the
+    minimal subset of SPIR-V 1.3 which is required to support the subgroup
+    features that are supported by the implementation.
+
+    In OpenGL ES implementations, this extension does NOT add support for
+    SPIR-V or for any of the built-in shading language functions (8.18)
+    that have genDType (double) prototypes.
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Accepted as the <pname> argument for GetIntegerv and
+    GetInteger64v:
+
+        SUBGROUP_SIZE_KHR                           0x9532
+        SUBGROUP_SUPPORTED_STAGES_KHR               0x9533
+        SUBGROUP_SUPPORTED_FEATURES_KHR             0x9534
+
+    Accepted as the <pname> argument for GetBooleanv:
+
+        SUBGROUP_QUAD_ALL_STAGES_KHR                0x9535
+
+    Returned as a bitfield in the <data> argument when GetIntegerv
+    is queried with a <pname> of SUBGROUP_SUPPORTED_STAGES_KHR
+
+        (existing tokens)
+        VERTEX_SHADER_BIT
+        TESS_CONTROL_SHADER_BIT
+        TESS_EVALUATION_SHADER_BIT
+        GEOMETRY_SHADER_BIT
+        FRAGMENT_SHADER_BIT
+        COMPUTE_SHADER_BIT
+
+    Returned as bitfield in the <data> argument when GetIntegerv
+    is queried with a <pname> of SUBGROUP_SUPPORTED_FEATURES_KHR:
+
+        SUBGROUP_FEATURE_BASIC_BIT_KHR              0x00000001
+        SUBGROUP_FEATURE_VOTE_BIT_KHR               0x00000002
+        SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR         0x00000004
+        SUBGROUP_FEATURE_BALLOT_BIT_KHR             0x00000008
+        SUBGROUP_FEATURE_SHUFFLE_BIT_KHR            0x00000010
+        SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR   0x00000020
+        SUBGROUP_FEATURE_CLUSTERED_BIT_KHR          0x00000040
+        SUBGROUP_FEATURE_QUAD_BIT_KHR               0x00000080
+
+
+Modifications to the OpenGL 4.6 Specification (Core Profile)
+
+Add a new Chapter SG, "Subgroups"
+
+    A subgroup is a set of invocations that can synchronize and share data
+    with each other efficiently. An invocation group is partitioned into
+    one or more subgroups.
+
+    Subgroup operations are divided into various categories as described
+    by SUBGROUP_SUPPORTED_FEATURES_KHR.
+
+    SG.1 Subgroup Operations
+
+    Subgroup operations are divided into a number of categories as
+    described in this section.
+
+    SG.1.1 Basic Subgroup Operations
+
+    The basic subgroup operations allow two classes of functionality within
+    shaders - elect and barrier. Invocations within a subgroup can choose a
+    single invocation to perform some task for the subgroup as a whole using
+    elect. Invocations within a subgroup can perform a subgroup barrier to
+    ensure the ordering of execution or memory accesses within a subgroup.
+    Barriers can be performed on buffer memory accesses, shared memory
+    accesses, and image memory accesses to ensure that any results written are
+    visible by other invocations within the subgroup. A _subgroupBarrier_ can
+    also be used to perform a full execution control barrier. A full execution
+    control barrier will ensure that each active invocation within the
+    subgroup reaches a point of execution before any are allowed to continue.
+
+    SG.1.2 Vote Subgroup Operations
+
+    The vote subgroup operations allow invocations within a subgroup to
+    compare values across a subgroup. The types of votes enabled are:
+
+    * Do all active subgroup invocations agree that an expression is true?
+    * Do any active subgroup invocations evaluate an expression to true?
+    * Do all active subgroup invocations have the same value of an expression?
+
+    Note:
+    These operations are useful in combination with control flow in that
+    they allow for developers to check whether conditions match across the
+    subgroup and choose potentially faster code-paths in these cases.
+
+    SG.1.3 Arithmetic Subgroup Operations
+
+    The arithmetic subgroup operations allow invocations to perform scan
+    and reduction operations across a subgroup. For reduction operations,
+    each invocation in a subgroup will obtain the same result of these
+    arithmetic operations applied across the subgroup. For scan operations,
+    each invocation in the subgroup will perform an inclusive or exclusive
+    scan, cumulatively applying the operation across the invocations in a
+    subgroup in an implementation-defined order. The operations supported
+    are add, mul, min, max, and, or, xor.
+
+    SG.1.4 Ballot Subgroup Operations
+
+    The ballot subgroup operations allow invocations to perform more
+    complex votes across the subgroup. The ballot functionality allows
+    all invocations within a subgroup to provide a boolean value and get
+    as a result what each invocation provided as their boolean value. The
+    broadcast functionality allows values to be broadcast from an
+    invocation to all other invocations within the subgroup, given that
+    the invocation to be broadcast from is known at shader compilation
+    time.
+
+    SG.1.5 Shuffle Subgroup Operations
+
+    The shuffle subgroup operations allow invocations to read values from
+    other invocations within a subgroup.
+
+    SG.1.6 Shuffle Relative Subgroup Operations
+
+    The shuffle relative subgroup operations allow invocations to read
+    values from other invocations within the subgroup relative to the
+    current invocation in the group. The relative operations supported
+    allow data to be shifted up and down through the invocations within
+    a subgroup.
+
+    SG.1.7 Clustered Subgroup Operations
+
+    The clustered subgroup operations allow invocations to perform
+    arithmetic operations among partitions of a subgroup, such that the
+    operation is only performed within the subgroup invocations within a
+    partition. The partitions for clustered subgroup operations are
+    consecutive power-of-two size groups of invocations and the cluster size
+    must be known at compilation time. The operations supported are
+    add, mul, min, max, and, or, xor.
+
+    SG.1.8 Quad Subgroup Operations
+
+    The quad subgroup operations allow clusters of 4 invocations (a quad),
+    to share data efficiently with each other. For fragment shaders, if the
+    value of SUBGROUP_SIZE_KHR is at least 4, each quad corresponds to one
+    of the groups of four shader invocations used for derivatives. The order
+    in which the fragments appear within the quad is implementation-defined.
+
+    Note:
+    In OpenGL and OpenGL ES, the order of invocations within a quad may
+    depend on the rendering orientation and whether rendering to a framebuffer
+    object or to the default framebuffer (window).
+
+    This language supersedes the quad arrangement described in the GLSL
+    KHR_shader_subgroup document.
+
+    SG.2 Subgroup Queries
+
+    SG.2.1 Subgroup Size
+
+    The subgroup size is the maximum number of invocations in a subgroup.
+    This is an implementation-dependent value which can be obtained by
+    calling GetIntegerv with a <pname> of SUBGROUP_SIZE_KHR. This value
+    is also provided in the gl_SubgroupSize built-in shading language
+    variable.  The subgroup size must be at least 1, and must be a power
+    of 2. The maximum number of invocations an implementation can support
+    per subgroup is 128.
+
+    SG.2.2 Subgroup Supported Stages
+
+    Subgroup operations may not be supported in all shader stages. To
+    determine which shader stages support the subgroup operations, call
+    GetIntegerv with a <pname> of SUBGROUP_SUPPORTED_STAGES_KHR. On
+    return, <data> will contain the bitwise OR of the *_SHADER_BIT flags
+    indicating which of the vertex, tessellation control, tessellation
+    evaluation, geometry, fragment, and compute shader stages support
+    subgroup operations.  All implementations must support at least
+    COMPUTE_SHADER_BIT.
+
+    SG.2.3 Subgroup Supported Operations
+
+    To determine which subgroup operations are supported by an
+    implementation, call GetIntegerv with a <pname> of
+    SUBGROUP_SUPPORTED_FEATURES_KHR. On return, <data> will
+    contain the bitwise OR of the SUBGROUP_FEATURE_*_BIT_KHR
+    flags indicating which subgroup operations are supported by the
+    implementation. Possible values include:
+
+    * SUBGROUP_FEATURE_BASIC_BIT_KHR indicates the GL supports shaders
+      with the KHR_shader_subgroup_basic extension enabled. See SG.1.1.
+
+    * SUBGROUP_FEATURE_VOTE_BIT_KHR indicates the GL supports shaders
+      with the KHR_shader_subgroup_vote extension enabled. See SG.1.2.
+
+    * SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR indicates the GL supports
+      shaders with the KHR_shader_subgroup_arithmetic extension enabled.
+      See SG.1.3.
+
+    * SUBGROUP_FEATURE_BALLOT_BIT_KHR indicates the GL supports
+      shaders with the KHR_shader_subgroup_ballot extension enabled.
+      See SG.1.4.
+
+    * SUBGROUP_FEATURE_SHUFFLE_BIT_KHR indicates the GL supports
+      shaders with the KHR_shader_subgroup_shuffle extension enabled.
+      See SG.1.5.
+
+    * SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR indicates the GL
+      supports shaders with the KHR_shader_subgroup_shuffle_relative
+      extension enabled. See SG.1.6.
+
+    * SUBGROUP_FEATURE_CLUSTERED_BIT_KHR indicates the GL supports
+      shaders with the KHR_shader_subgroup_clustered extension enabled.
+      See SG.1.7.
+
+    * SUBGROUP_FEATURE_QUAD_BIT_KHR indicates the GL supports shaders
+      with the GL_KHR_shader_subgroup_quad extension enabled. See SG.1.8.
+
+    All implementations must support SUBGROUP_FEATURE_BASIC_BIT_KHR.
+
+    SG.2.4 Subgroup Quads Support
+
+    To determine whether subgroup quad operations (See SG.1.8) are
+    available in all stages, call GetBooleanv with a <pname> of
+    SUBGROUP_QUAD_ALL_STAGES_KHR. On return, <data> will be TRUE
+    if subgroup quad operations are supported in all shader stages
+    which support subgroup operations. FALSE is returned if subgroup quad
+    operations are not supported, or if they are restricted to fragment
+    and compute stages.
+
+Modifications to Appendix C of the OpenGL 4.6 (Core Profile) Specification
+(The OpenGL SPIR-V Execution Environment)
+
+    Modifications to section C.1 (Required Versions and Formats) [p661]
+
+      Replace the first sentence with the following:
+
+        "Implementations must support the 1.0 and 1.3 versions of SPIR-V
+        and the 1.0 version of the SPIR-V Extended Instructions
+        for the OpenGL Shading Language (see section 1.3.4)."
+
+    Modifications to section C.2 (Valid SPIR-V Built-In Variable
+    Decorations) [661]
+
+      Add the following rows to Table C.1 (Built-in Variable Decorations)
+
+        NumSubgroups            (if SUBGROUP_FEATURE_BASIC_BIT_KHR is supported)
+        SubgroupId              (if SUBGROUP_FEATURE_BASIC_BIT_KHR is supported)
+        SubgroupSize            (if SUBGROUP_FEATURE_BASIC_BIT_KHR is supported)
+        SubgroupLocalInvocationId (if SUBGROUP_FEATURE_BASIC_BIT_KHR is supported)
+        SubgroupEqMask          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+        SubgroupGeMask          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+        SubgroupGtMask          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+        SubgroupLeMask          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+        SubgroupLtMask          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+
+    Additions to section C.3 (Valid SPIR-V Capabilities):
+
+    Add the following rows to Table C.2 (Valid SPIR-V Capabilities):
+
+        GroupNonUniform                (if SUBGROUP_FEATURE_BASIC_BIT_KHR is supported)
+        GroupNonUniformVote            (if SUBGROUP_FEATURE_VOTE_BIT_KHR is supported)
+        GroupNonUniformArithmetic      (if SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR is supported)
+        GroupNonUniformBallot          (if SUBGROUP_FEATURE_BALLOT_BIT_KHR is supported)
+        GroupNonUniformShuffle         (if SUBGROUP_FEATURE_SHUFFLE_BIT_KHR is supported)
+        GroupNonUniformShuffleRelative (if SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR is supported)
+        GroupNonUniformClustered       (if SUBGROUP_FEATURE_CLUSTERED_BIT_KHR is supported)
+        GroupNonUniformQuad            (if SUBGROUP_FEATURE_QUAD_BIT_KHR is supported)
+
+    Additions to section C.4 (Validation Rules):
+
+      Make the following changes to the validation rules:
+
+        Add *Subgroup* to the list of acceptable scopes for memory.
+
+      Add:
+
+        *Scope* for *Non Uniform Group Operations* must be limited to:
+          - *Subgroup*
+
+        * If OpControlBarrier is used in fragment, vertex, tessellation
+           evaluation, or geometry stages, the execution Scope must be
+           *Subgroup*.
+
+        * "`Result Type`" for *Non Uniform Group Operations* must be
+          limited to 32-bit float, 32-bit integer, boolean, or vectors
+          of these types. If the Float64 capability is enabled, double
+          and vectors of double types are also permitted.
+
+        * If OpGroupNonUniformBallotBitCount is used, the group operation
+          must be one of:
+          - *Reduce*
+          - *InclusiveScan*
+          - *ExclusiveScan*
+
+      Add the following restrictions (disallowing SPIR-V 1.1, 1.2, and
+      1.3 features not related to subgroups);
+
+        * The *LocalSizeId* Execution Mode must not be used.
+
+        [[If SPV_KHR_storage_buffer_storage_class is not supported]]
+        * The *StorageBuffer* Storage Class must not be used.
+
+        * The *DependencyInfinite* and *DependencyLength* Loop Control
+          masks must not be used.
+
+        [[If SPV_KHR_shader_draw_parameters or OpenGL 4.6 is not supported]]
+        * The *DrawParameters* Capability must not be used.
+
+        * The *StorageBuffer16BitAccess*, *UniformAndStorageBuffer16BitAccess*,
+          *StoragePushConstant16*, *StorageInputOutput16* Capabilities must
+          not be used.
+
+        * The *DeviceGroup*, *MultiView*, *VariablePointersStorageBuffer*, and
+          *VariablePointers* Capabilities must not be used.
+
+        * The *OpModuleProcessed*, *OpDecorateId*, and *OpExecutionModeId*
+          Instructions must not be used.
+
+Modifications to the OpenGL Shading Language Specification, Version 4.60
+
+    See the separate KHR_shader_subgroup GLSL document.
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/khr/GL_KHR_shader_subgroup.txt
+
+Dependencies on ARB_gl_spirv and OpenGL 4.6
+
+    If ARB_gl_spirv or OpenGL 4.6 are not supported, ignore all
+    references to SPIR-V functionality.
+
+Dependencies on ARB_spirv_extensions and OpenGL 4.6
+
+    If ARB_spirv_extensions or OpenGL 4.6 are not supported, ignore
+    references to the ability to advertise additional SPIR-V extensions.
+
+Dependencies on OpenGL ES 3.x
+
+    If implemented in OpenGL ES, ignore all references to SPIR-V and to
+    GLSL built-in functions which utilize the genDType (double) types.
+
+Dependencies on ARB_shader_draw_parameters and SPV_KHR_shader_draw_parameters
+
+    If neither OpenGL 4.6, nor ARB_shader_draw_parameters and
+    SPV_KHR_shader_draw_parameters are supported, the *DrawParameters*
+    Capability is not supported.
+
+Dependencies on SPV_KHR_storage_buffer_storage_class
+
+    If SPV_KHR_storage_buffer_storage_class is not supported, the
+    *StorageBuffer* Storage Class must not be used.
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None
+
+Errors
+
+    None
+
+New State
+
+    None
+
+New Implementation Dependent State
+
+    Additions to table 2.53 - Implementation Dependent Values
+
+                                                    Minimum
+    Get Value                Type  Get Command      Value   Description                   Sec.
+    ---------                ----- ---------------  ------- ------------------------      ------
+    SUBGROUP_SIZE_KHR        Z+    GetIntegerv      1       No. of invocations in         SG.2.1
+                                                            each subgroup
+
+    SUBGROUP_SUPPORTED_      E     GetIntegerv      Sec     Bitfield of stages that       SG.2.2
+      STAGES_KHR                                    SG.2.2  subgroups are supported in
+
+    SUBGROUP_SUPPORTED_      E     GetIntegerv      Sec     Bitfield of subgroup          SG.2.3
+      FEATURES_KHR                                  SG.2.3  operations supported
+
+    SUBGROUP_QUAD_           B     GetBooleanv      -       Quad subgroups supported      SG.2.4
+      ALL_STAGES_KHR                                        in all stages
+
+Issues
+
+    1. What should we name this extension?
+
+       DISCUSSION. We will use the same name as the GLSL extension
+       in order to minimize confusion. This has been done for other
+       extensions and people seem to have figured it out. Other
+       options considered: KHR_subgroups, KHR_shader_subgroup_operations,
+       KHR_subgroup_operations.
+
+       RESOLVED: use KHR_shader_subgroup to match the GLSL extension.
+
+    2. What should happen if subgroup operations are attempted on
+       unsupported stages?
+
+       DISCUSSION: There are basically two options
+         A. compile or link-time error?
+         B. draw time invalid_op error?
+       Seems like Option (A) would be more user friendly, and there doesn't
+       seem to be much point in requiring an implementation to
+       support compiling the functionality in stages they won't work in.
+       Typically this should be detectable by an implementation at compile
+       time since this will just require them to reject shaders with
+       #extension GL_KHR_shader_subgroup* in shader stages that they don't
+       support. However, for SPIR-V implementations, this may happen at
+       lowering time, so it may happen at either compile or link-time.
+
+       RESOLVED: Compile or link-time error.
+
+    3. How should we enable SPIR-V support for this extension?
+
+       DISCUSSION: Options could include:
+         A. add support for SPIR-V 1.1, 1.2, and 1.3.
+         B. add support for only the subgroups capabilities from SPIR-V 1.3.
+
+       Doing option (A) seems like a weird way of submarining support
+       for new versions of SPIR-V into OpenGL, and it seems like there
+       should be a separate extension for that.
+       If option (B) is selected, we need to be sure to disallow other
+       new capabilities that are added in SPIR-V 1.1, 1.2, and 1.3
+
+       RESOLVED: (B) only add support for subgroup capabilities from SPIR-V
+       1.3. If a future GL core version incorporates this extension it should
+       add support for all of SPIR-V 1.3.
+
+    4. What functionality of SPIR-V 1.1, 1.2, and 1.3 needs to be disallowed?
+
+       RESOLVED:
+       Additions that aren't gated by specific capabilities and are disallowed
+       are the following:
+
+         LocalSizeId (1.2)
+         DependencyInfinite (1.1)
+         DependencyLength (1.1)
+         OpModuleProcessed (1.1)
+         OpDecorateId (1.2)
+         OpExecutionModeId (1.2)
+
+       Additions that are gated by graphics-compatible capabilities not
+       being enabled by this extension (but could be enabled by other
+       extensions):
+
+       Capabilities                                 Enabling extension
+
+         StorageBuffer (1.3)                        SPV_KHR_storage_buffer_storage_class
+
+         DrawParameters (1.3)                       SPV_KHR_shader_draw_parameters
+           - BaseVertex
+           - BaseInstance
+           - DrawIndex
+
+         DeviceGroup (1.3)                          SPV_KHR_device_group
+           - DeviceIndex
+
+         MultiView (1.3)                            SPV_KHR_multiview
+           - ViewIndex
+
+         StorageBuffer16BitAccess (1.3)             SPV_KHR_16bit_storage
+         StorageUniformBufferBlock16 (1.3)          SPV_KHR_16bit_storage
+         UniformAndStorageBuffer16BitAccess (1.3)   SPV_KHR_16bit_storage
+         StorageUniform16 (1.3)                     SPV_KHR_16bit_storage
+         StoragePushConstant16 (1.3)                SPV_KHR_16bit_storage
+         StorageInputOutput16 (1.3)                 SPV_KHR_16bit_storage
+
+         VariablePointersStorageBuffer (1.3)        SPV_KHR_variable_pointers
+         VariablePointers (1.3)                     SPV_KHR_variable_pointers
+
+    5. Given Issues (3) and (4) what exactly are the additional SPIR-V
+       requirements are being added by this extension?
+
+       RESOLVED: We add support for the following from SPIR-V 1.3:
+
+       Capabilities (3.31)                  Enabling API Feature
+
+         GroupNonUniform                    SUBGROUP_FEATURE_BASIC_BIT_KHR
+         GroupNonUniformVote                SUBGROUP_FEATURE_VOTE_BIT_KHR
+         GroupNonUniformArithmetic          SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR
+         GroupNonUniformBallot              SUBGROUP_FEATURE_BALLOT_BIT_KHR
+         GroupNonUniformShuffle             SUBGROUP_FEATURE_SHUFFLE_BIT_KHR
+         GroupNonUniformShuffleRelative     SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR
+         GroupNonUniformClustered           SUBGROUP_FEATURE_CLUSTERED_BIT_KHR
+         GroupNonUniformQuad                SUBGROUP_FEATURE_QUAD_BIT_KHR
+
+       Builtins (3.21)              Enabling Capability
+
+         SubgroupSize               GroupNonUniform
+         NumSubgroups               GroupNonUniform
+         SubgroupId                 GroupNonUniform
+         SubgroupLocalInvocationId  GroupNonUniform
+         SubgroupEqMask             GroupNonUniformBallot
+         SubgroupGeMask             GroupNonUniformBallot
+         SubgroupGtMask             GroupNonUniformBallot
+         SubgroupLeMask             GroupNonUniformBallot
+         SubgroupLtMask             GroupNonUniformBallot
+
+       Group Operations         Enabling Capability
+       (3.28)
+
+         Reduce                 GroupNonUniformArithmetic, GroupNonUniformBallot
+         InclusiveScan          GroupNonUniformArithmetic, GroupNonUniformBallot
+         ExclusiveScan          GroupNonUniformArithmetic, GroupNonUniformBallot
+         ClusteredReduce        GroupNonUniformClustered
+
+       Non-Uniform Instructions             Enabling Capability
+       (3.32.24)
+
+         OpGroupNonUniformElect             GroupNonUniform
+         OpGroupNonUniformAll               GroupNonUniformVote
+         OpGroupNonUniformAny               GroupNonUniformVote
+         OpGroupNonUniformAllEqual          GroupNonUniformVote
+         OpGroupNonUniformBroadcast         GroupNonUniformBallot
+         OpGroupNonUniformBroadcastFirst    GroupNonUniformBallot
+         OpGroupNonUniformBallot            GroupNonUniformBallot
+         OpGroupNonUniformInverseBallot     GroupNonUniformBallot
+         OpGroupNonUniformBallotBitExtract  GroupNonUniformBallot
+         OpGroupNonUniformBallotBitCount    GroupNonUniformBallot
+         OpGroupNonUniformBallotFindLSB     GroupNonUniformBallot
+         OpGroupNonUniformBallotFindMSB     GroupNonUniformBallot
+         OpGroupNonUniformShuffle           GroupNonUniformShuffle
+         OpGroupNonUniformShuffleXor        GroupNonUniformShuffle
+         OpGroupNonUniformShuffleUp         GroupNonUniformShuffle
+         OpGroupNonUniformShuffleDown       GroupNonUniformShuffle
+         OpGroupNonUniformIAdd              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformFAdd              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformIMul              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformFMul              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformSMin              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformUMin              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformFMin              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformSMax              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformUMax              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformFMax              GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformBitwiseAnd        GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformBitwiseOr         GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformBitwiseXor        GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformLogicalAnd        GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformLogicalOr         GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformLogicalXor        GroupNonUniformArithmetic, GroupNonUniformClustered
+         OpGroupNonUniformQuadBroadcast     GroupNonUniformQuad
+         OpGroupNonUniformQuadSwap          GroupNonUniformQuad
+
+       *Subgroup* as an acceptable memory scope.
+
+       OpControlBarrier in fragment, vertex, tessellation evaluation, tessellation
+       control, and geometry stages with the *Subgroup* execution Scope.
+
+
+Revision History
+
+    Rev.  Date          Author     Changes
+    ----  -----------   --------   -------------------------------------------
+     8    2019-07-26    dgkoch     Update status and assign extension numbers
+     7    2019-05-22    dgkoch     Resync language with Vulkan spec. Address feedback
+                                   from Graeme. Relax quad ordering definition.
+     6    2019-03-28    dgkoch     rename to KHR_shader_subgroup, update some issues
+     5    2018-05-30    dgkoch     Address feedback from Graeme and Jesse.
+     4    2018-05-28    dgkoch     change ALLSTAGES -> ALL_STAGES, fix typos
+     3    2018-05-23    dgkoch     Add overview and interactions, add SPIR-V 1.3
+                                   restrictions, Issues 4 and 5.
+     2    2018-04-26    dgkoch     Various updates to match latest vulkan spec
+                                   Assign tokens. Add SPIR-V support.
+     1    2018-01-19    dgkoch     Initial revision.
+

--- a/extensions/NV/NV_shader_subgroup_partitioned.txt
+++ b/extensions/NV/NV_shader_subgroup_partitioned.txt
@@ -1,0 +1,163 @@
+Name
+
+    NV_shader_subgroup_partitioned
+
+Name Strings
+
+    GL_NV_shader_subgroup_partitioned
+
+Contact
+
+    Daniel Koch, NVIDIA Corportation
+
+Contributors
+
+    Jeff Bolz, NVIDIA
+    Pyarelal Knowles, NVIDIA
+
+Status
+
+    Complete
+
+Version
+
+    Last Modified:  2019-07-26
+    Revision:       1
+
+Number
+
+    OpenGL Extension #544
+    OpenGL ES Extension #322
+
+Dependencies
+
+    This extension is written against the OpenGL 4.6 Specification
+    (Core Profile), dated July 30, 2017.
+
+    This extension requires OpenGL 4.3 or OpenGL ES 3.1.
+
+    This extension requires the KHR_shader_subgroup API and GLSL extensions.
+
+    This extension interacts with ARB_gl_spirv and OpenGL 4.6.
+
+    This extension interacts with ARB_spirv_extensions and OpenGL 4.6.
+
+    This extension interacts with OpenGL ES 3.x.
+
+    This extension requires SPV_NV_shader_subgroup_partitioned when SPIR-V is
+    supported in OpenGL.
+
+Overview
+
+    This extension enables support for the NV_shader_subgroup_partitioned
+    shading language extension in OpenGL and OpenGL ES.
+
+    This extension adds a new SUBGROUP_FEATURE_PARTITIONED_BIT_NV feature bit
+    that is returned by queryies for SUBGROUP_SUPPORTED_FEATURES_KHR.
+
+    In OpenGL implementations supporting SPIR-V, this extension enables
+    support for the SPV_NV_shader_subgroup_partitioned extension.
+
+    In OpenGL ES implementations, this extension does NOT add support for
+    SPIR-V or for any of the built-in shading language functions (8.18)
+    that have genDType (double) prototypes.
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Returned as bitfield in the <data> argument when GetIntegerv
+    is queried with a <pname> of SUBGROUP_SUPPORTED_FEATURES_KHR:
+
+        SUBGROUP_FEATURE_PARTITIONED_BIT_NV         0x00000100
+
+
+Modifications to the OpenGL 4.6 Specification (Core Profile)
+
+Modifications to Chapter SG, "Subgroups" (as added by KHR_shader_subgroups)
+
+    (add a new subsection to SG.1, "Subgroup Operations")
+
+    SG.1.9 Partitioned Subgroup Operations
+
+    The partitioned subgroup operations allow a subgroup to partition
+    its invocations into disjoint subsets and to perform scan and reduction
+    operations among invocations belonging to the same subset. The partitions
+    for partitioned subgroup operations are specified by a ballot operand and
+    can be computed at runtime. The operations supported are add, mul, min,
+    max, and, or, xor.
+
+    (Add a new bullet point to the list in SG.2.3, "Subgroup Supported
+     Operations")
+
+    * SUBGROUP_FEATURE_PARTITIONED_BIT_NV indicates the GL supports shaders
+      with the NV_shader_subgroup_partitioned extension enabled. See SG.1.9.
+
+Modifications to Appendix C of the OpenGL 4.6 (Core Profile) Specification
+(The OpenGL SPIR-V Execution Environment)
+
+    Additions to section C.3 (Valid SPIR-V Capabilities):
+
+    Add the following rows to Table C.2 (Valid SPIR-V Capabilities):
+
+        GroupNonUniformPartitionedNV   (if SUBGROUP_FEATURE_PARTITIONED_BIT_NV is supported)
+
+Modifications to the OpenGL Shading Language Specification, Version 4.60
+
+    See the separate KHR_shader_subgroup GLSL document.
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GL_NV_shader_subgroup_partitioned.txt
+
+Dependencies on ARB_gl_spirv and OpenGL 4.6
+
+    If ARB_gl_spirv or OpenGL 4.6 are not supported, ignore all
+    references to SPIR-V functionality.
+
+Dependencies on ARB_spirv_extensions and OpenGL 4.6
+
+    If ARB_spirv_extensions or OpenGL 4.6 are not supported, ignore
+    references to the ability to advertise additional SPIR-V extensions.
+
+Dependencies on OpenGL ES 3.x
+
+    If implemented in OpenGL ES, ignore all references to SPIR-V and to
+    GLSL built-in functions which utilize the genDType (double) types.
+
+Additions to the AGL/GLX/WGL Specifications
+
+    None
+
+Errors
+
+    None
+
+New State
+
+    None
+
+New Implementation Dependent State
+
+    None
+
+Issues
+
+    1. What should we name this extension?
+
+       DISCUSSION. We will use the same name as the GLSL extension.
+
+       RESOLVED: Use NV_shader_subgroup_partitioned.
+
+    2. Should SPV_NV_shader_subgroup_partitioned be advertised in the
+       list of extensions enumerated by the SPIR_V_EXTENSIONS query?
+
+       RESOLVED: Yes. There is no spec language for this because it
+       is just expected when this extension is supported (on an implementation
+       that supports SPIR-V).
+
+Revision History
+
+    Rev.  Date          Author     Changes
+    ----  -----------   --------   -------------------------------------------
+     1    2019-07-27    dgkoch     Internal revisions.
+

--- a/extensions/NV/WGL_NV_multigpu_context.txt
+++ b/extensions/NV/WGL_NV_multigpu_context.txt
@@ -1,0 +1,146 @@
+Name
+
+    NV_multigpu_context
+
+Name Strings
+
+    WGL_NV_multigpu_context
+
+Contact
+
+    Ralf Biermann (rbiermann 'at' nvidia.com)
+
+Contributors
+
+    Joshua Schnarr, NVIDIA
+    Ingo Esser, NVIDIA
+    Robert Menzel, NVIDIA
+
+Notice
+
+    Copyright (c) 2019 NVIDIA
+
+Status
+
+    Complete.
+
+Version
+
+    Last Modified Date:         2019-05-29
+    Author Revision:            4
+
+Number
+
+    OpenGL Extension #542
+
+Dependencies
+
+    WGL_NV_multigpu_context is written against the
+    WGL_ARB_create_context specification, which is required.
+
+    This extension interacts with NV_gpu_multicast.
+    This extension interacts with WGL_ARB_make_current_read.
+
+Overview
+
+    This extension allows the creation of an OpenGL context in a multi-GPU
+    environment with a specified multi-GPU strategy (known as SLI mode) which
+    takes precedence over process-wide multi-GPU mode settings.
+    
+    The multi-GPU mode denotes vendor specific techniques to allow distributed
+    rendering on multiple GPUs, further called AFR (alternate frame rendering)
+    and Multicast (as defined in NV_gpu_multicast).
+    
+    OpenGL supports multiple contexts. The semantics of switching contexts 
+    is generally left to window system binding APIs such as WGL, GLX and EGL.
+    The extension WGL_NV_multigpu_context allows to specify a preferred 
+    multi-GPU rendering mode per context, thus context switching can also
+    switch the current multi-GPU rendering mode.
+    
+    The implementation is platform dependent and the actual multi-GPU rendering
+    mode of the created context may vary on different hardware and operation 
+    system platforms.
+    
+New Procedures and Functions
+
+    None
+
+New Tokens (WGL)
+
+    Accepted as an attribute name in the <*attrib_list> argument to
+    wglCreateContextAttribsARB:
+
+        WGL_CONTEXT_MULTIGPU_ATTRIB_NV                         0x20AA
+
+    Accepted as an attribute value for WGL_CONTEXT_MULTIGPU_ATTRIB_NV in
+    the <*attrib_list> argument to wglCreateContextAttribsARB:
+
+        WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV                  0x20AB
+        WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV                     0x20AC
+        WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV               0x20AD
+        WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV 0x20AE
+
+Additions to WGL_ARB_create_context and WGL_ARB_make_current_read 
+
+    Add a new paragraph to the description of wglCreateContextAttribsARB, as
+    defined by WGL_ARB_create_context:
+
+    "The attribute name WGL_CONTEXT_MULTIGPU_ATTRIB_NV indicates the 
+    preferred multi-GPU rendering mode for the OpenGL context. 
+    This specified mode precedes other selected configuration settings."
+
+    Add a new paragraph to the description of wglMakeCurrent and 
+    wglMakeContextCurrentARB:
+
+    "With OpenGL on Windows, a thread can only have one current rendering context
+    and a device context can only be used by a single thread at a time. 
+    Violating this by using the same device context with multiple rendering 
+    contexts does not normally return an error, but can lead to undefined and 
+    undesirable behavior.
+    When multigpu context attributes are used, however, wglMakeCurrent and 
+    wglMakeContextCurrentARB will return FALSE and set ERROR_INVALID_OPERATION 
+    if a HDC passed to the function is already current with a rendering context 
+    using an alternate multigpu attribute."
+
+GLX Protocol
+
+    None.
+
+Errors for WGL
+
+    A GL error ERROR_INVALID_PARAMETER is generated when a value for
+    WGL_CONTEXT_MULTIGPU_ATTRIB_NV passed into a wglCreateContextAttribsARB 
+    attribute list is not an accepted value.
+    
+    A GL error ERROR_NOT_SUPPORTED is generated when an unsupported SLI rendering 
+    mode value is passed as value of attribute WGL_CONTEXT_MULTIGPU_ATTRIB_NV in a 
+    wglCreateContextAttribsARB attribute list.
+
+    A GL error ERROR_NOT_SUPPORTED is generated when passing a device context HDC
+    to wglMakeCurrent or wglMakeContextCurrentARB if the HDC is already current with 
+    a rendering context using a multigpu attribute in a different thread.
+
+New State
+
+    None.
+
+Issues
+
+    1. Is MULTICAST mode supported in a multi-display configuration where displays attached
+       to multiple GPUs are linked together in a desktop configuration spanning multiple GPUs?
+
+       RESOLVED: Not by default. 
+
+       A dedicated attribute value WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV has to be 
+       specified when a linked multi-GPU display configuration is considered for multicast rendering
+       by the application creating the context.
+
+
+Revision History
+
+ Rev.   Date      Author    Changes
+ ---- ----------  --------  ---------------------------------------------
+   1  2017-02-21  rbiermann  Initial draft
+   2  2018-09-17  rbiermann  Updated attribute list and spec proposal
+   3  2019-05-08  rbiermann  Added multi-display multicast mode
+   4  2019-05-29  rbiermann  Added behavior of multithreaded wglMakeCurrent

--- a/extensions/NVX/NVX_gpu_multicast2.txt
+++ b/extensions/NVX/NVX_gpu_multicast2.txt
@@ -1,0 +1,249 @@
+Name
+
+    NVX_gpu_multicast2
+
+Name Strings
+
+    GL_NVX_gpu_multicast2
+
+Contact
+
+    Joshua Schnarr, NVIDIA Corporation (jschnarr 'at' nvidia.com)
+    Ingo Esser, NVIDIA Corporation (iesser 'at' nvidia.com)
+
+Contributors
+
+    Robert Menzel, NVIDIA
+    Ralf Biermann, NVIDIA
+
+Status
+
+    Complete.
+
+Version
+
+    Last Modified Date: July 23, 2019
+    Author Revision: 8
+
+Number
+
+    OpenGL Extension #543
+
+Dependencies
+
+    This extension is written against the OpenGL 4.6 specification
+    (Compatibility Profile), dated October 24, 2016.
+
+    This extension requires NV_gpu_multicast.
+    
+    This extension requires EXT_device_group.
+
+    This extension requires NV_viewport_array.
+    
+    This extension requires NV_clip_space_w_scaling.
+
+    This extension requires NVX_progress_fence.
+
+    
+Overview
+
+    This extension provides additional mechanisms that influence multicast rendering which is
+    simultaneous rendering to multiple GPUs.
+    
+New Procedures and Functions
+
+    uint AsyncCopyImageSubDataNVX(
+        sizei waitSemaphoreCount, const uint *waitSemaphoreArray, const uint64 *waitValueArray,
+        uint srcGpu, GLbitfield dstGpuMask,
+        uint srcName, GLenum srcTarget, int srcLevel, int srcX, int srcY, int srcZ,
+        uint dstName, GLenum dstTarget, int dstLevel, int dstX, int dstY, int dstZ,
+        sizei srcWidth, sizei srcHeight, sizei srcDepth,
+        sizei signalSemaphoreCount, const uint *signalSemaphoreArray, const uint64 *signalValueArray);
+
+    sync AsyncCopyBufferSubDataNVX(
+        sizei waitSemaphoreCount, const uint *waitSemaphoreArray, const uint64 *fenceValueArray,
+        uint readGpu, GLbitfield writeGpuMask,
+        uint readBuffer, uint writeBuffer,
+        GLintptr readOffset, GLintptr writeOffset, sizeiptr size,
+        sizei signalSemaphoreCount, const uint *signalSemaphoreArray, const uint64 *signalValueArray);
+
+    void UploadGpuMaskNVX(bitfield mask);
+        
+    void MulticastViewportArrayvNVX(uint gpu, uint first, sizei count, const float *v);
+
+    void MulticastScissorArrayvNVX(uint gpu, uint first, sizei count, const int *v);
+    
+    void MulticastViewportPositionWScaleNVX(uint gpu, uint index, float xcoeff, float ycoeff);    
+
+    
+New Tokens
+
+    Accepted by the <pname> parameter of GetIntegerv and GetInteger64v:
+
+        UPLOAD_GPU_MASK_NVX                        0x954A
+
+Additions to Chapter 20 (Multicast Rendering) added to the OpenGL 4.5 (Compatibility Profile)
+Specification by NV_gpu_multicast
+
+    Additions to Section 20.1 (Controlling Individual GPUs)
+
+    Texture data uploads using the functions TexImage1D, TexImage2D, TexImage3D, 
+    TexSubImage1D, TexSubImage2D and TexSubImage3D are restricted to a specific set of GPUs with
+
+      void UploadGpuMaskNVX(bitfield mask);
+
+    This command also restricts buffer object data uploads using the functions BufferStorage, 
+    NamedBufferStorage, BufferSubData and NamedBufferSubData to the specified set of GPUs.
+
+    Further this command also restricts buffer object clears using the functions ClearBufferData,
+    ClearNamedBufferData, ClearBufferSubData and ClearNamedBufferSubData.
+    
+    The following errors apply to UploadGpuMaskNVX:
+
+    INVALID_VALUE is generated
+    * if <mask> is zero,
+    * if <mask> is greater than or equal to 2^n, where n is equal to MULTICAST_GPUS_NV
+
+    If the command does not generate an error, UPLOAD_GPU_MASK_NVX is set to <mask>.  
+    
+    The default value of UPLOAD_GPU_MASK_NVX is (2^n)-1.
+
+    If a function restricted by UploadGpuMaskNVX operates on textures or buffer objects
+    with GPU-shared storage type (as opposed to per-GPU storage), UPLOAD_GPU_MASK_NVX is ignored.
+
+    Modify Section 20.2 (Multi-GPU Buffer Storage)
+
+    Append the following paragraphs:
+
+    To initiate a copy of buffer data without waiting for it to complete, use the following command:
+
+    void AsyncCopyBufferSubDataNVX(
+        sizei waitSemaphoreCount, const uint *waitSemaphoreArray, const uint64 *fenceValueArray,
+        uint readGpu, GLbitfield writeGpuMask,
+        uint readBuffer, uint writeBuffer,
+        GLintptr readOffset, GLintptr writeOffset, sizeiptr size,
+        sizei signalSemaphoreCount, const uint *signalSemaphoreArray, const uint64 *signalValueArray);
+
+    This command behaves equivalently to MulticastCopyBufferSubDataNV, except that it may be
+    performed concurrently with commands submitted in the future.
+    Fence semaphore objects created with CreateProgressFenceNVX are used for synchronization of one or 
+    multiple copies. 
+    An array of <waitSemaphoreCount> synchronization objects can be specified in the <waitSemaphoresArray>
+    parameter as a pointer to the array of semaphore objects.
+    The copy will wait for all fence semaphores in the <waitSemaphoreArray> array to be reach or exceed
+    their corresponding fence value in <fenceValueArray> before starting the transfer. 
+    A signal operation for each of the <signalSemaphoreCount> semaphores in <signalSemaphoresArray> is written
+    after the copy with the corresponding fence value in <signalValueArray>.
+    To wait for the copy to complete, use WaitSemaphoreui64NVX or ClientWaitSemaphoreui64NVX to wait
+    for the semaphores in <signalSemaphoreArray> to be signalled with the fence values in <signalValueArray>.
+    
+    Modify Section 20.3.1 (Copying Image Data Between GPUs)
+
+    Insert the following paragraphs above the line starting "To copy pixel values":
+
+    To initiate a copy of texel data without waiting for it to complete, use the following command:
+
+    void AsyncCopyImageSubDataNVX(
+        sizei waitSemaphoreCount, const uint *waitSemaphoreArray, const uint64 *waitValueArray,
+        uint srcGpu, GLbitfield dstGpuMask,
+        uint srcName, GLenum srcTarget, int srcLevel, int srcX, int srcY, int srcZ,
+        uint dstName, GLenum dstTarget, int dstLevel, int dstX, int dstY, int dstZ,
+        sizei srcWidth, sizei srcHeight, sizei srcDepth,
+        sizei signalSemaphoreCount, const uint *signalSemaphoreArray, const uint64 *signalValueArray);
+
+    This command behaves equivalently to MulticastCopyImageSubDataNV, except that it may be
+    performed concurrently with commands submitted in the future. 
+    Fence semaphore objects created with CreateProgressFenceNVX are used for synchronization of one or
+    multiple copies. An array of <waitSemaphoreCount> synchronization objects can be specified in the 
+    <waitSemaphoreArray> parameter as a pointer to the array of semaphore objects.
+    The copy will wait for all fence semaphores in the <waitSemaphoresArray> array to be reach or exceed
+    their corresponding fence value in <fenceValueArray> before starting the transfer. 
+    A signal operation for each of the <signalSemaphoreCount> semaphores in <signalSemaphoreArray> is written
+    after the copy with the corresponding fence value in <signalValueArray>.
+    To wait for the copy to complete, use WaitSemaphoreui64NVX or ClientWaitSemaphoreui64NVX to wait
+    for the semaphores in <signalSemaphoresArray> to be signalled with the fence values in <signalValueArray>.
+
+Additions to Chapter 13 (Fixed-Function Vertex Post-Processing) added to the OpenGL 4.5 (Compatibility Profile)
+
+    Modify Section 13.6 (Coordinate transformations)
+    
+    Viewport transformation parameters for multiple viewports are specified using
+
+        MulticastViewportArrayvNVX(uint gpu, uint first, sizei count, const float * v);
+    
+    where the array of viewport parameters can be controlled for each multicast GPU, respectively.
+    
+    A set of scissor rectangles that are each applied to the corresponding viewport is specified
+    using
+    
+        MulticastScissorArrayvNVX(uint gpu, uint first, sizei count, const int *v);
+    
+    where the rectangle parameters can be controlled for each multicast GPU, respectively.
+    
+    
+    If VIEWPORT_POSITION_W_SCALE_NV is enabled, the w coordinates for each
+    primitive sent to a given viewport will be scaled as a function of
+    its x and y coordinates using the following equation:
+
+        w' = xcoeff * x + ycoeff * y + w;
+
+    The coefficients for "x" and "y" used in the above equation depend on the
+    viewport index and can be controlled for each multicast GPU, respectively, by the command
+
+        MulticastViewportPositionWScaleNVX(uint gpu, uint index, float xcoeff, float ycoeff);
+
+    An error INVALID_VALUE error is generated if <gpu> is greater than or equal to MULTICAST_GPUS_NV. 
+    
+Additions to the OpenGL Shading Language Specification, Version 4.50
+        
+    Including the following line in a shader can be used to enumerate multicast GPUs
+    by using the shader built-in variable gl_DeviceIndex:
+
+        #extension GL_EXT_device_group : enable
+    
+    Each multicast GPU contains a unique device index in the gl_DeviceIndex variable.
+
+Errors
+
+    Relaxation of INVALID_ENUM errors
+    ---------------------------------
+    GetIntegerv and GetInteger64v now accept new tokens as
+    described in the "New Tokens" section.
+    
+New State
+
+    Additions to Table 23.6 Buffer Object State
+                                                   Initial
+    Get Value                   Type  Get Command Value  Description               Sec.  Attribute
+    -------------------------- ------ ----------- -----  -----------------------   ----  ---------
+    UPLOAD_GPU_MASK_NVX          Z+   GetIntegerv   *    Mask of GPUs that         20.1     -
+                                                         restricts buffer data
+                                                         writes
+    * See section 20.1
+
+
+New Implementation Dependent State
+
+    None.
+
+Sample Code
+
+    None.
+
+Issues
+
+    None.
+
+Revision History
+
+    Rev.    Date    Author    Changes
+    ----  --------  --------  -----------------------------------------------
+     1    09/20/17  jschnarr  initial draft
+     2    02/23/18  rbiermann updated draft with new functions
+     3    05/23/18  rbiermann updated draft with new ViewportArray and AsyncCopy functions
+     4    06/08/18  rbiermann added NVX_progress_fence for synchronization objects
+     5    08/15/18  rbiermann updated draft with gl_deviceIndex
+     6    04/16/19  rbiermann updated draft with UploadGpuMaskNVX
+     7    07/19/19  rbiermann updated draft with modifications of UploadGpuMaskNVX section
+     8    07/23/19  rbiermann updated draft with support of Clear(Named)Buffer(Sub)Data by UploadGpuMaskNVX
+

--- a/extensions/NVX/NVX_progress_fence.txt
+++ b/extensions/NVX/NVX_progress_fence.txt
@@ -1,0 +1,182 @@
+Name
+
+    NVX_progress_fence
+
+Name Strings
+
+    GL_NVX_progress_fence
+
+Contributors
+
+    Ingo Esser, NVIDIA
+    Joshua Schnarr, NVIDIA
+    Ralf Biermann, NVIDIA
+
+Contact
+
+    Ralf Biermann, NVIDIA corporation (rbiermann'at' nvidia.com)
+
+Status
+
+    Complete.
+
+Version
+
+    Last Modified Date: August 15, 2018
+    Author Revision: 2
+
+Number
+
+    OpenGL Extension #541
+
+Dependencies
+
+    This extension is written against the OpenGL 4.5 and OpenGL ES 3.2 specifications.
+    
+    This extension requires EXT_external_objects.
+
+    This extension requires EXT_external_objects_win32
+
+    This extension interacts with NV_gpu_multicast.
+
+Overview
+
+    This extension uses the concept of GL semaphores as defined in 
+    GL_EXT_semaphore to better coordinate operations between multiple
+    GPU command streams. A semaphore type called "progress fence" is 
+    derived from the GL semaphore. The progress fence semaphore is
+    created by CreateProgressFenceNVX() returning the name of a newly
+    created semaphore object. Like other semaphores, these are signaled
+    by the GL server. Each signal operation is queued in the GPU command
+    stream with an associated fence value that is written to the semaphore
+    at the completion of a signal operation. 
+
+    A GL server wait can be added to the command stream using WaitSemaphoreui64NVX.
+    This blocks the GPU until the progress fence semaphore reaches or exceeds the 
+    specified fence value.
+    
+    A GL client wait can be initiated using ClientWaitSemaphoreui64NVX. 
+    This blocks the CPU until the specified fence value is reached.
+
+New Procedures and Functions
+
+    uint CreateProgressFenceNVX();
+
+    void SignalSemaphoreui64NVX(uint signalGpu, 
+                                sizei fenceObjectCount, 
+                                const uint *semaphoreArray, 
+                                const uint64 *fenceValueArray);
+                        
+    void WaitSemaphoreui64NVX(uint waitGpu, 
+                              sizei fenceObjectCount, 
+                              const uint *semaphoreArray, 
+                              const uint64 *fenceValueArray);
+                            
+    void ClientWaitSemaphoreui64NVX(sizei fenceObjectCount, 
+                                    const uint *semaphoreArray, 
+                                    const uint64 *fenceValueArray);
+
+New Types
+
+    None
+
+New Tokens
+
+    None
+
+Additions to Chapter 4 of the OpenGL 4.5 Specification (Event Model)
+
+  Addition to Section 4.2, "Semaphore Objects”
+
+
+    A command 
+
+      uint CreateProgressFenceNVX();
+
+    creates a named progress fence semaphore object.
+
+    A set of progress fence objects can be deleted by passing the names in the
+    array <semaphores> to the command
+
+      void DeleteSemaphoresEXT(sizei n, const uint *semaphores);
+
+    Progress fence operations can be performed on named semaphore objects. The
+    command
+
+      void SignalSemaphoreui64NVX(uint signalGpu, 
+                                  sizei fenceObjectCount, 
+                                  const uint *semaphoreArray, 
+                                  const uint64 *fenceValueArray);
+
+    SignalSemaphoreui64NVX inserts a signal operation for each of the <fenceObjectCount>
+    semaphores in <semaphoreArray>. Each signal writes the corresponding fence value in 
+    <fenceValueArray>.
+
+    If the GL context uses NV_gpu_multicast to control multiple GPUs, the 
+    <signalGpu> parameter is required to specify the GPU that signals the 
+    fence value to the fence object. Otherwise <signalGpu> must be 0.
+
+    If a value in <semaphoreArray> is not the name of a semaphore object, 
+    an INVALID_VALUE error is generated.
+
+    If NV_gpu_multicast is supported, an INVALID_VALUE error is generated if <signalGpu> 
+    is greater than or equal to MULTICAST_GPUS_NV. Otherwise, an INVALID_VALUE error is 
+    generated if <signalGpu> != 0.
+
+    The command
+
+      void WaitSemaphoreui64NVX(uint waitGpu, 
+                                sizei fenceObjectCount, 
+                                const uint *semaphoreArray, 
+                                const uint64 *fenceValueArray);
+
+    inserts a wait command into the GL server command stream of a specified GPU <waitGpu> 
+    for each of the <fenceObjectCount> progress fence objects in <semaphoreArray> which 
+    blocks <waitGpu> until all fence objects reach or exceed the associated fence value 
+    in <fenceValueArray>.
+
+    If a value in <semaphoreArray> is not the name of a semaphore object, 
+    an INVALID_VALUE error is generated.
+
+    The command
+
+      void ClientWaitSemaphoreui64NVX(sizei fenceObjectCount, 
+                                      const uint *semaphoreArray, 
+                                      const uint64 *fenceValueArray);
+
+    blocks the CPU until each of the <fenceObjectCount> fence objects in a 
+    specified array <semaphoreArray> reaches the corresponding fence value 
+    in <fenceValueArray>, respectively. 
+
+    If a value in <semaphoreArray> is not the name of a semaphore object, 
+    an INVALID_VALUE error is generated.
+  
+    The commands SignalSemaphoreui64NVX, WaitSemaphoreui64NVX and 
+    ClientWaitSemaphoreui64NVX accept semaphore object names as input in 
+    <semaphoreArray> that were created by CreateProgressFenceNVX or imported
+    from a handle of the type HANDLE_TYPE_D3D12_FENCE_EXT. 
+    If a value in <semaphoreArray> is not the name of such a semaphore object, 
+    an INVALID_VALUE error is generated.
+    
+    The command
+
+      boolean IsSemaphoreEXT(uint semaphore);
+
+    can be used with progress fence semaphores and returns TRUE if <semaphore>
+    is the name of a semaphore as defined in EXT_external_objects.
+
+Issues
+
+    1) Are Vulkan semaphores imported via the GL_EXT_memory_object_win32 supported
+       by GL_NVX_progress_fence as input parameters?
+
+       RESOLVED: No. As Vulkan semaphores currently do not support progress fence
+       operation, these are not compatible with progress fence semaphores.
+
+Revision History
+
+    Revision 1, 2018-08-14 (Ralf Biermann)
+        - Initial specification proposal.
+
+    Revision 2, 2018-08-15 (Ralf Biermann)
+        - Adding Vulkan semaphore limitation to Issues.

--- a/extensions/arbext.php
+++ b/extensions/arbext.php
@@ -419,4 +419,6 @@
 </li>
 <li value=195><a href="extensions/ARB/ARB_texture_filter_anisotropic.txt">GL_ARB_texture_filter_anisotropic</a>
 </li>
+<li value=196><a href="extensions/KHR/KHR_shader_subgroup.txt">GL_KHR_shader_subgroup</a>
+</li>
 </ol>

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -665,4 +665,8 @@
 </li>
 <li value=320><a href="extensions/EXT/EXT_texture_shadow_lod.txt">GL_EXT_texture_shadow_lod</a>
 </li>
+<li value=321><a href="extensions/KHR/KHR_shader_subgroup.txt">GL_KHR_shader_subgroup</a>
+</li>
+<li value=322><a href="extensions/NV/NV_shader_subgroup_partitioned.txt">GL_NV_shader_subgroup_partitioned</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1019,4 +1019,10 @@
 </li>
 <li value=540><a href="extensions/MESA/MESA_framebuffer_flip_y.txt">GL_MESA_framebuffer_flip_y</a>
 </li>
+<li value=541><a href="extensions/NVX/NVX_progress_fence.txt">GL_NVX_progress_fence</a>
+</li>
+<li value=542><a href="extensions/NV/WGL_NV_multigpu_context.txt">WGL_NV_multigpu_context</a>
+</li>
+<li value=543><a href="extensions/NVX/NVX_gpu_multicast2.txt">GL_NVX_gpu_multicast2</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1025,4 +1025,6 @@
 </li>
 <li value=543><a href="extensions/NVX/NVX_gpu_multicast2.txt">GL_NVX_gpu_multicast2</a>
 </li>
+<li value=544><a href="extensions/NV/NV_shader_subgroup_partitioned.txt">GL_NV_shader_subgroup_partitioned</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2935,6 +2935,12 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/KHR/KHR_robustness.txt',
     },
+    'GL_KHR_shader_subgroup' : {
+        'arbnumber' : 196,
+        'esnumber' : 321,
+        'flags' : { 'public' },
+        'url' : 'extensions/KHR/KHR_shader_subgroup.txt',
+    },
     'GL_KHR_texture_compression_astc_hdr' : {
         'arbnumber' : 118,
         'esnumber' : 117,
@@ -3743,6 +3749,12 @@ registry = {
         'number' : 448,
         'flags' : { 'public' },
         'url' : 'extensions/NV/NV_shader_thread_shuffle.txt',
+    },
+    'GL_NV_shader_subgroup_partitioned' : {
+        'number' : 544,
+        'esnumber' : 322,
+        'flags' : { 'public' },
+        'url' : 'extensions/NV/NV_shader_subgroup_partitioned.txt',
     },
     'GL_NV_shading_rate_image' : {
         'number' : 531,

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3422,6 +3422,18 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/NV/NV_gpu_multicast.txt',
     },
+    'GL_NVX_gpu_multicast2' : {
+        'number' : 543,
+        'flags' : { 'public' },
+        'supporters' : { 'NVIDIA' },
+        'url' : 'extensions/NVX/NVX_gpu_multicast2.txt',
+    },
+    'GL_NVX_progress_fence' : {
+        'number' : 541,
+        'flags' : { 'public' },
+        'supporters' : { 'NVIDIA' },
+        'url' : 'extensions/NVX/NVX_progress_fence.txt',
+    },
     'GL_NV_gpu_program4' : {
         'number' : 322,
         'flags' : { 'public' },
@@ -5513,5 +5525,11 @@ registry = {
         'flags' : { 'public' },
         'supporters' : { 'KHR' },
         'url' : 'extensions/OML/WGL_OML_sync_control.txt',
+    },
+    'WGL_NV_multigpu_context' : {
+        'number' : 542,
+        'flags' : { 'public' },
+        'supporters' : { 'NVIDIA' },
+        'url' : 'extensions/NV/WGL_NV_multigpu_context.txt',
     },
 }

--- a/xml/genheaders.py
+++ b/xml/genheaders.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2013-2018 The Khronos Group Inc.
 #

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10914,7 +10914,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9547" name="GL_QUERY_RESOURCE_BUFFEROBJECT_NV"/>
         <enum value="0x9548" name="GL_PER_GPU_STORAGE_NV"/>
         <enum value="0x9549" name="GL_MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV"/>
-            <unused start="0x954A" end="0x954C" vendor="NV"/>
+        <enum value="0x954A" name="GL_UPLOAD_GPU_MASK_NVX"/>
+            <unused start="0x954B" end="0x954C" vendor="NV"/>
         <enum value="0x954D" name="GL_CONSERVATIVE_RASTER_MODE_NV"/>
         <enum value="0x954E" name="GL_CONSERVATIVE_RASTER_MODE_POST_SNAP_NV"/>
         <enum value="0x954F" name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV"/>
@@ -11276,6 +11277,48 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLuint</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLuint</ptype> <name>glAsyncCopyBufferSubDataNVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>waitSemaphoreCount</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint</ptype> *<name>waitSemaphoreArray</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
+            <param><ptype>GLuint</ptype> <name>readGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>writeGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>readBuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>writeBuffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>readOffset</name></param>
+            <param><ptype>GLintptr</ptype> <name>writeOffset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLsizei</ptype> <name>signalSemaphoreCount</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint</ptype> *<name>signalSemaphoreArray</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint64</ptype> *<name>signalValueArray</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLuint</ptype> <name>glAsyncCopyImageSubDataNVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>waitSemaphoreCount</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint</ptype> *<name>waitSemaphoreArray</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint64</ptype> *<name>waitValueArray</name></param>
+            <param><ptype>GLuint</ptype> <name>srcGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>dstGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>srcName</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLint</ptype> <name>srcLevel</name></param>
+            <param><ptype>GLint</ptype> <name>srcX</name></param>
+            <param><ptype>GLint</ptype> <name>srcY</name></param>
+            <param><ptype>GLint</ptype> <name>srcZ</name></param>
+            <param><ptype>GLuint</ptype> <name>dstName</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLint</ptype> <name>dstLevel</name></param>
+            <param><ptype>GLint</ptype> <name>dstX</name></param>
+            <param><ptype>GLint</ptype> <name>dstY</name></param>
+            <param><ptype>GLint</ptype> <name>dstZ</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcWidth</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcHeight</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcDepth</name></param>
+            <param><ptype>GLsizei</ptype> <name>signalSemaphoreCount</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint</ptype> *<name>signalSemaphoreArray</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint64</ptype> *<name>signalValueArray</name></param>
         </command>
         <command>
             <proto>void <name>glAsyncMarkerSGIX</name></proto>
@@ -12540,6 +12583,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClientAttribDefaultEXT</name></proto>
             <param group="ClientAttribMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
+        </command>
+        <command>
+            <proto>void <name>glClientWaitSemaphoreui64NVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
         </command>
         <command>
             <proto group="SyncStatus"><ptype>GLenum</ptype> <name>glClientWaitSync</name></proto>
@@ -14288,6 +14337,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCreateProgramPipelines</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param len="n"><ptype>GLuint</ptype> *<name>pipelines</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLuint</ptype> <name>glCreateProgressFenceNVX</name></proto>
         </command>
         <command>
             <proto>void <name>glCreateQueries</name></proto>
@@ -23006,6 +23058,27 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
+            <proto>void <name>glMulticastScissorArrayvNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastViewportArrayvNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="COMPSIZE(count)">const <ptype>GLfloat</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastViewportPositionWScaleNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <param><ptype>GLfloat</ptype> <name>xcoeff</name></param>
+            <param><ptype>GLfloat</ptype> <name>ycoeff</name></param>
+        </command>
+        <command>
             <proto>void <name>glMulticastWaitSyncNV</name></proto>
             <param><ptype>GLuint</ptype> <name>signalGpu</name></param>
             <param><ptype>GLbitfield</ptype> <name>waitGpuMask</name></param>
@@ -27213,6 +27286,13 @@ typedef unsigned int GLhandleARB;
             <param group="TextureLayout" len="COMPSIZE(numTextureBarriers)">const <ptype>GLenum</ptype> *<name>dstLayouts</name></param>
         </command>
         <command>
+            <proto>void <name>glSignalSemaphoreui64NVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>signalGpu</name></param>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
+        </command>
+        <command>
             <proto>void <name>glSpecializeShader</name></proto>
             <param><ptype>GLuint</ptype> <name>shader</name></param>
             <param>const <ptype>GLchar</ptype> *<name>pEntryPoint</name></param>
@@ -30255,6 +30335,10 @@ typedef unsigned int GLhandleARB;
             <param group="PreserveModeATI"><ptype>GLenum</ptype> <name>preserve</name></param>
         </command>
         <command>
+            <proto>void <name>glUploadGpuMaskNVX</name></proto>
+            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
+        </command>
+        <command>
             <proto>void <name>glUseProgram</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
         </command>
@@ -32836,6 +32920,13 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>numTextureBarriers</name></param>
             <param len="COMPSIZE(numTextureBarriers)">const <ptype>GLuint</ptype> *<name>textures</name></param>
             <param group="TextureLayout" len="COMPSIZE(numTextureBarriers)">const <ptype>GLenum</ptype> *<name>srcLayouts</name></param>
+        </command>
+        <command>
+            <proto>void <name>glWaitSemaphoreui64NVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>waitGpu</name></param>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
         </command>
         <command>
             <proto>void <name>glWaitSync</name></proto>
@@ -47826,7 +47917,7 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_NVX_gpu_multicast2" supported="gl">
             <require>
-                <enum name="GL_UPLOAD_GPU_MASK_NV"/>
+                <enum name="GL_UPLOAD_GPU_MASK_NVX"/>
                 <command name="glUploadGpuMaskNVX"/>
                 <command name="glMulticastViewportArrayvNVX"/>
                 <command name="glMulticastViewportPositionWScaleNVX"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -2990,6 +2990,18 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_ALL_SHADER_BITS_EXT"/>
         </group>
 
+        <group name="SubgroupSupportedFeatures">
+            <enum name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
+        </group>
+
         <group name="VertexPointerType">
             <enum name="GL_DOUBLE"/>
             <enum name="GL_FLOAT"/>
@@ -4414,6 +4426,18 @@ typedef unsigned int GLhandleARB;
         <enum value="0x00000080" name="GL_TASK_SHADER_BIT_NV"/>
         <enum value="0xFFFFFFFF" name="GL_ALL_SHADER_BITS"/>
         <enum value="0xFFFFFFFF" name="GL_ALL_SHADER_BITS_EXT"/>
+    </enums>
+
+    <enums namespace="GL" group="SubgroupSupportedFeatures" type="bitmask">
+        <enum value="0x00000001" name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+        <enum value="0x00000002" name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+        <enum value="0x00000004" name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+        <enum value="0x00000008" name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+        <enum value="0x00000010" name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+        <enum value="0x00000020" name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+        <enum value="0x00000040" name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+        <enum value="0x00000080" name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+        <enum value="0x00000100" name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
     </enums>
 
     <!-- Bitmasks defined by vendor extensions -->
@@ -10893,7 +10917,10 @@ typedef unsigned int GLhandleARB;
     <enums namespace="GL" start="0x9530" end="0x962F" vendor="NV" comment="Khronos bug 12977">
         <enum value="0x9530" name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
         <enum value="0x9531" name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
-            <unused start="0x9532" end="0x9535" vendor="NV"/>
+        <enum value="0x9532" name="GL_SUBGROUP_SIZE_KHR"/>
+        <enum value="0x9533" name="GL_SUBGROUP_SUPPORTED_STAGES_KHR"/>
+        <enum value="0x9534" name="GL_SUBGROUP_SUPPORTED_FEATURES_KHR"/>
+        <enum value="0x9535" name="GL_SUBGROUP_QUAD_ALL_STAGES_KHR"/>
         <enum value="0x9536" name="GL_MAX_MESH_TOTAL_MEMORY_SIZE_NV"/>
         <enum value="0x9537" name="GL_MAX_TASK_TOTAL_MEMORY_SIZE_NV"/>
         <enum value="0x9538" name="GL_MAX_MESH_OUTPUT_VERTICES_NV"/>
@@ -46975,6 +47002,22 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetnUniformuivKHR"/>
             </require>
         </extension>
+        <extension name="GL_KHR_shader_subgroup" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SUBGROUP_SIZE_KHR"/>
+                <enum name="GL_SUBGROUP_SUPPORTED_STAGES_KHR"/>
+                <enum name="GL_SUBGROUP_SUPPORTED_FEATURES_KHR"/>
+                <enum name="GL_SUBGROUP_QUAD_ALL_STAGES_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+            </require>
+        </extension>
         <extension name="GL_KHR_texture_compression_astc_hdr" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_COMPRESSED_RGBA_ASTC_4x4_KHR"/>
@@ -48594,6 +48637,11 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_NV_shader_noperspective_interpolation" supported="gles2"/>
         <extension name="GL_NV_shader_storage_buffer_object" supported="gl"/>
+        <extension name="GL_NV_shader_subgroup_partitioned" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
+            </require>
+        </extension>
         <extension name="GL_NV_shader_texture_footprint" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_shader_thread_group" supported="gl|glcore">
             <require>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -47824,6 +47824,25 @@ typedef unsigned int GLhandleARB;
                 <command name="glMulticastGetQueryObjectui64vNV"/>
             </require>
         </extension>
+        <extension name="GL_NVX_gpu_multicast2" supported="gl">
+            <require>
+                <enum name="GL_UPLOAD_GPU_MASK_NV"/>
+                <command name="glUploadGpuMaskNVX"/>
+                <command name="glMulticastViewportArrayvNVX"/>
+                <command name="glMulticastViewportPositionWScaleNVX"/>
+                <command name="glMulticastScissorArrayvNVX"/>
+                <command name="glAsyncCopyBufferSubDataNVX"/>
+                <command name="glAsyncCopyImageSubDataNVX"/>
+            </require>
+        </extension>
+        <extension name="GL_NVX_progress_fence" supported="gl">
+            <require>
+                <command name="glCreateProgressFenceNVX"/>
+                <command name="glSignalSemaphoreui64NVX"/>
+                <command name="glWaitSemaphoreui64NVX"/>
+                <command name="glClientWaitSemaphoreui64NVX"/>
+            </require>
+        </extension>
         <extension name="GL_NV_memory_attachment" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_ATTACHED_MEMORY_OBJECT_NV"/>

--- a/xml/wgl.xml
+++ b/xml/wgl.xml
@@ -1985,5 +1985,14 @@ Registry at
                 <command name="wglWaitForSbcOML"/>
             </require>
         </extension>
+        <extension name="WGL_NV_multigpu_context" supported="wgl">
+            <require>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
+            </require>
+        </extension>
     </extensions>
 </registry>

--- a/xml/wgl.xml
+++ b/xml/wgl.xml
@@ -384,7 +384,12 @@ Registry at
         <enum value="0x20A8"        name="WGL_TYPE_RGBA_UNSIGNED_FLOAT_EXT"/>
         <enum value="0x20A9"        name="WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB"/>
         <enum value="0x20A9"        name="WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT"/>
-            <unused start="0x20AA" end="0x20AF"/>
+        <enum value="0x20AA"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+        <enum value="0x20AB"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+        <enum value="0x20AC"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+        <enum value="0x20AD"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+        <enum value="0x20AE"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
+            <unused start="0x20AF" end="0x20AF"/>
         <enum value="0x20B0"        name="WGL_FLOAT_COMPONENTS_NV"/>
         <enum value="0x20B1"        name="WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_R_NV"/>
         <enum value="0x20B2"        name="WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_RG_NV"/>


### PR DESCRIPTION
Replaces #287, since I can't update @rbiermann's branch in-place in their repository. Changes one extension number to avoid collision with recently merged MESA extension. I was unable to clone their branch into this repo and successfully merge it - some sort of commit history incompatibility - so just did a patch against master in this branch, instead. 

@dgkoch @pdaniell-nv I suggest adding the KHR extension to this branch.

Unfortunately, the changes in #287 directly updated the headers rather than adding the new interfaces to gl.xml / wgl.xml. As a result regenerating the headers will not actually include the interfaces for the new extensions. If you can attempt to add the interfaces for the new extensions introduced in #287 that would be great. If not I'll attempt to do it, but I can't guarantee I'll have time by Sunday evening, with the Vulkan update taking up my time. In terms of just publishing the specs, the branch should be fine as is.