### PR TITLE
Fix inconsistent length out and length for NV_command_list

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -21757,9 +21757,9 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>list</name></param>
             <param><ptype>GLuint</ptype> <name>segment</name></param>
             <param len="count">const void **<name>indirects</name></param>
-            <param>const <ptype>GLsizei</ptype> *<name>sizes</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>states</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>fbos</name></param>
+            <param len="count">const <ptype>GLsizei</ptype> *<name>sizes</name></param>
+            <param len="count">const <ptype>GLuint</ptype> *<name>states</name></param>
+            <param len="count">const <ptype>GLuint</ptype> *<name>fbos</name></param>
             <param><ptype>GLuint</ptype> <name>count</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16503,7 +16503,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glExtGetBufferPointervQCOM</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param>void **<name>params</name></param>
+            <param len="1">void **<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glExtGetBuffersQCOM</name></proto>
@@ -17720,7 +17720,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetBufferPointervOES</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="BufferPointerNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>void **<name>params</name></param>
+            <param len="1">void **<name>params</name></param>
             <alias name="glGetBufferPointerv"/>
         </command>
         <command>
@@ -18811,7 +18811,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetNamedBufferPointerv</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferPointerNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>void **<name>params</name></param>
+            <param len="1">void **<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedBufferPointervEXT</name></proto>
@@ -19271,7 +19271,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetPointervKHR</name></proto>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>void **<name>params</name></param>
+            <param len="1">void **<name>params</name></param>
             <alias name="glGetPointerv"/>
         </command>
         <command>
@@ -20444,7 +20444,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>void **<name>param</name></param>
+            <param len="1">void **<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayPointervEXT</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -21756,7 +21756,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glListDrawCommandsStatesClientNV</name></proto>
             <param><ptype>GLuint</ptype> <name>list</name></param>
             <param><ptype>GLuint</ptype> <name>segment</name></param>
-            <param>const void **<name>indirects</name></param>
+            <param len="count">const void **<name>indirects</name></param>
             <param>const <ptype>GLsizei</ptype> *<name>sizes</name></param>
             <param>const <ptype>GLuint</ptype> *<name>states</name></param>
             <param>const <ptype>GLuint</ptype> *<name>fbos</name></param>


### PR DESCRIPTION
Length for parameters which use a pointer as an ouptut parameter should have a length of 1 specified. For the fixes here some vendor counterparts do have the length while others don't.

Length for glListDrawCommandsStatesClientNV parameters was not specified despite it being described in the extension spec:
https://www.khronos.org/registry/OpenGL/extensions/NV/NV_command_list.txt

> The <indirects> pointer should point to a list of size <count> of pointers, each of which should point to a command sequence. 

The other parameters can be seen to be used with the same length in description of the DrawCommandsStatesNV function.