### PR TITLE
Len parameters

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -27440,20 +27440,20 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glScissorArrayv</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glScissorArrayvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glScissorArrayv"/>
         </command>
         <command>
             <proto>void <name>glScissorArrayvOES</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glScissorArrayv"/>
         </command>
         <command>
@@ -33555,20 +33555,20 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glViewportArrayv</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glViewportArrayvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glViewportArrayv"/>
         </command>
         <command>
             <proto>void <name>glViewportArrayvOES</name></proto>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="COMPSIZE(count)">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param len="count * 4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glViewportArrayv"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -20267,8 +20267,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetUniformIndices</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLsizei</ptype> <name>uniformCount</name></param>
-            <param len="COMPSIZE(uniformCount)">const <ptype>GLchar</ptype> *const*<name>uniformNames</name></param>
-            <param len="COMPSIZE(uniformCount)"><ptype>GLuint</ptype> *<name>uniformIndices</name></param>
+            <param len="uniformCount">const <ptype>GLchar</ptype> *const*<name>uniformNames</name></param>
+            <param len="uniformCount"><ptype>GLuint</ptype> *<name>uniformIndices</name></param>
             <glx type="single" opcode="215"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18826,14 +18826,14 @@ typedef unsigned int GLhandleARB;
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param>void *<name>data</name></param>
+            <param len="size">void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedBufferSubDataEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param len="COMPSIZE(size)">void *<name>data</name></param>
+            <param len="size">void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedFramebufferParameterfvAMD</name></proto>
@@ -23747,7 +23747,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedBufferDataEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param len="COMPSIZE(size)">const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
             <param group="VertexBufferObjectUsage"><ptype>GLenum</ptype> <name>usage</name></param>
         </command>
         <command>
@@ -23815,7 +23815,7 @@ typedef unsigned int GLhandleARB;
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param len="COMPSIZE(size)">const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
             <alias name="glNamedBufferSubData"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -23808,7 +23808,7 @@ typedef unsigned int GLhandleARB;
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param len="COMPSIZE(size)">const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferSubDataEXT</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22513,15 +22513,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawArrays</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>first</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>first</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLint</ptype> *<name>first</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="primcount">const <ptype>GLint</ptype> *<name>first</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glMultiDrawArrays"/>
         </command>
@@ -22592,36 +22592,36 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElements</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertex</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>basevertex</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertexEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>basevertex</name></param>
             <alias name="glMultiDrawElementsBaseVertex"/>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(primcount)">const void *const*<name>indices</name></param>
+            <param len="primcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glMultiDrawElements"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -23740,7 +23740,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedBufferData</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param>const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
             <param group="VertexBufferObjectUsage"><ptype>GLenum</ptype> <name>usage</name></param>
         </command>
         <command>


### PR DESCRIPTION
Fixes some len parameters, I went through all the lens that have a compsize and they should now all be pretty consistent such that none of them are not actually computing sizes.

Here are a few outliers that either had very difficult to find documentation or which i couldnt find the specific documentation i was looking for.
```
glGetUniformIndices
glGetnMapdv - No documentation??
glMultiDrawArraysIndirectCount
glMultiDrawElementsIndirectCount
glMulticastScissorArrayvNVX
glMulticastViewportArrayvNVX
glScissorExclusiveArrayvNV
glTransformFeedbackAttribsNV
glVariantbvEXT
glVertexArrayRangeNV
glWindowRectanglesEXT
```