### PR TITLE
Add GL_MESA_framebuffer_flip_x and GL_MESA_framebuffer_swap_xy

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20200407
+#define GL_GLEXT_VERSION 20200408
 
 #include <KHR/khrplatform.h>
 

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -34,7 +34,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20200319
+#define GLX_GLXEXT_VERSION 20200408
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20200319 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20200319
+#define WGL_WGLEXT_VERSION 20200408
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20200407 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20200407 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200407 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -38,7 +38,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20200407 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: gles2
@@ -2459,6 +2459,11 @@ GL_APICALL void GL_APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint quer
 #endif
 #endif /* GL_INTEL_performance_query */
 
+#ifndef GL_MESA_framebuffer_flip_x
+#define GL_MESA_framebuffer_flip_x 1
+#define GL_FRAMEBUFFER_FLIP_X_MESA        0x8BBC
+#endif /* GL_MESA_framebuffer_flip_x */
+
 #ifndef GL_MESA_framebuffer_flip_y
 #define GL_MESA_framebuffer_flip_y 1
 #define GL_FRAMEBUFFER_FLIP_Y_MESA        0x8BBB
@@ -2469,6 +2474,11 @@ GL_APICALL void GL_APIENTRY glFramebufferParameteriMESA (GLenum target, GLenum p
 GL_APICALL void GL_APIENTRY glGetFramebufferParameterivMESA (GLenum target, GLenum pname, GLint *params);
 #endif
 #endif /* GL_MESA_framebuffer_flip_y */
+
+#ifndef GL_MESA_framebuffer_swap_xy
+#define GL_MESA_framebuffer_swap_xy 1
+#define GL_FRAMEBUFFER_SWAP_XY_MESA       0x8BBD
+#endif /* GL_MESA_framebuffer_swap_xy */
 
 #ifndef GL_MESA_program_binary_formats
 #define GL_MESA_program_binary_formats 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -44,7 +44,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200407 */
+/* Generated on date 20200408 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/MESA/MESA_framebuffer_flip_x.txt
+++ b/extensions/MESA/MESA_framebuffer_flip_x.txt
@@ -1,0 +1,92 @@
+Name
+
+    MESA_framebuffer_flip_x
+
+Name Strings
+
+    GL_MESA_framebuffer_flip_x
+
+Contact
+
+    Cici Ruan <ruanc@chromium.org>
+
+Contributors
+
+    Cici Ruan, Google
+    Kristian Kristensen‎, Google
+    Fritz Koenig, Google
+    Rob Clark, Google
+    Chad Versace, Google
+
+Status
+
+    Proposal
+
+Version
+
+    Last Modified Date: April 8, 2020
+    Revision: 1
+
+Number
+
+    OpenGL Extension 548
+    OpenGL ES Extension 327
+
+Dependencies
+
+    Requires OpenGL ES 3.1 or OpenGL 4.3 for FramebufferParameteri.
+
+Overview
+
+    This extension defines a new framebuffer parameter,
+    GL_FRAMEBUFFER_FLIP_X_MESA, that changes the behavior of the reads and
+    writes to the framebuffer attachment points. When
+    GL_FRAMEBUFFER_FLIP_X_MESA is GL_TRUE, render commands and pixel transfer
+    operations access the backing store of each attachment point with an
+    x-inverted coordinate system. This x-inversion is relative to the
+    coordinate system set when GL_FRAMEBUFFER_FLIP_X_MESA is GL_FALSE.
+
+    Access through TexSubImage2D and similar calls will notice the effect of
+    the flip when they are not attached to framebuffer objects because
+    GL_FRAMEBUFFER_FLIP_X_MESA is associated with the framebuffer object and
+    not the attachment points.
+
+    This extension is mainly for pre-rotation and recommended to use it with
+    MESA_framebuffer_flip_y and MESA_framebuffer_swap_xy to have rotated
+    result.
+
+IP Status
+
+    None
+
+Issues
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Types
+
+    None
+
+New Tokens
+
+    Accepted by the <pname> argument of FramebufferParameteri and
+    GetFramebufferParameteriv:
+
+        GL_FRAMEBUFFER_FLIP_X_MESA                      0x8BBC
+
+    Interactions with OpenGL ES 3.1 and any other versions and
+    extensions that provide the entry points FramebufferParameteri
+    and GetFramebufferParameteriv
+
+Errors
+
+    None
+
+Revision History
+
+    Version 1, 2020/04/08
+      - Initial draft (Cici Ruan)

--- a/extensions/MESA/MESA_framebuffer_swap_xy.txt
+++ b/extensions/MESA/MESA_framebuffer_swap_xy.txt
@@ -1,0 +1,98 @@
+Name
+
+    MESA_framebuffer_swap_xy
+
+Name Strings
+
+    GL_MESA_framebuffer_swap_xy
+
+Contact
+
+    Cici Ruan <ruanc@chromium.org>
+
+Contributors
+
+    Cici Ruan, Google
+    Kristian Kristensen‎, Google
+    Fritz Koenig, Google
+    Rob Clark, Google
+    Chad Versace, Google
+
+Status
+
+    Proposal
+
+Version
+
+    Last Modified Date: April 8, 2020
+    Revision: 1
+
+Number
+
+    OpenGL Extension 549
+    OpenGL ES Extension 328
+
+Dependencies
+
+    Requires OpenGL ES 3.1 or OpenGL 4.3 for FramebufferParameteri.
+
+Overview
+
+    This extension defines a new framebuffer parameter,
+    GL_FRAMEBUFFER_SWAP_XY_MESA, that changes the behavior of the reads and
+    writes to the framebuffer attachment points. When
+    GL_FRAMEBUFFER_SWAP_XY_MESA is GL_TRUE, render commands and pixel transfer
+    operations access the backing store of each attachment point with an
+    xy-swapped coordinate system. This xy-inversion is relative to the
+    coordinate system set when GL_FRAMEBUFFER_SWAP_XY_MESA is GL_FALSE.
+
+    Access through TexSubImage2D and similar calls will notice the effect of
+    the swap when they are not attached to framebuffer objects because
+    GL_FRAMEBUFFER_SWAP_XY_MESA is associated with the framebuffer object and
+    not the attachment points.
+
+    The application should notice the display width and height are also swapped
+    when GL_FRAMEBUFFER_SWAP_XY_MESA is GL_TRUE.
+
+    This extension is mainly for pre-rotation and recommended to use it with
+    MESA_framebuffer_flip_x and MESA_framebuffer_flip_y to have rotated
+    result.
+
+IP Status
+
+    None
+
+Issues
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Types
+
+    None
+
+New Tokens
+
+    Accepted by the <pname> argument of FramebufferParameteri and
+    GetFramebufferParameteriv:
+
+        GL_FRAMEBUFFER_SWAP_XY_MESA                      0x8BBD
+
+    Interactions with OpenGL ES 3.1 and any other versions and
+    extensions that provide the entry points FramebufferParameteri
+    and GetFramebufferParameteriv
+
+    Token GL_FRAMEBUFFER_SWAP_XY_MESA is accepted as the <pname> argument of
+    FramebufferParameteri and GetFramebufferParameteriv.
+
+Errors
+
+    None
+
+Revision History
+
+    Version 1, 2020/04/08
+      - Initial draft (Cici Ruan)

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -679,4 +679,8 @@
 </li>
 <li value=326><a href="extensions/QCOM/QCOM_motion_estimation.txt">GL_QCOM_motion_estimation</a>
 </li>
+<li value=327><a href="extensions/MESA/MESA_framebuffer_flip_x.txt">GL_MESA_framebuffer_flip_x</a>
+</li>
+<li value=328><a href="extensions/MESA/MESA_framebuffer_swap_xy.txt">GL_MESA_framebuffer_swap_xy</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1033,4 +1033,8 @@
 </li>
 <li value=547><a href="extensions/INTEL/INTEL_shader_integer_functions2.txt">GL_INTEL_shader_integer_functions2</a>
 </li>
+<li value=548><a href="extensions/MESA/MESA_framebuffer_flip_x.txt">GL_MESA_framebuffer_flip_x</a>
+</li>
+<li value=549><a href="extensions/MESA/MESA_framebuffer_swap_xy.txt">GL_MESA_framebuffer_swap_xy</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2989,12 +2989,26 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_copy_sub_buffer.txt',
     },
+    'GL_MESA_framebuffer_flip_x' : {
+        'number' : 548,
+        'esnumber' : 327,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_framebuffer_flip_x.txt',
+    },
     'GL_MESA_framebuffer_flip_y' : {
         'number' : 540,
         'esnumber' : 302,
         'flags' : { 'public' },
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/MESA_framebuffer_flip_y.txt',
+    },
+    'GL_MESA_framebuffer_swap_xy' : {
+        'number' : 549,
+        'esnumber' : 328,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_framebuffer_swap_xy.txt',
     },
     'GL_MESA_pack_invert' : {
         'number' : 300,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9291,6 +9291,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8BB9" name="GL_TILE_RASTER_ORDER_INCREASING_X_MESA"/>
         <enum value="0x8BBA" name="GL_TILE_RASTER_ORDER_INCREASING_Y_MESA"/>
         <enum value="0x8BBB" name="GL_FRAMEBUFFER_FLIP_Y_MESA"/>
+        <enum value="0x8BBC" name="GL_FRAMEBUFFER_FLIP_X_MESA" />
+        <enum value="0x8BBD" name="GL_FRAMEBUFFER_SWAP_XY_MESA" />
     </enums>
 
     <enums namespace="GL" start="0x8BC0" end="0x8BFF" vendor="QCOM" comment="Reassigned from AMD to QCOM">
@@ -47738,11 +47740,21 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
             </require>
         </extension>
+        <extension name="GL_MESA_framebuffer_flip_x" supported="gles2">
+            <require>
+                <enum name="GL_FRAMEBUFFER_FLIP_X_MESA"/>
+            </require>
+        </extension>
         <extension name="GL_MESA_framebuffer_flip_y" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_FRAMEBUFFER_FLIP_Y_MESA"/>
                 <command name="glFramebufferParameteriMESA"/>
                 <command name="glGetFramebufferParameterivMESA"/>
+            </require>
+        </extension>
+        <extension name="GL_MESA_framebuffer_swap_xy" supported="gles2">
+            <require>
+                <enum name="GL_FRAMEBUFFER_SWAP_XY_MESA"/>
             </require>
         </extension>
         <extension name="GL_MESA_pack_invert" supported="gl">


### PR DESCRIPTION
GL_MESA_framebuffer_swap_xy and GL_MESA_framebuffer_flip_x are used
together with GL_MESA_framebuffer_flip_y to implement the
pre-rotation feature.