### PR TITLE
Fix parameter ref for glMultiDrawElementsBaseVertexEXT

### DIFF
--- a/extensions/EXT/EXT_draw_elements_base_vertex.txt
+++ b/extensions/EXT/EXT_draw_elements_base_vertex.txt
@@ -29,8 +29,8 @@ Status
 
 Version
 
-    Last Modified Date:  September 30, 2014
-    Version:             3
+    Last Modified Date:  August 11, 2020
+    Version:             4
 
 Number
 
@@ -138,7 +138,7 @@ New Procedures and Functions
                                         const sizei *count,
                                         enum type,
                                         const void * const *indices,
-                                        sizei primcount,
+                                        sizei drawcount,
                                         const int *basevertex);
 
 New Tokens
@@ -361,7 +361,12 @@ Issues
 Revision History
 
     Rev.    Date    Author     Changes
-    ----  -------- ---------  ----------------------------------------
+    ----  -------- ---------  ----------------------------------------------
+     4    08/11/20  pdaniell  Renamed the 'primcount' parameter of
+                              MultiDrawElementsBaseVertexEXT in the
+                              "New Procedures and Functions" section to
+                              'drawcount' to match the extension spec body.
+                              
      3    09/30/14  dkoch     Resolved issues 1, 2 as proposed.
                               Added issue 5. Mark complete.
 

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22597,7 +22597,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
-            <param><ptype>GLsizei</ptype> <name>primcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
             <alias name="glMultiDrawElementsBaseVertex"/>
         </command>


### PR DESCRIPTION
This is a replacement for https://github.com/KhronosGroup/OpenGL-Registry/pull/414 to also include the extension spec update.