### PR TITLE
Fix ES extension numbering conflict between GL_EXT_shader_samples_identical and GL_EXT_separate_depth_stencil

### DIFF
--- a/extensions/EXT/EXT_shader_samples_identical.txt
+++ b/extensions/EXT/EXT_shader_samples_identical.txt
@@ -30,7 +30,7 @@ Version
 Number
 
     OpenGL Extension #557
-    OpenGL ES Extension #338
+    OpenGL ES Extension #339
 
 Dependencies
 

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -701,5 +701,8 @@
 </li>
 <li value=337><a href="extensions/EXT/EXT_EGL_image_storage_compression.txt">GL_EXT_EGL_image_storage_compression</a>
 </li>
-<li value=338><a href="extensions/EXT/EXT_shader_samples_identical.txt">EXT_shader_samples_identical</a>
+<li value=338><a href="extensions/EXT/EXT_separate_depth_stencil.txt">GL_EXT_separate_depth_stencil</a>
+</li>
+<li value=339><a href="extensions/EXT/EXT_shader_samples_identical.txt">GL_EXT_shader_samples_identical</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2285,6 +2285,12 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/EXT/EXT_shader_pixel_local_storage2.txt',
     },
+    'GL_EXT_shader_samples_identical' : {
+        'number' : 557,
+        'esnumber' : 339,
+        'flags' : { 'public' },
+        'url' : 'extensions/EXT/EXT_shader_samples_identical.txt',
+    },
     'GL_EXT_shader_texture_lod' : {
         'esnumber' : 77,
         'flags' : { 'public' },


### PR DESCRIPTION
It looks like https://github.com/KhronosGroup/OpenGL-Registry/pull/504 didn't update registry.py - and then there was a race with GL_EXT_separate_depth_stencil resulting in both taking ES extension number 338.

GL_EXT_separate_depth_stencil  is now not visible from https://www.khronos.org/registry/OpenGL/index_es.php.

This resolves the numbering conflict in favor of GL_EXT_separate_depth_stencil just because that was merged first.


CC: @jekstrand, @oddhack 