### PR TITLE
Reserve enums 0x96C0..0x96CF for Arm

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20200221
+#define GL_GLEXT_VERSION 20200312
 
 #include <KHR/khrplatform.h>
 

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20200221 */
+/* Generated on date 20200312 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20200221 */
+/* Generated on date 20200312 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200221 */
+/* Generated on date 20200312 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20200221 */
+/* Generated on date 20200312 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200221 */
+/* Generated on date 20200312 */
 
 /* Generated C header for:
  * API: gles2

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -11634,6 +11634,10 @@ typedef unsigned int GLhandleARB;
             <unused start="0x96B0" end="0x96BF" vendor="ANGLE"/>
     </enums>
 
+    <enums namespace="GL" start="0x96C0" end="0x96CF" vendor="ARM" comment="Contact Jan-Harald Fredriksen">
+            <unused start="0x96C0" end="0x96CF" vendor="ARM"/>
+    </enums>
+
 <!-- Enums reservable for future use. To reserve a new range, allocate one
      or more multiples of 16 starting at the lowest available point in this
      block and note it in a new <enums> block immediately above.
@@ -11643,8 +11647,8 @@ typedef unsigned int GLhandleARB;
      file) File requests in the Khronos Bugzilla, OpenGL project, Registry
      component. -->
 
-    <enums namespace="GL" start="0x96C0" end="99999" vendor="ARB" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
-        <unused start="0x96C0" end="99999" comment="RESERVED"/>
+    <enums namespace="GL" start="0x96D0" end="99999" vendor="ARB" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
+        <unused start="0x96D0" end="99999" comment="RESERVED"/>
     </enums>
 
 <!-- Historical large block allocations, all unused except (in older days) by IBM -->


### PR DESCRIPTION
More enums..

We have a few spare ones in the current Arm-reserved range, but I'd like a larger set of consecutive ones.