### PR TITLE
Add len parameters to char* methods

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -11775,7 +11775,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glExtGetProgramBinarySourceQCOM</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
-            <param><ptype>GLchar</ptype> *<name>source</name></param>
+            <param len="length"><ptype>GLchar</ptype> *<name>source</name></param>
             <param><ptype>GLint</ptype> *<name>length</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -12873,7 +12873,7 @@ typedef unsigned int GLhandleARB;
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>size</name></param>
             <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
-            <param len="COMPSIZE(program,index,bufSize)"><ptype>GLchar</ptype> *<name>name</name></param>
+            <param len="length"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetArrayObjectfvATI</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -15502,7 +15502,7 @@ typedef unsigned int GLhandleARB;
             <param class="shader"><ptype>GLuint</ptype> <name>shader</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
-            <param><ptype>GLchar</ptype> *<name>source</name></param>
+            <param len="length"><ptype>GLchar</ptype> *<name>source</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetUniformBlockIndex</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14371,9 +14371,9 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>queryId</name></param>
             <param><ptype>GLuint</ptype> <name>counterId</name></param>
             <param><ptype>GLuint</ptype> <name>counterNameLength</name></param>
-            <param><ptype>GLchar</ptype> *<name>counterName</name></param>
+            <param len="counterNameLength"><ptype>GLchar</ptype> *<name>counterName</name></param>
             <param><ptype>GLuint</ptype> <name>counterDescLength</name></param>
-            <param><ptype>GLchar</ptype> *<name>counterDesc</name></param>
+            <param len="counterDescLength"><ptype>GLchar</ptype> *<name>counterDesc</name></param>
             <param><ptype>GLuint</ptype> *<name>counterOffset</name></param>
             <param><ptype>GLuint</ptype> *<name>counterDataSize</name></param>
             <param><ptype>GLuint</ptype> *<name>counterTypeEnum</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -12873,7 +12873,7 @@ typedef unsigned int GLhandleARB;
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>size</name></param>
             <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
-            <param len="length"><ptype>GLchar</ptype> *<name>name</name></param>
+            <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetArrayObjectfvATI</name></proto>
@@ -15502,7 +15502,7 @@ typedef unsigned int GLhandleARB;
             <param class="shader"><ptype>GLuint</ptype> <name>shader</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
-            <param len="length"><ptype>GLchar</ptype> *<name>source</name></param>
+            <param len="bufSize"><ptype>GLchar</ptype> *<name>source</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetUniformBlockIndex</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14441,7 +14441,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetPerfQueryInfoINTEL</name></proto>
             <param><ptype>GLuint</ptype> <name>queryId</name></param>
             <param><ptype>GLuint</ptype> <name>queryNameLength</name></param>
-            <param><ptype>GLchar</ptype> *<name>queryName</name></param>
+            <param len="queryNameLength"><ptype>GLchar</ptype> *<name>queryName</name></param>
             <param><ptype>GLuint</ptype> *<name>dataSize</name></param>
             <param><ptype>GLuint</ptype> *<name>noCounters</name></param>
             <param><ptype>GLuint</ptype> *<name>noInstances</name></param>


### PR DESCRIPTION
I noticed some methods with char*'s didnt have len attributes. This pr fixes almost all of them.


https://www.khronos.org/registry/OpenGL/extensions/QCOM/QCOM_extended_get2.txt
glExtGetProgramBinarySourceQCOM is missing a len attribute for parameter 'source'
Didn't find a direct message in the documentation. But based on the parameter names, I would say this is fixed correctly.


https://www.khronos.org/registry/OpenGL/extensions/NV/NV_transform_feedback.txt
glGetActiveVaryingNV has a 'COMPSIZE' string length for parameter 'name'!
`The actual number of characters written into <name>, excluding
    the null terminator, is returned in <length>` Hence this should not be a compsize, but rather just point to the length parameter.


https://www.khronos.org/registry/OpenGL/extensions/ANGLE/ANGLE_translated_shader_source.txt
glGetTranslatedShaderSourceANGLE is missing a len attribute for parameter 'source'
Didn't find a direct message in the documentation. But based on the parameter names, I would say this is fixed correctly.


https://www.khronos.org/registry/OpenGL/extensions/INTEL/INTEL_performance_query.txt
glGetPerfCounterInfoINTEL is missing a len attribute for parameter 'counterDesc'
glGetPerfCounterInfoINTEL is missing a len attribute for parameter 'counterName'
glGetPerfQueryInfoINTEL is missing a len attribute for parameter 'queryName'
These have been fixed base off of code samples in the documentation linked above.

glGetPerfQueryIdByNameINTEL is missing a len attribute for parameter 'queryName'
This one is documented in the link above with the other intel commands. But it dosent seem like it actually has a length. This makes this parameter the only char* left (from what i've found) that dosent have a length parameter.