### PR TITLE
Fix/missing and wrong enums

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5937,7 +5937,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8010" name="GL_CONVOLUTION_1D_EXT" group="GetPName,ConvolutionTargetEXT,EnableCap"/>
         <enum value="0x8011" name="GL_CONVOLUTION_2D" group="ConvolutionTarget,ConvolutionTargetEXT"/>
         <enum value="0x8011" name="GL_CONVOLUTION_2D_EXT" group="GetPName,ConvolutionTargetEXT,EnableCap"/>
-        <enum value="0x8012" name="GL_SEPARABLE_2D" group="SeparableTargetEXT"/>
+        <enum value="0x8012" name="GL_SEPARABLE_2D" group="SeparableTarget,SeparableTargetEXT"/>
         <enum value="0x8012" name="GL_SEPARABLE_2D_EXT" group="SeparableTargetEXT,EnableCap,GetPName"/>
         <enum value="0x8013" name="GL_CONVOLUTION_BORDER_MODE" group="GetConvolutionParameter,ConvolutionParameterEXT"/>
         <enum value="0x8013" name="GL_CONVOLUTION_BORDER_MODE_EXT" group="GetConvolutionParameter,ConvolutionParameterEXT"/>
@@ -20827,7 +20827,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnSeparableFilter</name></proto>
-            <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>rowBufSize</name></param>
@@ -38078,6 +38078,7 @@ typedef unsigned int GLhandleARB;
             <command name="glReadnPixels"/>
         </require>
         <require profile="compatibility" comment="Reuse GL_ARB_robustness">
+            <enum name="GL_SEPARABLE_2D"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>
             <command name="glGetnMapiv"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6318,31 +6318,31 @@ typedef unsigned int GLhandleARB;
         <enum value="0x80D1" name="GL_POST_CONVOLUTION_COLOR_TABLE_SGI" group="GetPName,ColorTableTargetSGI,EnableCap"/>
         <enum value="0x80D2" name="GL_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI,EnableCap"/>
         <enum value="0x80D2" name="GL_POST_COLOR_MATRIX_COLOR_TABLE_SGI" group="GetPName,ColorTableTargetSGI,EnableCap"/>
-        <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE" group="ColorTableTarget"/>
+        <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE" group="ColorTableTargetSGI,ColorTableTarget"/>
         <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTarget"/>
+        <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTargetSGI,ColorTableTarget"/>
         <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTarget"/>
+        <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTargetSGI,ColorTableTarget"/>
         <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS" group="GetColorTableParameterPName,ColorTableParameterPName"/>
-        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS_SGI" group="GetColorTableParameterPName,ColorTableParameterPName"/>
-        <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI,GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
     </enums>
 
@@ -38078,18 +38078,6 @@ typedef unsigned int GLhandleARB;
             <command name="glReadnPixels"/>
         </require>
         <require profile="compatibility" comment="Reuse GL_ARB_robustness">
-            <enum name="GL_COLOR_TABLE"/>
-            <enum name="GL_POST_CONVOLUTION_COLOR_TABLE"/>
-            <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE"/>
-            <enum name="GL_PROXY_COLOR_TABLE"/>
-            <enum name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE"/>
-            <enum name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE"/>
-            <enum name="GL_CONVOLUTION_1D"/>
-            <enum name="GL_CONVOLUTION_2D"/>
-            <enum name="GL_SEPARABLE_2D"/>
-            <enum name="GL_HISTOGRAM"/>
-            <enum name="GL_PROXY_HISTOGRAM"/>
-            <enum name="GL_MINMAX"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>
             <command name="glGetnMapiv"/>
@@ -38102,6 +38090,20 @@ typedef unsigned int GLhandleARB;
             <command name="glGetnSeparableFilter"/>
             <command name="glGetnHistogram"/>
             <command name="glGetnMinmax"/>
+        </require>
+        <require profile="compatibility">
+            <enum name="GL_COLOR_TABLE"/>
+            <enum name="GL_POST_CONVOLUTION_COLOR_TABLE"/>
+            <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE"/>
+            <enum name="GL_PROXY_COLOR_TABLE"/>
+            <enum name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE"/>
+            <enum name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE"/>
+            <enum name="GL_CONVOLUTION_1D"/>
+            <enum name="GL_CONVOLUTION_2D"/>
+            <enum name="GL_SEPARABLE_2D"/>
+            <enum name="GL_HISTOGRAM"/>
+            <enum name="GL_PROXY_HISTOGRAM"/>
+            <enum name="GL_MINMAX"/>
         </require>
         <require comment="Reuse GL_ARB_texture_barrier">
             <command name="glTextureBarrier"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6312,37 +6312,37 @@ typedef unsigned int GLhandleARB;
     </enums>
 
     <enums namespace="GL" start="0x80D0" end="0x80DF" vendor="SGI">
