### PR TITLE
Finish adding GL_EXT_texture_storage to big-GL

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -4678,6 +4678,41 @@ GLAPI void APIENTRY glFramebufferFetchBarrierEXT (void);
 #define GL_EXT_texture_shadow_lod 1
 #endif /* GL_EXT_texture_shadow_lod */
 
+#ifndef GL_EXT_texture_storage
+#define GL_EXT_texture_storage 1
+#define GL_TEXTURE_IMMUTABLE_FORMAT_EXT   0x912F
+#define GL_ALPHA8_EXT                     0x803C
+#define GL_LUMINANCE8_EXT                 0x8040
+#define GL_LUMINANCE8_ALPHA8_EXT          0x8045
+#define GL_RGBA32F_EXT                    0x8814
+#define GL_RGB32F_EXT                     0x8815
+#define GL_ALPHA32F_EXT                   0x8816
+#define GL_LUMINANCE32F_EXT               0x8818
+#define GL_LUMINANCE_ALPHA32F_EXT         0x8819
+#define GL_RGBA16F_EXT                    0x881A
+#define GL_RGB16F_EXT                     0x881B
+#define GL_ALPHA16F_EXT                   0x881C
+#define GL_LUMINANCE16F_EXT               0x881E
+#define GL_LUMINANCE_ALPHA16F_EXT         0x881F
+#define GL_RGB10_A2_EXT                   0x8059
+#define GL_RGB10_EXT                      0x8052
+#define GL_BGRA8_EXT                      0x93A1
+#define GL_R8_EXT                         0x8229
+#define GL_RG8_EXT                        0x822B
+#define GL_R32F_EXT                       0x822E
+#define GL_RG32F_EXT                      0x8230
+#define GL_R16F_EXT                       0x822D
+#define GL_RG16F_EXT                      0x822F
+typedef void (APIENTRYP PFNGLTEXSTORAGE1DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void (APIENTRYP PFNGLTEXSTORAGE2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (APIENTRYP PFNGLTEXSTORAGE3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glTexStorage1DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+GLAPI void APIENTRY glTexStorage2DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+GLAPI void APIENTRY glTexStorage3DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+#endif
+#endif /* GL_EXT_texture_storage */
+
 #ifndef GL_EXT_window_rectangles
 #define GL_EXT_window_rectangles 1
 #define GL_INCLUSIVE_EXT                  0x8F10

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -32,7 +32,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20210420
+#define GL_GLEXT_VERSION 20210922
 
 #include <KHR/khrplatform.h>
 
@@ -8624,6 +8624,36 @@ GLAPI void APIENTRY glTextureNormalEXT (GLenum mode);
 #define GL_RGB_SNORM                      0x8F92
 #define GL_RGBA_SNORM                     0x8F93
 #endif /* GL_EXT_texture_snorm */
+
+#ifndef GL_EXT_texture_storage
+#define GL_EXT_texture_storage 1
+#define GL_TEXTURE_IMMUTABLE_FORMAT_EXT   0x912F
+#define GL_RGBA32F_EXT                    0x8814
+#define GL_RGB32F_EXT                     0x8815
+#define GL_ALPHA32F_EXT                   0x8816
+#define GL_LUMINANCE32F_EXT               0x8818
+#define GL_LUMINANCE_ALPHA32F_EXT         0x8819
+#define GL_RGBA16F_EXT                    0x881A
+#define GL_RGB16F_EXT                     0x881B
+#define GL_ALPHA16F_EXT                   0x881C
+#define GL_LUMINANCE16F_EXT               0x881E
+#define GL_LUMINANCE_ALPHA16F_EXT         0x881F
+#define GL_BGRA8_EXT                      0x93A1
+#define GL_R8_EXT                         0x8229
+#define GL_RG8_EXT                        0x822B
+#define GL_R32F_EXT                       0x822E
+#define GL_RG32F_EXT                      0x8230
+#define GL_R16F_EXT                       0x822D
+#define GL_RG16F_EXT                      0x822F
+typedef void (APIENTRYP PFNGLTEXSTORAGE1DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void (APIENTRYP PFNGLTEXSTORAGE2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (APIENTRYP PFNGLTEXSTORAGE3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+#ifdef GL_GLEXT_PROTOTYPES
+GLAPI void APIENTRY glTexStorage1DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+GLAPI void APIENTRY glTexStorage2DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+GLAPI void APIENTRY glTexStorage3DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+#endif
+#endif /* GL_EXT_texture_storage */
 
 #ifndef GL_EXT_texture_swizzle
 #define GL_EXT_texture_swizzle 1

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20210107 */
+/* Generated on date 20210922 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20210107 */
+/* Generated on date 20210922 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20210306 */
+/* Generated on date 20210922 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20210512 */
+/* Generated on date 20210922 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20210107 */
+/* Generated on date 20210922 */
 
 /* Generated C header for:
  * API: gles2

--- a/extensions/EXT/EXT_texture_storage.txt
+++ b/extensions/EXT/EXT_texture_storage.txt
@@ -31,12 +31,13 @@ Status
 
 Version
 
-    Last Modified Date: 18 September, 2013
-    Author Revision: 28
+    Last Modified Date: 22 September, 2021
+    Author Revision: 29
 
 Number
 
     OpenGL ES Extension #108
+    OpenGL Extension #556
 
 Dependencies
 
@@ -997,6 +998,9 @@ Issues
     decision.
 
 Revision History
+
+    Revision 29, 2021/09/22 (Adam Jackson)
+      - Assign OpenGL extension number
 
     Revision 28, 2013/09/18 (Benj Lipchak)
       - Add interaction with APPLE_texture_format_BGRA8888.

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1049,4 +1049,6 @@
 </li>
 <li value=555><a href="extensions/EXT/EXT_texture_sRGB_RG8.txt">GL_EXT_texture_sRGB_RG8</a>
 </li>
+<li value=556><a href="extensions/EXT/EXT_texture_storage.txt">GL_EXT_texture_storage</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2592,6 +2592,7 @@ registry = {
         'url' : 'extensions/EXT/EXT_texture_snorm.txt',
     },
     'GL_EXT_texture_storage' : {
+        'number' : 556,
         'esnumber' : 108,
         'flags' : { 'public' },
         'url' : 'extensions/EXT/EXT_texture_storage.txt',

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -42140,7 +42140,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_SIGNED_NORMALIZED"/>
             </require>
         </extension>
-        <extension name="GL_EXT_texture_storage" supported="gles1|gles2">
+        <extension name="GL_EXT_texture_storage" supported="gles1|gles2|gl|glcore">
             <require comment="Not clear all of these enums should be here for OpenGL ES. Many are only defined if other extensions also requiring them are supported">
                 <enum name="GL_TEXTURE_IMMUTABLE_FORMAT_EXT"/>
                 <enum name="GL_ALPHA8_EXT"/>


### PR DESCRIPTION
The spec text says this is defined even for GL 1.2, but we don't have a
GL extension number for it and the headers don't mention it. Fix that so
we can extend immutable-format texture image support to GL < 4.2.