### PR TITLE
ARB_framebuffer_sRGB: Clarify interaction with GLX

### DIFF
--- a/extensions/ARB/ARB_framebuffer_sRGB.txt
+++ b/extensions/ARB/ARB_framebuffer_sRGB.txt
@@ -21,6 +21,7 @@ Contributors
     Yanjun Zhang, S3 Graphics
     Jeremy Sandmel, Apple
     Jon Leech
+    Adam Jackson, Red Hat
 
 Contact
 
@@ -47,8 +48,8 @@ Status
 
 Version
 
-    Date: August 11, 2008
-    Revision: 1.2
+    Date: September 19, 2019
+    Revision: 1.3
 
 Number
 
@@ -111,8 +112,9 @@ New Procedures and Functions
 
 New Tokens
 
-    Accepted by the <attribList> parameter of glXChooseVisual, and by
-    the <attrib> parameter of glXGetConfig:
+    Accepted by the <attribList> parameter of glXChooseVisual and
+    glXChooseFBConfig, and by the <attrib> parameter of glXGetConfig
+    and glXGetFBConfigAttrib:
 
         GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB             0x20B2
 
@@ -244,7 +246,10 @@ Additions to the OpenGL Shading Language specification
 
 Additions to the GLX Specification
 
-    None
+    If GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB is specified for glXChooseVisual or
+    glXChooseFBConfig, it is treated as an exact match. If it is not specified,
+    it is treated as GLX_DONT_CARE. Sorting of visuals and fbconfigs by
+    GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB is undefined.
 
 Dependencies on ARB_color_buffer_float
 
@@ -601,6 +606,7 @@ Revision History
 
         Rev.    Date    Author    Changes
         ----  --------  --------  -------------------------------------
+         1.3  09/19/19  ajax      Clarify GLX interaction.
          1.2  08/11/08  jleech    Use per-FBO-attachment state for
                                   sRGB-capable queries, rather then the
                                   EXT's single boolean query for the


### PR DESCRIPTION
Update the text to mention the GLX 1.3 entrypoints and specify the
selection and sorting behavior.

Resolves: https://github.com/KhronosGroup/OpenGL-Registry/issues/199