### PR TITLE
Fix typo in the New Procedures section of NV_shading_rate_image.

### DIFF
--- a/extensions/NV/NV_shading_rate_image.txt
+++ b/extensions/NV/NV_shading_rate_image.txt
@@ -24,8 +24,8 @@ Status
 
 Version
 
-    Last Modified:      March 15, 2019
-    Revision:           2
+    Last Modified:      March 16, 2020
+    Revision:           3
 
 Number
 
@@ -111,7 +111,7 @@ New Procedures and Functions
       void GetShadingRateImagePaletteNV(uint viewport, uint entry,
                                         enum *rate);
       void ShadingRateImageBarrierNV(boolean synchronize);
-      void ShadingRateImageBarrierNV(enum order);
+      void ShadingRateSampleOrderNV(enum order);
       void ShadingRateSampleOrderCustomNV(enum rate, uint samples,
                                           const int *locations);
       void GetShadingRateSampleLocationivNV(enum rate, uint samples,
@@ -1024,6 +1024,11 @@ Issues
     Also, please refer to issues in the GLSL extension specification.
 
 Revision History
+
+    Revision 3 (pbrown), March 16, 2020
+    - Fix cut-and-paste error in "New Procedures and Functions" incorrectly
+      listing ShadingRateSampleOrderNV as a second instance of
+      ShadingRateImageBarrier.
 
     Revision 2 (pknowles)
     - ES interactions.


### PR DESCRIPTION
The old version of the spec created a prototype for
ShadingRateSampleOrderNV by copy-pasting the definition for
ShadingRateImageBarrierNV.  Unfortunately, that copy-paste failed to
fix the function name, so we have two instances of
ShadingRateImageBarrierNV.