### PR TITLE
ARB_texture_query_lod: update OpenGL version needed

### DIFF
--- a/extensions/ARB/ARB_texture_query_lod.txt
+++ b/extensions/ARB/ARB_texture_query_lod.txt
@@ -16,6 +16,7 @@ Contributors
     Pat Brown, NVIDIA
     Greg Roth, NVIDIA
     Eric Werness, NVIDIA
+    Alejandro Piñeiro, Igalia, SL
 
 Notice
 
@@ -28,8 +29,8 @@ Status
 
 Version
 
-    Last Modified Date:         04/10/2013
-    Revision:                   7
+    Last Modified Date:         04/22/2020
+    Revision:                   8
 
 Number
 
@@ -37,7 +38,7 @@ Number
 
 Dependencies
 
-    OpenGL 2.0 is required.
+    OpenGL 3.0 is required.
 
     OpenGL Shading Language 1.30 is required
 
@@ -233,6 +234,10 @@ Revision History
 
     Rev.    Date      Author    Changes
     ----  ----------  --------  -----------------------------------------
+    8     04/22/2020  apinheiro Update OpenGL version required, to be
+                                consistent with GLSL version required (internal API
+                                issue 124)
+
     7     04/10/2013  Jon Leech Add issue 3 regarding different spelling
                                 of "LOD" vs. "Lod" in extension & core.
 


### PR DESCRIPTION
The original requirement of OpenGL version 2.0 and OpenGL Shading
language version 1.30 was inconsistent, as it is not possible a driver
exposing both is not possible. Updating the OpenGL version required.

This fixes the internal API issue 124.