### PR TITLE
Add implicit flush and non-listable commands to external objects

### DIFF
--- a/extensions/EXT/EXT_external_objects.txt
+++ b/extensions/EXT/EXT_external_objects.txt
@@ -532,7 +532,8 @@ Additions to Chapter 4 of the OpenGL 4.5 Specification (Event Model)
                                     const GLenum *dstLayouts);
 
         will insert a semaphore signaling operation in the GL command
-        stream.
+        stream, and flush the command stream as if /Flush/ were inserted
+        immediately after the semaphore operation.
 
         Prior to signaling the semaphore, memory used by the specified
         buffer objects and textures will be made visible, and textures
@@ -784,6 +785,33 @@ Samplers)
         +--------------------+---------+---------------------------------------+
         | TEXTURE_TILING_EXT | enum    | OPTIMAL_TILING_EXT, LINEAR_TILING_EXT |
         +--------------------+---------+---------------------------------------+
+
+Additions to Chapter 21 of the OpenGL 4.5 Specification (Special Functions)
+
+    Add the following to section 21.4.1, Commands Not Usable in Display
+    Lists.
+
+    Under the "Memory objects" section:
+
+        DeleteMemoryObjectsEXT, CreateMemoryObjectsEXT,
+        MemoryObjectParameterivEXT
+
+    Under the "Pixels and textures" section:
+
+        TexStorageMem2DEXT, TexStorageMem2DMultisampleEXT,
+        TexStorageMem3DEXT, TexStorageMem3DMultisampleEXT,
+        TextureStorageMem2DEXT, TextureStorageMem2DMultisampleEXT,
+        TextureStorageMem3DEXT, TextureStorageMem3DMultisampleEXT,
+        TexStorageMem1DEXT, TextureStorageMem1DEXT
+
+    Under the "Buffer objects" section:
+
+        BufferStorageMemEXT, NamedBufferStorageMemEXT
+
+    Under the "GL command stream management" section:
+
+        GenSemaphoresEXT, DeleteSemaphoresEXT, SemaphoreParameterui64vEXT,
+        WaitSemaphoreEXT, SignalSemaphoreEXT
 
 Additions to Chapter 22 of the OpenGL 4.5 Specification (Context state
 Queries)
@@ -1121,6 +1149,11 @@ Issues
         the new OpenGL texture layouts.
 
 Revision History
+
+    Revision 15, 2022-07-15 (James Jones)
+        - Noted SignalSemaphoreEXT implicitly flushes the command stream
+        - Added commands to the list of commands not permitted in display
+          lists.
 
     Revision 14, 2018-07-18 (James Jones)
         - Fixed a typo: Replace NamedBufferStroage with NamedBufferStorage

--- a/extensions/EXT/EXT_external_objects_fd.txt
+++ b/extensions/EXT/EXT_external_objects_fd.txt
@@ -130,6 +130,19 @@ Additions to Chapter 6 of the OpenGL 4.5 Specification (Memory Objects)
         <fd> in the application after an import results in undefined
         behavior.
 
+Additions to Chapter 21 of the OpenGL 4.5 Specification (Special Functions)
+
+    Add the following to section 21.4.1, Commands Not Usable in Display
+    Lists.
+
+    Under the "Memory Objects" section:
+
+        ImportMemoryFdEXT
+
+    Under the "GL command stream management" section:
+
+        ImportSemaphoreFdEXT
+
 Issues
 
     1)  Does this extension need to support importing Android/Linux
@@ -140,6 +153,10 @@ Issues
         contexts is not compelling enough to justify the additional effort.
 
 Revision History
+
+    Revision 8, 2022-07-15 (James Jones)
+        - Added commands to the list of commands not permitted in display
+          lists.
 
     Revision 7, 2017-06-02 (James Jones)
         - Added extension numbers.

--- a/extensions/EXT/EXT_external_objects_win32.txt
+++ b/extensions/EXT/EXT_external_objects_win32.txt
@@ -252,6 +252,19 @@ Additions to Chapter 6 of the OpenGL 4.5 Specification (Memory Objects)
         handle types defined as NT handles, the application must release the
         handle using an appropriate system call when it is no longer needed.
 
+Additions to Chapter 21 of the OpenGL 4.5 Specification (Special Functions)
+
+    Add the following to section 21.4.1, Commands Not Usable in Display
+    Lists.
+
+    Under the "Memory Objects" section:
+
+        ImportMemoryWin32HandleEXT, ImportMemoryWin32NameEXT
+
+    Under the "GL command stream management" section:
+
+        ImportSemaphoreWin32HandleEXT, ImportSemaphoreWin32NameEXT
+
 Issues
 
     1) What should the type of the <name> parameter be in the functions
@@ -268,6 +281,10 @@ Issues
        prototype and define its type through spec language.
 
 Revision History
+
+    Revision 9, 2022-07-15 (James Jones)
+        - Added commands to the list of commands not permitted in display
+          lists.
 
     Revision 8, 2017-06-02 (James Jones)
         - Added extension numbers.


### PR DESCRIPTION
-SignalSemaphoreEXT implicitly flushes command stream

-None of the new external object commands can be included in display lists