### PR TITLE
Fix EXT_primitive_bounding_box name string

### DIFF
--- a/extensions/EXT/EXT_primitive_bounding_box.txt
+++ b/extensions/EXT/EXT_primitive_bounding_box.txt
@@ -4,7 +4,7 @@ Name
 
 Name Strings
 
-    GL_EXT_primitive_bounding box
+    GL_EXT_primitive_bounding_box
 
 Contact
 


### PR DESCRIPTION
It is unexpected that name string would have space in it.

Fix proposal for #372 