### PR TITLE
Fix duplicate parameter names in GL_NV_memory_object_sparse

### DIFF
--- a/extensions/NV/NV_memory_object_sparse.txt
+++ b/extensions/NV/NV_memory_object_sparse.txt
@@ -21,8 +21,8 @@ Status
 
 Version
 
-    Last Modified Date: Jul 10, 2020
-    Revision:           1
+    Last Modified Date: August 14, 2020
+    Revision:           2
 
 Number
 
@@ -53,12 +53,12 @@ New Procedures and Functions
 
     void BufferPageCommitmentMemNV(enum target,
                                    intptr offset, sizeiptr size,
-                                   uint memory, uint64 offset,
+                                   uint memory, uint64 memOffset,
                                    boolean commit);
 
     void NamedBufferPageCommitmentMemNV(uint buffer,
                                         intptr offset, sizeiptr size,
-                                        uint memory, uint64 offset,
+                                        uint memory, uint64 memOffset,
                                         boolean commit);
 
     void TexPageCommitmentMemNV(enum target,
@@ -91,18 +91,18 @@ Additions to Chapter 6 of the OpenGL 4.4 (core) Specification (Buffer Objects)
 
         void BufferPageCommitmentMemNV(enum target,
                                        intptr offset, sizeiptr size,
-                                       uint memory, uint64 offset,
+                                       uint memory, uint64 memOffset,
                                        boolean commit);
 
         void NamedBufferPageCommitmentMemNV(uint buffer,
                                             intptr offset,
                                             sizeiptr size,
-                                            uint memory, uint64 offset,
+                                            uint memory, uint64 memOffset,
                                             boolean commit);
 
     behaves similarly to BufferPageCommitmentARB and
     NamedBufferPageCommitmentMemARB except that the pages of the sparse buffer
-    are bound to the memory specified by <memory> and <offset>.
+    are bound to the memory specified by <memory> and <memOffset>.
 
     Errors (additionally to non-Mem variants)
 
@@ -178,6 +178,10 @@ Issues
               isn't required for NVIDIA hardware.
 
 Revision History
+
+    Revision 2, 2020-08-14 (Piers Daniell)
+        - Fix duplicate parameter names in BufferPageCommitmentMemNV and
+          NamedBufferPageCommitmentMemNV.
 
     Revision 1, 2020-08-04 (Carsten Rohde)
         - Initial draft.

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -12810,7 +12810,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
-            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+            <param><ptype>GLuint64</ptype> <name>memOffset</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
@@ -23768,7 +23768,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
-            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+            <param><ptype>GLuint64</ptype> <name>memOffset</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
@@ -48730,8 +48730,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glNamedBufferAttachMemoryNV"/>
             </require>
         </extension>
-        <!-- until fixed, per #421 supported="gl|glcore|gles2" -->
-        <extension name="GL_NV_memory_object_sparse" supported="disabled">
+        <extension name="GL_NV_memory_object_sparse" supported="gl|glcore|gles2">
             <require>
                 <command name="glBufferPageCommitmentMemNV"/>
                 <command name="glTexPageCommitmentMemNV"/>


### PR DESCRIPTION
This fixes the duplicate "offset" parameter name in the functions:
glBufferPageCommitmentMemNV
glNamedBufferPageCommitmentMemNV

Fixes issue 421