### PR TITLE
Remove BOM from gl.xml

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
 Copyright 2013-2020 The Khronos Group Inc.


### PR DESCRIPTION
This was inserted in #343, probably as an accidental side-effect of
someone's editor - it is not mentioned in the PR comments - and is
breaking downstream scripts in vk-gl-cts which consume the file. The file encoding is defined to be UTF-8 in any event.