### PR TITLE
[xml] Add missing group "FogCoordSrc"

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -2557,11 +2557,11 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8450" name="GL_FOG_COORDINATE_SOURCE"/>
         <enum value="0x8450" name="GL_FOG_COORDINATE_SOURCE_EXT"/>
         <enum value="0x8450" name="GL_FOG_COORD_SRC" alias="GL_FOG_COORDINATE_SOURCE" group="FogPName"/>
-        <enum value="0x8451" name="GL_FOG_COORDINATE"/>
-        <enum value="0x8451" name="GL_FOG_COORD" alias="GL_FOG_COORDINATE"/>
-        <enum value="0x8451" name="GL_FOG_COORDINATE_EXT"/>
-        <enum value="0x8452" name="GL_FRAGMENT_DEPTH"/>
-        <enum value="0x8452" name="GL_FRAGMENT_DEPTH_EXT" group="LightTextureModeEXT"/>
+        <enum value="0x8451" name="GL_FOG_COORDINATE" group="FogCoordSrc"/>
+        <enum value="0x8451" name="GL_FOG_COORDINATE_EXT" group="FogCoordSrc"/>
+        <enum value="0x8451" name="GL_FOG_COORD" group="FogCoordSrc" alias="GL_FOG_COORDINATE"/>
+        <enum value="0x8452" name="GL_FRAGMENT_DEPTH" group="FogCoordSrc,LightTextureModeEXT"/>
+        <enum value="0x8452" name="GL_FRAGMENT_DEPTH_EXT" group="FogCoordSrc,LightTextureModeEXT"/>
         <enum value="0x8453" name="GL_CURRENT_FOG_COORDINATE"/>
         <enum value="0x8453" name="GL_CURRENT_FOG_COORD" alias="GL_CURRENT_FOG_COORDINATE"/>
         <enum value="0x8453" name="GL_CURRENT_FOG_COORDINATE_EXT"/>


### PR DESCRIPTION
Enums of groups `FogMode` and `FogCoordSrc` are accepted by the second parameter of `glFogi`, depending on the first parameter:
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glFog.xml
Though there is currently no way to specify this relation in the `glFogi` definition...
