### PR TITLE
Tidy-up for NV_alpha_to_coverage_dither_control extension specification

### DIFF
--- a/extensions/NV/NV_alpha_to_coverage_dither_control.txt
+++ b/extensions/NV/NV_alpha_to_coverage_dither_control.txt
@@ -43,7 +43,7 @@ Overview
 
 New Procedures and Functions
 
-    AlphaToCoverageDitherControlNV(enum mode):.
+    void AlphaToCoverageDitherControlNV(enum mode)
     
 New Tokens
 


### PR DESCRIPTION
Resolution for GLEW Issue: https://github.com/nigels-com/glew/issues/245

Align `AlphaToCoverageDitherControlNV` specification with norms.