### PR TITLE
xml: Remove duplicate EP for separate shader ext.

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -46183,7 +46183,6 @@ typedef unsigned int GLhandleARB;
                 <command name="glProgramUniform2uivEXT"/>
                 <command name="glProgramUniform3uivEXT"/>
                 <command name="glProgramUniform4uivEXT"/>
-                <command name="glProgramUniformMatrix4fvEXT"/>
                 <command name="glProgramUniformMatrix2x3fvEXT"/>
                 <command name="glProgramUniformMatrix3x2fvEXT"/>
                 <command name="glProgramUniformMatrix2x4fvEXT"/>


### PR DESCRIPTION
The glProgramUniformMatrix4fvEXT entry point was listed in a second
require block that listed the entry point as depending on GLES 3.0
or GL_NV_non_square_matrices.

Fixes #443

@pdaniell-nv  PTAL