### PR TITLE
Fix parameter ref for glMultiDrawElementsBaseVertexEXT

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22597,7 +22597,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
-            <param><ptype>GLsizei</ptype> <name>primcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
             <alias name="glMultiDrawElementsBaseVertex"/>
         </command>


### PR DESCRIPTION
Renamed 'primcount' to 'drawcount' matching the naming in glMultiDrawElementsBaseVertex and fixing the referenced parameter in len argument as well, which used 'drawcount' already.