### PR TITLE
Add EXT_separate_depth_stencil extension

### DIFF
--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20211115 */
+/* Generated on date 20220330 */
 
 /* Generated C header for:
  * API: gles2
@@ -1802,6 +1802,10 @@ GL_APICALL void GL_APIENTRY glImportSemaphoreWin32NameEXT (GLuint semaphore, GLe
 #endif
 #endif /* GL_EXT_semaphore_win32 */
 
+#ifndef GL_EXT_separate_depth_stencil
+#define GL_EXT_separate_depth_stencil 1
+#endif /* GL_EXT_separate_depth_stencil */
+
 #ifndef GL_EXT_separate_shader_objects
 #define GL_EXT_separate_shader_objects 1
 #define GL_ACTIVE_PROGRAM_EXT             0x8259
@@ -2266,11 +2270,11 @@ GL_APICALL void GL_APIENTRY glTextureStorage3DEXT (GLuint texture, GLenum target
 #define GL_SURFACE_COMPRESSION_FIXED_RATE_10BPC_EXT 0x96CD
 #define GL_SURFACE_COMPRESSION_FIXED_RATE_11BPC_EXT 0x96CE
 #define GL_SURFACE_COMPRESSION_FIXED_RATE_12BPC_EXT 0x96CF
-typedef void (GL_APIENTRYP PFNTEXSTORAGEATTRIBS2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, const int *attrib_list);
-typedef void (GL_APIENTRYP PFNTEXSTORAGEATTRIBS3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, const int *attrib_list);
+typedef void (GL_APIENTRYP PFNGLTEXSTORAGEATTRIBS2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, const GLint* attrib_list);
+typedef void (GL_APIENTRYP PFNGLTEXSTORAGEATTRIBS3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, const GLint* attrib_list);
 #ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY TexStorageAttribs2DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, const int *attrib_list);
-GL_APICALL void GL_APIENTRY TexStorageAttribs3DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, const int *attrib_list);
+GL_APICALL void GL_APIENTRY glTexStorageAttribs2DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, const GLint* attrib_list);
+GL_APICALL void GL_APIENTRY glTexStorageAttribs3DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, const GLint* attrib_list);
 #endif
 #endif /* GL_EXT_texture_storage_compression */
 

--- a/extensions/EXT/EXT_separate_depth_stencil.txt
+++ b/extensions/EXT/EXT_separate_depth_stencil.txt
@@ -24,7 +24,7 @@ Version
 
 Number
 
-    OpenGL ES Extension #???
+    OpenGL ES Extension #338
 
 Dependencies
 

--- a/extensions/EXT/EXT_separate_depth_stencil.txt
+++ b/extensions/EXT/EXT_separate_depth_stencil.txt
@@ -1,0 +1,65 @@
+Name
+
+    EXT_separate_depth_stencil
+
+Name Strings
+
+    GL_EXT_separate_depth_stencil
+
+Contributors
+
+    Thomas Spurden
+
+Contact
+
+    Thomas Spurden, Broadcom (thomas.spurden 'at' broadcom.com)
+
+Status
+
+    TBD
+
+Version
+
+    Last Modified Date: 21/01/2022
+
+Number
+
+    OpenGL ES Extension #???
+
+Dependencies
+
+    The extension is written against the OpenGL ES 3.0.6 (November 1, 2019)
+    standard
+
+Overview
+
+    This extension adds support for binding a different image to the depth and
+    stencil attachments of a framebuffer object.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+   None
+
+New Tokens
+
+   None
+
+Additions to Chapter 4 of the OpenGL ES 3.0 Specification (Per-Fragment Operations and the
+Framebuffer)
+
+   Modify section 4.4.4.2 (Whole Framebuffer Completeness)
+
+   Delete the whole of the 4th bullet point "Depth and stencil attachments, if
+   present, are the same image..."
+
+Issues
+
+Revision History
+    #2   (March 3, 2022) Thomas Spurden
+         - Changed to EXT from BRCM
+    #1   (January 21, 2022) Thomas Spurden
+         - Initial draft

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2210,6 +2210,12 @@ registry = {
         'supporters' : { '3DFX', 'NVIDIA', 'REND' },
         'url' : 'extensions/EXT/EXT_secondary_color.txt',
     },
+    'GL_EXT_separate_depth_stencil' : {
+        'esnumber' : 338,
+        'flags' : { 'public' },
+        'supporters' : { 'BRCM' },
+        'url' : 'extensions/EXT/EXT_separate_depth_stencil.txt',
+    },
     'GL_EXT_separate_shader_objects' : {
         'number' : 377,
         'esnumber' : 101,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -41464,6 +41464,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glSecondaryColorPointerEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_separate_depth_stencil" supported="gles2"/>
         <extension name="GL_EXT_separate_shader_objects" supported="gl|glcore|gles2">
             <require api="gl" comment="The OpenGL version of this extension is completely unrelated to the OpenGL ES version">
                 <enum name="GL_ACTIVE_PROGRAM_EXT"/>


### PR DESCRIPTION
Allows separate depth and stencil buffers to be attached to an FBO in GLES3.