### PR TITLE
Adding GLX_NV_multigpu_context extension

### DIFF
--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20190728
+#define GLX_GLXEXT_VERSION 20190822
 
 /* Generated C header for:
  * API: glx
@@ -554,6 +554,15 @@ Bool glXDelayBeforeSwapNV (Display *dpy, GLXDrawable drawable, GLfloat seconds);
 #define GLX_NV_float_buffer 1
 #define GLX_FLOAT_COMPONENTS_NV           0x20B0
 #endif /* GLX_NV_float_buffer */
+
+#ifndef GLX_NV_multigpu_context
+#define GLX_NV_multigpu_context 1
+#define GLX_CONTEXT_MULTIGPU_ATTRIB_NV    0x20AA
+#define GLX_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV 0x20AB
+#define GLX_CONTEXT_MULTIGPU_ATTRIB_AFR_NV 0x20AC
+#define GLX_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV 0x20AD
+#define GLX_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV 0x20AE
+#endif /* GLX_NV_multigpu_context */
 
 #ifndef GLX_NV_multisample_coverage
 #define GLX_NV_multisample_coverage 1

--- a/extensions/NV/GLX_NV_multigpu_context.txt
+++ b/extensions/NV/GLX_NV_multigpu_context.txt
@@ -1,0 +1,142 @@
+Name
+
+    NV_multigpu_context
+
+Name Strings
+
+    GLX_NV_multigpu_context
+
+Contact
+
+    Ben Quest (bquest 'at' nvidia.com)
+
+Contributors
+
+    Ben Quest, NVIDIA
+    Joshua Schnarr, NVIDIA
+    Ralf Biermann, NVIDIA
+    Ingo Esser, NVIDIA
+    Robert Menzel, NVIDIA
+    James Jones, NVIDIA
+
+Notice
+
+    Copyright (c) 2019 NVIDIA
+
+Status
+
+    Complete.
+
+Version
+
+    Last Modified Date:         2019-05-17
+    Author Revision:            1
+
+Number
+
+    OpenGL Extension #545
+
+Dependencies
+
+    GLX_NV_multigpu_context is written against the GLX 1.4 and
+    GLX_ARB_create_context specifications. Both are required.
+
+    This extension interacts with NV_gpu_multicast.
+
+Overview
+
+    This extension allows the creation of an OpenGL context in a multi-GPU
+    environment with a specified multi-GPU strategy (known as SLI mode) which
+    takes precedence over process-wide multi-GPU mode settings.
+
+    The multi-GPU mode denotes vendor specific techniques to allow distributed
+    rendering on multiple GPUs, further called AFR (alternate frame rendering)
+    and Multicast (as defined in NV_gpu_multicast).
+
+    OpenGL supports multiple contexts. The semantics of switching contexts
+    is generally left to window system binding APIs such as WGL, GLX and EGL.
+    The extension GLX_NV_multigpu_context allows to specify a preferred
+    multi-GPU rendering mode per context, thus context switching can also
+    switch the current multi-GPU rendering mode.
+
+    In addition to the modes described above, this extension allows creating
+    contexts in single mode to force all rendering to be done on a single GPU,
+    and multi-display multicast mode to allow multicast rendering on a
+    multi-display configuration where displays attached to multiple GPUs are
+    linked together in a desktop configuration spanning multiple GPUs.
+
+    The implementation is platform dependent and the actual multi-GPU rendering
+    mode of the created context may vary on different hardware and operation
+    system platforms.
+
+New Procedures and Functions
+
+    None
+
+New Tokens (GLX)
+
+    Accepted as an attribute name in the <*attrib_list> argument to
+    glXCreateContextAttribsARB:
+
+        GLX_CONTEXT_MULTIGPU_ATTRIB_NV                         0x20AA
+
+    Accepted as an attribute value for GLX_CONTEXT_MULTIGPU_ATTRIB_NV in
+    the <*attrib_list> argument to glXCreateContextAttribsARB:
+
+        GLX_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV                  0x20AB
+        GLX_CONTEXT_MULTIGPU_ATTRIB_AFR_NV                     0x20AC
+        GLX_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV               0x20AD
+        GLX_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV 0x20AE
+
+Additions to the GLX 1.4 Specification
+
+    This extension modifies language specified in the GLX_ARB_create_context
+    extension.
+
+    Add a new paragraph to the description of glXCreateContextAttribsARB:
+
+    "The attribute name GLX_CONTEXT_MULTIGPU_ATTRIB_NV indicates the
+    preferred multi-GPU rendering mode for the OpenGL context.
+    This specified mode precedes other selected configuration settings."
+
+    Add a new context creation error to glXCreateContextAttribsARB:
+
+    "If attribute GLX_CONTEXT_MULTIGPU_ATTRIB_NV does not describe a valid and
+    supported SLI rendering mode, BadValue is generated."
+
+    Append a new paragraph to the end of section 3.5 "Rendering Contexts":
+
+    "When multiple contexts created with a multigpu context attribute are being
+    used, glXMakeCurrent and glXMakeContextCurrent will return FALSE if the
+    GLXDrawable is already current with a context using a different multigpu
+    attribute."
+
+GLX Errors
+
+    BadValue is generated if GLX_CONTEXT_MULTIGPU_ATTRIB_NV does not describe a
+    valid and supported SLI rendering mode.
+
+    GLXBadContextState is generated if glXMakeCurrent is called with a context
+    created with a different multigpu attribute than the context previously
+    current to the drawable.
+
+GLX Protocol
+
+    None
+
+New State
+
+    None
+
+Issues
+
+    All non-window-system dependent issues described in the
+    WGL_NV_multigpu_context extension specification apply equally to
+    GLX_NV_multigpu_context.
+
+Revision History
+
+ Rev.   Date      Author    Changes
+ ---- ----------  --------  ---------------------------------------------
+   1  2019-05-17  bquest    Fork from WGL_NV_multigpu_context
+

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1027,4 +1027,6 @@
 </li>
 <li value=544><a href="extensions/NV/NV_shader_subgroup_partitioned.txt">GL_NV_shader_subgroup_partitioned</a>
 </li>