-        <enum value="0x80D0" name="GL_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI"/>
+        <enum value="0x80D0" name="GL_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI,EnableCap"/>
         <enum value="0x80D0" name="GL_COLOR_TABLE_SGI" group="GetPName,ColorTableTargetSGI,EnableCap"/>
-        <enum value="0x80D1" name="GL_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI"/>
+        <enum value="0x80D1" name="GL_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI,EnableCap"/>
         <enum value="0x80D1" name="GL_POST_CONVOLUTION_COLOR_TABLE_SGI" group="GetPName,ColorTableTargetSGI,EnableCap"/>
-        <enum value="0x80D2" name="GL_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI"/>
+        <enum value="0x80D2" name="GL_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTarget,ColorTableTargetSGI,EnableCap"/>
         <enum value="0x80D2" name="GL_POST_COLOR_MATRIX_COLOR_TABLE_SGI" group="GetPName,ColorTableTargetSGI,EnableCap"/>
-        <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE" group="ColorTableTargetSGI"/>
+        <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE" group="ColorTableTarget"/>
         <enum value="0x80D3" name="GL_PROXY_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTargetSGI"/>
+        <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE" group="ColorTableTarget"/>
         <enum value="0x80D4" name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTargetSGI"/>
+        <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE" group="ColorTableTarget"/>
         <enum value="0x80D5" name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE_SGI" group="ColorTableTargetSGI"/>
-        <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D6" name="GL_COLOR_TABLE_SCALE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D7" name="GL_COLOR_TABLE_BIAS_SGI" group="GetColorTableParameterPName,ColorTableParameterPName"/>
+        <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D8" name="GL_COLOR_TABLE_FORMAT_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80D9" name="GL_COLOR_TABLE_WIDTH_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DA" name="GL_COLOR_TABLE_RED_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DB" name="GL_COLOR_TABLE_GREEN_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DC" name="GL_COLOR_TABLE_BLUE_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DD" name="GL_COLOR_TABLE_ALPHA_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DE" name="GL_COLOR_TABLE_LUMINANCE_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
-        <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
+        <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE" group="GetColorTableParameterPName,ColorTableParameterPName"/>
         <enum value="0x80DF" name="GL_COLOR_TABLE_INTENSITY_SIZE_SGI" group="GetColorTableParameterPNameSGI,ColorTableParameterPNameSGI"/>
     </enums>
 
@@ -38078,6 +38078,12 @@ typedef unsigned int GLhandleARB;
             <command name="glReadnPixels"/>
         </require>
         <require profile="compatibility" comment="Reuse GL_ARB_robustness">
+            <enum name="GL_COLOR_TABLE"/>
+            <enum name="GL_POST_CONVOLUTION_COLOR_TABLE"/>
+            <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE"/>
+            <enum name="GL_PROXY_COLOR_TABLE"/>
+            <enum name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE"/>
+            <enum name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE"/>
             <enum name="GL_SEPARABLE_2D"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -38084,6 +38084,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_PROXY_COLOR_TABLE"/>
             <enum name="GL_PROXY_POST_CONVOLUTION_COLOR_TABLE"/>
             <enum name="GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE"/>
+            <enum name="GL_CONVOLUTION_1D"/>
+            <enum name="GL_CONVOLUTION_2D"/>
             <enum name="GL_SEPARABLE_2D"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5993,7 +5993,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x802C" name="GL_HISTOGRAM_LUMINANCE_SIZE_EXT" group="GetHistogramParameterPNameEXT"/>
         <enum value="0x802D" name="GL_HISTOGRAM_SINK" group="GetHistogramParameterPNameEXT"/>
         <enum value="0x802D" name="GL_HISTOGRAM_SINK_EXT" group="GetHistogramParameterPNameEXT"/>
-        <enum value="0x802E" name="GL_MINMAX" group="MinmaxTargetEXT"/>
+        <enum value="0x802E" name="GL_MINMAX" group="MinmaxTarget,MinmaxTargetEXT"/>
         <enum value="0x802E" name="GL_MINMAX_EXT" group="MinmaxTargetEXT,EnableCap,GetPName"/>
         <enum value="0x802F" name="GL_MINMAX_FORMAT" group="GetMinmaxParameterPNameEXT"/>
         <enum value="0x802F" name="GL_MINMAX_FORMAT_EXT" group="GetMinmaxParameterPNameEXT"/>
