### PR TITLE
Advance notice of old-style grouping removals

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,23 @@
+// XX to be filled in by the merger of this PR (likely Jon)
+= *Advance Notice of Pending XML Registry Change (posted 2020-11-XX)*
+
+[WARNING]
+.Warning
+====
+Shortly after 2021-02-XX, we will be removing the old-style group blocks
+(contained within the `groups` section at the top of the XML registry)
+The groups are intended to contain all the possible legal values
+for corresponding function parameters, but it is likely that many
+of the groups are out of date relative to current OpenGL and OpenGL
+ES specifications, and the many extensions to those specifications.
+As of Wednesday 8th January 2020, these group blocks have been
+deprecated in favour of group attributes declared inline with
+the enumerant itself, which are currently the only actively updated
+source for groupings. For more information, see public issue 
+link:https://github.com/KhronosGroup/OpenGL-Registry/issues/335[#335].
+====
+
+
 = OpenGL-Registry
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 // XX to be filled in by the merger of this PR (likely Jon)
-= *Advance Notice of Pending XML Registry Change (posted 2020-11-XX)*
+= *Advance Notice of Pending XML Registry Change (posted 2021-01-XX)*
 
 [WARNING]
 .Warning
 ====
-Shortly after 2021-02-XX, we will be removing the old-style group blocks
+Shortly after 2021-04-XX, we will be removing the old-style group blocks
 (contained within the `groups` section at the top of the XML registry)
 The groups are intended to contain all the possible legal values
 for corresponding function parameters, but it is likely that many


### PR DESCRIPTION
It's about time we start working to get #335 closed off. After a number of checkups in that thread, it seems that most users are happy for the old-style groupings to be removed, either having migrated to the new-style attributes or are in the process of doing so (maintaining a fork in the meantime)

The old-style groups have been deprecated for a long time now, so I've proposed a 3 month timeline between the date of merge and removal. The notice I have added to the README is akin to the one that was added to Vulkan a little while back.

I've enabled "Allow edits by maintainers" so the merger of this PR will be able to fill in the missing dates annotated with `XX` by just editing the file on the PR.