### PR TITLE
SGIX_fragment_specular_lighting const getter fixup

### DIFF
--- a/extensions/SGIX/SGIX_fragment_specular_lighting.txt
+++ b/extensions/SGIX/SGIX_fragment_specular_lighting.txt
@@ -127,8 +127,8 @@ New Procedures and Functions
 
     void FragmentColorMaterialSGIX(enum face, enum mode);
 
-    void GetFragmentMaterialfvSGIX(enum face, enum pname, const float *data);
-    void GetFragmentMaterialivSGIX(enum face, enum pname, const int *data);
+    void GetFragmentMaterialfvSGIX(enum face, enum pname, float *data);
+    void GetFragmentMaterialivSGIX(enum face, enum pname, int *data);
 
 New Tokens
 


### PR DESCRIPTION
Align this extension with the XML/glext.h:

```
    void GetFragmentMaterialfvSGIX(enum face, enum pname, float *data);
    void GetFragmentMaterialivSGIX(enum face, enum pname, int *data);
```

```
typedef void (APIENTRYP PFNGLGETFRAGMENTMATERIALFVSGIXPROC) (GLenum face, GLenum pname, GLfloat *params);
typedef void (APIENTRYP PFNGLGETFRAGMENTMATERIALIVSGIXPROC) (GLenum face, GLenum pname, GLint *params);
```
 
In relation to https://github.com/nigels-com/glew/pull/239