### PR TITLE
The key word of FLOAT16_MAT4x3_AMD should should be f16mat4x3

### DIFF
--- a/extensions/AMD/AMD_gpu_shader_half_float.txt
+++ b/extensions/AMD/AMD_gpu_shader_half_float.txt
@@ -122,7 +122,7 @@ Additions to Chapter 7 of the OpenGL 4.5 (Core Profile) Specification
     | FLOAT16_MAT3x2_AMD         | f16mat3x2      |  *   |  *   |  *   |
     | FLOAT16_MAT3x4_AMD         | f16mat3x4      |  *   |  *   |  *   |
     | FLOAT16_MAT4x2_AMD         | f16mat4x2      |  *   |  *   |  *   |
-    | FLOAT16_MAT4x3_AMD         | f16mat4x2      |  *   |  *   |  *   |
+    | FLOAT16_MAT4x3_AMD         | f16mat4x3      |  *   |  *   |  *   |
     +----------------------------+----------------+------+------+------+
 
 


### PR DESCRIPTION
It's a document issue.