### PR TITLE
[gl.xml] add glGetInteger64vEXT to EXT_disjoint_timer_query

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18216,6 +18216,12 @@ typedef unsigned int GLhandleARB;
             <alias name="glGetInteger64v"/>
         </command>
         <command>
+            <proto>void <name>glGetInteger64vEXT</name></proto>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>data</name></param>
+            <alias name="glGetInteger64v"/>
+        </command>
+        <command>
             <proto>void <name>glGetIntegerIndexedvEXT</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
@@ -45003,6 +45009,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetQueryObjectuivEXT"/>
                 <command name="glGetQueryObjecti64vEXT"/>
                 <command name="glGetQueryObjectui64vEXT"/>
+                <command name="glGetInteger64vEXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_draw_buffers" supported="gles2">


### PR DESCRIPTION
From EXT_disjoint_timer_query spec:
   "Interaction: This extension adds GetInteger64vEXT if
    OpenGL ES 3.0 is not supported"

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>