### PR TITLE
Add missing interactions between ARB_viewport_array and NV_depth_buffer_float

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -48038,7 +48038,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MAX_DEEP_3D_TEXTURE_DEPTH_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_depth_buffer_float" supported="gl">
+        <extension name="GL_NV_depth_buffer_float" supported="gl|glcore">
             <require>
                 <enum name="GL_DEPTH_COMPONENT32F_NV"/>
                 <enum name="GL_DEPTH32F_STENCIL8_NV"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -15432,6 +15432,12 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="174"/>
         </command>
         <command>
+            <proto>void <name>glDepthRangeArraydvNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param>const <ptype>GLdouble</ptype> *<name>v</name></param>
+        </command>
+        <command>
             <proto>void <name>glDepthRangeArrayfvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
@@ -15451,6 +15457,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangeIndexed</name></proto>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <param><ptype>GLdouble</ptype> <name>n</name></param>
+            <param><ptype>GLdouble</ptype> <name>f</name></param>
+        </command>
+        <command>
+            <proto>void <name>glDepthRangeIndexeddNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLdouble</ptype> <name>n</name></param>
             <param><ptype>GLdouble</ptype> <name>f</name></param>
@@ -44024,6 +44036,10 @@ typedef unsigned int GLhandleARB;
                 <command name="glDepthRangeIndexed"/>
                 <command name="glGetFloati_v"/>
                 <command name="glGetDoublei_v"/>
+            </require>
+            <require comment="ARB_viewport_array interactions with NV_depth_buffer_float">
+                <command name="glDepthRangeArraydvNV"/>
+                <command name="glDepthRangeIndexeddNV"/>
             </require>
         </extension>
         <extension name="GL_ARB_window_pos" supported="gl">


### PR DESCRIPTION
# Related Issues
Closes #350 

# Thoughts
- It feels weird putting NVIDIA functions in an ARB extension. Perhaps this isn't the right place for them.
- ARB_viewport_array is supported on both the core and compatibility profiles, whereas NV_depth_buffer_float is only supported on the compatibility profile. I'm not sure whether it's appropriate for compatibility-only functions to be referenced from a core extension