### PR TITLE
 Add the MESA_bgra GLES extension

### DIFF
--- a/extensions/MESA/MESA_bgra.txt
+++ b/extensions/MESA/MESA_bgra.txt
@@ -1,0 +1,106 @@
+Name
+
+    MESA_bgra
+
+Name Strings
+
+    GL_MESA_bgra
+
+Contact
+
+    Gert Wollny (gert.wollny 'at' collabora.com)
+
+Notice
+
+    Copyright (c) 2021 Collabora LTD 
+    Copyright (c) 2009-2013 The Khronos Group Inc. Copyright terms at
+        http://www.khronos.org/registry/speccopyright.html
+
+Version
+
+    Version 1, 2021/04/30.
+    Based on EXT_bgra version 1, modified 1997/05/19.
+
+Number
+
+    OpenGL ES extension #335
+
+Dependencies
+
+    OpenGL ES 2.0 is required.
+    Written based on the wording of the OpenGL ES 3.2 specification.
+    There are interactions with the extensions EXT_clear_texture.
+
+Overview
+
+    MESA_bgra extends the list of combinations host-memory color formats
+    with internal formats to include BGRA and BGR as acceptable formats
+    with RGB8/SRGB8 and RGBA/sRGB8_ALPHA8 as internal formats respectively.
+    This feature is of interest in virtualized environments, where the host
+    supports OpenGL ES only, and the virtualized guest is supposed to support
+    a subset of OpenGL including textures created with the format BGRA.
+
+IP Status
+
+    Open-source; freely implementable.
+
+Issues
+
+    None.
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+   Accepted by the <format> parameter of TexImage2D and TexSubImage2D:
+
+       GL_BGR_EXT                                      0x80E0
+       GL_BGRA_EXT                                     0x80E1
+
+Additions to Chapter 8 of the GLES 3.2 Specification (Textures and Samplers)
+
+    Add to table 8.2 (Pixels data formats, valid combinations of format,
+    type, and unsized internalformat).
+
+      Format     Type            External          Internal Format 
+                                  Bytes
+                                per Pixel
+      -------------------------------------------------------------
+      BGRA      UNSIGNED_BYTE        4                   RGBA
+      BGR       UNSIGNED_BYTE        3                   RGB
+
+
+
+    Add to table 8.5 (Pixels data formats).
+
+      Format Name   Elements Meaning and Order    Target Buffer
+      -------------------------------------------------------------
+      BGR_EXT                 B, G, R                Color
+      BGRA_EXT               B, G, R, A              Color
+
+
+    Add to table 8.9 (Effective internal format correspondig to
+    external format).
+
+      Format        Type                          Effective
+                                                Internal format
+      -------------------------------------------------------------
+      BGRA_EXT       UNSIGNED_BYTE                  RGBA8
+      BGR_EXT        UNSIGNED_BYTE                  RGB8
+
+Interactions with EXT_clear_texture
+
+    When EXT_clear_texture is supported the accepted formats for
+    ClearTextureEXT and ClearSubTextureEXT are extended to include
+    the entries added above. 
+
+
+Revision History
+
+    Original draft, revision 1.0, May 4, 2021 (Gert Wollny)
+       rewrite EXT_bgra against OpenGL ES 3.2 instead of OpenGL 1,0.
+
+    Revision 1.1 (May 5. 2021): Add the new tokens, and fix
+       Clear*Texture function names.

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3001,6 +3001,13 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_copy_sub_buffer.txt',
     },
+    'GL_MESA_bgra' : {
+        'esnumber' : 335,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_bgra.txt',
+    },
+
     'GL_MESA_framebuffer_flip_x' : {
         'number' : 548,
         'esnumber' : 327,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -43117,6 +43117,13 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
             </require>
         </extension>
+        <extension name="GL_MESA_bgra" supported="gles2">
+          <require>
+                <enum name="GL_BGR_EXT"/>
+                <enum name="GL_BGRA_EXT"/>
+            </require>
+        </extension>
+
         <extension name="GL_MESA_framebuffer_flip_x" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_FRAMEBUFFER_FLIP_X_MESA"/>


### PR DESCRIPTION
This extensions adds the pairs BGRA_EXT/RGBA8 and BGR_EXT/RGB8
to the accepted combinations for format/internalformat in the
TexImage and TexSubImage calls. This is of interest in virtualized
enviornments where one wants to emulate a subset of OpenGL in a guest
that runs on a host that supports only GLES.

An implementation is currently about to be merged in mesa: 
  https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/10613