+<li value=545><a href="extensions/NV/GLX_NV_multigpu_context.txt">GLX_NV_multigpu_context</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -5544,4 +5544,10 @@ registry = {
         'supporters' : { 'NVIDIA' },
         'url' : 'extensions/NV/WGL_NV_multigpu_context.txt',
     },
+    'GLX_NV_multigpu_context' : {
+        'number' : 545,
+        'flags' : { 'public' },
+        'supporters' : { 'NVIDIA' },
+        'url' : 'extensions/NV/GLX_NV_multigpu_context.txt',
+    },
 }

--- a/xml/glx.xml
+++ b/xml/glx.xml
@@ -387,6 +387,11 @@ typedef unsigned __int64 uint64_t;
     </enums>
 
     <enums namespace="GLX" start="0x20A0" end="0x219F" vendor="NV" comment="Shared with WGL">
+        <enum value="0x20AA"        name="GLX_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+        <enum value="0x20AB"        name="GLX_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+        <enum value="0x20AC"        name="GLX_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+        <enum value="0x20AD"        name="GLX_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+        <enum value="0x20AE"        name="GLX_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
         <enum value="0x20B0"        name="GLX_FLOAT_COMPONENTS_NV"/>
         <enum value="0x20B1"        name="GLX_RGBA_UNSIGNED_FLOAT_TYPE_EXT"/>
         <enum value="0x20B2"        name="GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB"/>
@@ -2196,6 +2201,15 @@ typedef unsigned __int64 uint64_t;
         <extension name="GLX_SUN_get_transparent_index" supported="glx">
             <require>
                 <command name="glXGetTransparentIndexSUN"/>
+            </require>
+        </extension>
+        <extension name="GLX_NV_multigpu_context" supported="glx">
+            <require>
+                <enum name="GLX_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+                <enum name="GLX_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+                <enum name="GLX_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+                <enum name="GLX_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+                <enum name="GLX_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Adding GLX_NV_multigpu_context extension, see https://github.com/KhronosGroup/OpenGL-Registry/pull/287 for the WGL equivalent.  Please review and merge.

Thanks,
Ben Quest (NVIDIA)