### PR TITLE
Add EXT_multisampled_render_to_texture2 to gl.xml

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -45761,6 +45761,10 @@ typedef unsigned int GLhandleARB;
                 <command name="glFramebufferTexture2DMultisampleEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_multisampled_render_to_texture2" supported="gles2">
+            <require>
+            </require>
+        </extension>
         <extension name="GL_EXT_multiview_draw_buffers" supported="gles2">
             <require>
                 <enum name="GL_COLOR_ATTACHMENT_EXT"/>


### PR DESCRIPTION
This extension was missing from `gl.xml`. It doesn't introduce any new symbols though.