### PR TITLE
[gl.xml] Add GL_NONE to ReadBufferMode

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -2940,6 +2940,8 @@ typedef unsigned int GLhandleARB;
         </group>
 
         <group name="ReadBufferMode">
+            <enum name="GL_NONE"/>
+            <enum name="GL_NONE_OES"/>
             <enum name="GL_AUX0"/>
             <enum name="GL_AUX1"/>
             <enum name="GL_AUX2"/>


### PR DESCRIPTION
`ReadbufferMode` should include `GL_NONE`.

Fix proposal for #315 