### PR TITLE
Fix "shared p-bits" specification in EXT_texture_compression_bptc

### DIFF
--- a/extensions/EXT/EXT_texture_compression_bptc.txt
+++ b/extensions/EXT/EXT_texture_compression_bptc.txt
@@ -28,8 +28,8 @@ Status
 
 Version
 
-    Last Modified Date:         April 7, 2017
-    Revision:                   1
+    Last Modified Date:         December 10, 2019
+    Revision:                   2
 
 Number
 
@@ -290,15 +290,16 @@ Appendix
     subset, then green and blue stored similarly. If a block has non-zero
     alpha bits, the alpha data follows the color data with the same
     organization. If not, alpha is overridden to 1.0. These bits are treated
-    as the high bits of a fixed-point value in a byte. If the format has a
-    shared P-bit, there are two bits for endpoints 0 and 1 from low to
-    high. If the format has a per-endpoint P-bits, then there are 2*subsets
-    P-bits stored in the same order as color and alpha. Both kinds of P-bits
-    are added as a bit below the color data stored in the byte. So, for a
-    format with 5 red bits, the P-bit ends up in bit 2. For final scaling, the
-    top bits of the value are replicated into any remaining bits in the
-    byte. For the preceding example, bits 6 and 7 would be written to bits 0
-    and 1.
+    as the high bits of a fixed-point value in a byte. If the format has
+    shared P-bits, there are two endpoint bits, the lower of which applies to
+    both endpoints of subset 0 and the upper of which applies to both
+    endpoints of subset 1. If the format has a per-endpoint P-bits, then there
+    are 2*subsets P-bits stored in the same order as color and alpha. Both
+    kinds of P-bits are added as a bit below the color data stored in the
+    byte. So, for a format with 5 red bits, the P-bit ends up in bit 2. For
+    final scaling, the top bits of the value are replicated into any remaining
+    bits in the byte. For the preceding example, bits 6 and 7 would be written
+    to bits 0 and 1.
 
     The endpoint colors are interpolated using index values stored in the
     block. The index bits are stored in x-major order. Each index has the
@@ -752,6 +753,8 @@ Revision History
 
     Rev.    Date    Author       Changes
     ----  --------  -----------  --------------------------------------------
+     2    12/10/19  pdaniell     Fix shared p-bits specification to match
+                                 DX and the Khronos Data Format spec.
+                                 
      1    04/10/17  jaschmidt    EXT version based on revision 9 of
                                  ARB_texture_compression_bptc
-


### PR DESCRIPTION
This is a follow-on to https://github.com/KhronosGroup/OpenGL-Registry/pull/322, which fixed the "shared p-bits" for ARB_texture_compression_bptc. This makes the same fix to the OpenGL ES EXT_texture_compression_bptc.
