### PR TITLE
Mark GL_EXT_separate_depth_stencil as "Complete"

### DIFF
--- a/extensions/EXT/EXT_separate_depth_stencil.txt
+++ b/extensions/EXT/EXT_separate_depth_stencil.txt
@@ -16,7 +16,7 @@ Contact
 
 Status
 
-    TBD
+    Complete
 
 Version
 


### PR DESCRIPTION
This was accidently missed out when pushing the extension for initial publication.