### PR TITLE
Clarify EGL_EXT_image_dma_buf_import / EXT_EGL_image_storage interact…

### DIFF
--- a/extensions/EXT/EXT_EGL_image_storage.txt
+++ b/extensions/EXT/EXT_EGL_image_storage.txt
@@ -17,6 +17,7 @@ Contributors
     Jesse Hall, Google
     Jan-Harald Fredriksen, ARM
     Daniel Koch, Nvidia
+    Gurchetan Singh, Google
 
 Status
 
@@ -24,7 +25,7 @@ Status
 
 Version
 
-    February 7, 2018 (version 7)
+    August 22, 2019 (version 8)
 
 Number
 
@@ -40,9 +41,10 @@ Dependencies
 
     The EGL_KHR_gl_texture_2D_image, EGL_KHR_gl_texture_cubemap_image,
     EGL_KHR_gl_texture_3D_image, EGL_KHR_gl_renderbuffer_image,
-    EGL_KHR_vg_parent_image, and EGL_ANDROID_get_native_client_buffer
-    extensions provide additional functionality layered on EGL_KHR_image_base
-    and related to this extension.
+    EGL_KHR_vg_parent_image, EGL_ANDROID_get_native_client_buffer,
+    EGL_EXT_image_dma_buf_import and EGL_EXT_image_gl_colorspace extensions
+    provide additional functionality layered on EGL_KHR_image_base and
+    related to this extension.
 
     EXT_direct_state_access, ARB_direct_state_access, and OpenGL 4.5 affect
     the definition of this extension.
@@ -140,6 +142,18 @@ Samplers)
     eglImageOES, or <target> is GL_TEXTURE_2D but <image> contains a cube map),
     the error INVALID_OPERATION is generated.
 
+    If the EGL image was created using EGL_EXT_image_dma_buf_import, then the
+    following applies:
+
+        - <target> must be GL_TEXTURE_2D or GL_TEXTURE_EXTERNAL_OES. Otherwise,
+          the error INVALID_OPERATION is generated.
+        - if <target> is GL_TEXTURE_2D, then the resultant texture must have a
+          sized internal format which is colorspace and size compatible with the
+          dma-buf. If the GL is unable to determine such a format, the error
+          INVALID_OPERATION is generated.
+        - if <target> is GL_TEXTURE_EXTERNAL_OES, the internal format of the
+          texture is implementation defined.
+
     If <attrib_list> is neither NULL nor a pointer to the value GL_NONE, the
     error INVALID_VALUE is generated.
 
@@ -200,6 +214,8 @@ Issues
         through texture parameters would require more complex validation.
 
 Revision History
+
+    #8 (August 22, 2019) - Clarify interaction with EGL_EXT_image_dma_buf_import.
 
     #7 (February 7, 2018) - Amend the explanation of the attrib_list parameter.
 


### PR DESCRIPTION
EXT_image_dma_buf_import doesn't specify the internal format of the EGL image, since the dma-buf  could be a YUV buffer for example.  The concept of an internal format is a GL, not EGL, concept anyways.

Currently, many implementations just choose GL_RGBA when glEGLImageTargetTexture2DOES is called with a dma-buf EGLImage.  However, glTexStorage(..) explicitly requires sized internal formats upon creation.  We should clarify expectations around this use case.  