### PR TITLE
[xml] Missing class=sync

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -15006,7 +15006,7 @@ typedef unsigned int GLhandleARB;
             <param len="n"><ptype>GLuint</ptype> *<name>states</name></param>
         </command>
         <command>
-            <proto group="sync"><ptype>GLsync</ptype> <name>glCreateSyncFromCLeventARB</name></proto>
+            <proto class="sync" group="sync"><ptype>GLsync</ptype> <name>glCreateSyncFromCLeventARB</name></proto>
             <param group="cl_context"><ptype>struct _cl_context</ptype> *<name>context</name></param>
             <param group="cl_event"><ptype>struct _cl_event</ptype> *<name>event</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
@@ -16601,12 +16601,12 @@ typedef unsigned int GLhandleARB;
             <param len="n">const <ptype>GLfixed</ptype> *<name>buffer</name></param>
         </command>
         <command>
-            <proto group="sync"><ptype>GLsync</ptype> <name>glFenceSync</name></proto>
+            <proto class="sync" group="sync"><ptype>GLsync</ptype> <name>glFenceSync</name></proto>
             <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
             <param group="SyncBehaviorFlags"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
-            <proto group="sync"><ptype>GLsync</ptype> <name>glFenceSyncAPPLE</name></proto>
+            <proto class="sync" group="sync"><ptype>GLsync</ptype> <name>glFenceSyncAPPLE</name></proto>
             <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
             <param group="SyncBehaviorFlags"><ptype>GLbitfield</ptype> <name>flags</name></param>
             <alias name="glFenceSync"/>
@@ -21119,7 +21119,7 @@ typedef unsigned int GLhandleARB;
             <param>const void *<name>name</name></param>
         </command>
         <command>
-            <proto group="sync"><ptype>GLsync</ptype> <name>glImportSyncEXT</name></proto>
+            <proto class="sync" group="sync"><ptype>GLsync</ptype> <name>glImportSyncEXT</name></proto>
             <param><ptype>GLenum</ptype> <name>external_sync_type</name></param>
             <param><ptype>GLintptr</ptype> <name>external_sync</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>


### PR DESCRIPTION
Small update to #428.

When updating my bindings to use classes i noticed - i missed few functions returning `GLsync` type...
For most other classes return type is `GLuint`, so i wasn't checking functions by return type.