### PR TITLE
const fixup for ARB_direct_state_access ClearNamedFramebufferfv value

### DIFF
--- a/extensions/ARB/ARB_direct_state_access.txt
+++ b/extensions/ARB/ARB_direct_state_access.txt
@@ -220,7 +220,7 @@ New Procedures and Functions
                                   int drawbuffer, const uint *value);
 
     void ClearNamedFramebufferfv(uint framebuffer, enum buffer,
-                                 int drawbuffer, float *value);
+                                 int drawbuffer, const float *value);
 
     void ClearNamedFramebufferfi(uint framebuffer, enum buffer,
                                  int drawbuffer, float depth, int stencil);


### PR DESCRIPTION
Aligning with `glext.h`

```
GLAPI void APIENTRY glClearNamedFramebufferfv (GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLfloat *value);
```

In relation to https://github.com/nigels-com/glew/issues/246