@@ -20763,7 +20763,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnMinmax</name></proto>
-            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -38089,6 +38089,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_SEPARABLE_2D"/>
             <enum name="GL_HISTOGRAM"/>
             <enum name="GL_PROXY_HISTOGRAM"/>
+            <enum name="GL_MINMAX"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>
             <command name="glGetnMapiv"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5973,9 +5973,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8022" name="GL_POST_CONVOLUTION_BLUE_BIAS_EXT" group="PixelTransferParameter,GetPName"/>
         <enum value="0x8023" name="GL_POST_CONVOLUTION_ALPHA_BIAS" group="PixelTransferParameter"/>
         <enum value="0x8023" name="GL_POST_CONVOLUTION_ALPHA_BIAS_EXT" group="PixelTransferParameter,GetPName"/>
-        <enum value="0x8024" name="GL_HISTOGRAM" group="HistogramTargetEXT"/>
+        <enum value="0x8024" name="GL_HISTOGRAM" group="HistogramTarget,HistogramTargetEXT"/>
         <enum value="0x8024" name="GL_HISTOGRAM_EXT" group="HistogramTargetEXT,EnableCap,GetPName"/>
-        <enum value="0x8025" name="GL_PROXY_HISTOGRAM" group="HistogramTargetEXT"/>
+        <enum value="0x8025" name="GL_PROXY_HISTOGRAM" group="HistogramTarget,HistogramTargetEXT"/>
         <enum value="0x8025" name="GL_PROXY_HISTOGRAM_EXT" group="HistogramTargetEXT"/>
         <enum value="0x8026" name="GL_HISTOGRAM_WIDTH" group="GetHistogramParameterPNameEXT"/>
         <enum value="0x8026" name="GL_HISTOGRAM_WIDTH_EXT" group="GetHistogramParameterPNameEXT"/>
@@ -20703,7 +20703,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnHistogram</name></proto>
-            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -38087,6 +38087,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONVOLUTION_1D"/>
             <enum name="GL_CONVOLUTION_2D"/>
             <enum name="GL_SEPARABLE_2D"/>
+            <enum name="GL_HISTOGRAM"/>
+            <enum name="GL_PROXY_HISTOGRAM"/>
             <command name="glGetnMapdv"/>
             <command name="glGetnMapfv"/>
             <command name="glGetnMapiv"/>


### PR DESCRIPTION
In the effort of writing a new binder for OpenTK we came across some stuff which didn't emit compilable code for us, where stuff was missing. We are pretty sure that there are mistakes there and propose changes in this PR, but we are not completely sure whether it is the correct way to resolve these inconsistencies.

# The function glGetnColorTable part of compatibility 4.5 references group ColorTableTarget.

GL_PROXY_POST_CONVOLUTION_COLOR_TABLE(_SGI) both in ColorTableSGI group, whereas my guess would be that it should be in ColorTable-group(without SGI prefix) same for GL_PROXY_POST_COLOR_MATRIX_COLOR_TABLE(_SGI), GL_PROXY_COLOR_TABLE(_SGI)

GL_COLOR_TABLE, GL_POST_CONVOLUTION_COLOR_TABLE, GL_POST_COLOR_MATRIX_COLOR_TABLE not part of EnableCap, GetPName whereas SGI version is?
This PR only added it to EnableCap as I couldn't find any documentation where it was referenced for GetPName.
These enum values where also added to 4.5 compatibility from where the glGetnColorTable is introduced as well.

# The function glGetnConvolutionFilter part of compatibility 4.5 references group ConvolutionTarget. 
These enum values where also added to 4.5 compatibility from where the glGetnConvolutionFilter is introduced as well.

# The function glGetnSeparableFilter part of compatibility 4.6 referencing enum SeparableTarget
SeparableTargetEXT was changed to SeparableTarget and GL_SEPARABLE_2D in turn added to SeparableTarget group.

These enum values where also added to 4.5 compatibility from where the glGetnConvolutionFilter is introduced as well.

# The function glGetnHistogram part of compatibility 4.5 references group HistogramTarget .
HistogramTargetEXT was changed to HistogramTarget and GL_HISTOGRAM, GL_PROXY_HISTOGRAM in turn added to HistogramTarget group.

These enum values where also added to 4.5 compatibility from where the glGetnConvolutionFilter is introduced as well.

GL_HISTOGRAM not part of EnableCap, GetPName whereas EXT version is?

# The function glGetnMinmax part of compatibility 4.5 references group MinmaxTarget.
MinmaxTargetEXT was changed to MinmaxTarget and GL_MINMAX in turn added to MinmaxTarget group.

GL_MINMAX not part of EnableCap, GetPName, whereas EXT version is?