### PR TITLE
Removed unnecessary COMPSIZE for all glMultiDraw* functions

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17765,15 +17765,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawArrays</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>first</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>first</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLint</ptype> *<name>first</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="primcount">const <ptype>GLint</ptype> *<name>first</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glMultiDrawArrays"/>
         </command>
@@ -17787,7 +17787,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawArraysIndirectAMD</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param>const void *<name>indirect</name></param>
+            <param len="COMPSIZE(primcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <alias name="glMultiDrawArraysIndirect"/>
@@ -17844,36 +17844,36 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiDrawElements</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertex</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>basevertex</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertexEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="drawcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
+            <param len="drawcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
+            <param len="drawcount">const <ptype>GLint</ptype> *<name>basevertex</name></param>
             <alias name="glMultiDrawElementsBaseVertex"/>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(primcount)">const void *const*<name>indices</name></param>
+            <param len="primcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glMultiDrawElements"/>
         </command>
@@ -17889,7 +17889,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiDrawElementsIndirectAMD</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param>const void *<name>indirect</name></param>
+            <param len="COMPSIZE(primcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <alias name="glMultiDrawElementsIndirect"/>
@@ -17965,18 +17965,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiModeDrawArraysIBM</name></proto>
-            <param group="PrimitiveType" len="COMPSIZE(primcount)">const <ptype>GLenum</ptype> *<name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLint</ptype> *<name>first</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param group="PrimitiveType" len="COMPSIZE(primcount,modestride)">const <ptype>GLenum</ptype> *<name>mode</name></param>
+            <param len="primcount">const <ptype>GLint</ptype> *<name>first</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLint</ptype> <name>modestride</name></param>
         </command>
         <command>
             <proto>void <name>glMultiModeDrawElementsIBM</name></proto>
-            <param group="PrimitiveType" len="COMPSIZE(primcount)">const <ptype>GLenum</ptype> *<name>mode</name></param>
-            <param len="COMPSIZE(primcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
+            <param group="PrimitiveType" len="COMPSIZE(primcount,modestride)">const <ptype>GLenum</ptype> *<name>mode</name></param>
+            <param len="primcount">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(primcount)">const void *const*<name>indices</name></param>
+            <param len="primcount">const void *const*<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLint</ptype> <name>modestride</name></param>
         </command>


### PR DESCRIPTION
Removed `COMPSIZE` from the `len` attributes from the parameters to applicable glMultiDraw* functions.
```c
// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMultiDrawArrays.xhtml
glMultiDrawArrays
glMultiDrawArraysEXT

//https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMultiDrawElements.xhtml
glMultiDrawElements
glMultiDrawElementsEXT

// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMultiDrawElementsBaseVertex.xhtml
glMultiDrawElementsBaseVertex
glMultiDrawElementsBaseVertexEXT

// https://www.ibm.com/docs/en/aix/7.1?topic=subroutines-glmultimodedrawarraysibm-subroutine
glMultiModeDrawArraysIBM
// https://www.ibm.com/docs/en/aix/7.1?topic=subroutines-glmultimodedrawelementsibm-subroutine
glMultiModeDrawElementsIBM
```
I also added COMPSIZE to three functions:
```c
// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMultiDrawArraysIndirect.xhtml
glMultiDrawArraysIndirect

// https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_multi_draw_indirect.txt
glMultiDrawArraysIndirectAMD
glMultiDrawElementsIndirectAMD
```

This should be putting good `len` attributes on almost all `glMultiDraw*` functions. 
There are a few functions from nvidia extensions that would require some weird COMPSIZE` stuff that I decided wasn't worth figuring out.

It would be great if someone could double check my changes as interpreting docs is pretty error prone.