### PR TITLE
Added group PixelType to multiple-enums

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5112,8 +5112,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8DAA" name="GL_LAYER_NV"/>
         <enum value="0x8DAB" name="GL_DEPTH_COMPONENT32F_NV" group="InternalFormat,SizedInternalFormat"/>
         <enum value="0x8DAC" name="GL_DEPTH32F_STENCIL8_NV" group="InternalFormat,SizedInternalFormat"/>
-        <enum value="0x8DAD" name="GL_FLOAT_32_UNSIGNED_INT_24_8_REV"/>
-        <enum value="0x8DAD" name="GL_FLOAT_32_UNSIGNED_INT_24_8_REV_NV"/>
+        <enum value="0x8DAD" name="GL_FLOAT_32_UNSIGNED_INT_24_8_REV" group="PixelType"/>
+        <enum value="0x8DAD" name="GL_FLOAT_32_UNSIGNED_INT_24_8_REV_NV" group="PixelType"/>
         <enum value="0x8DAE" name="GL_SHADER_INCLUDE_ARB"/>
         <enum value="0x8DAF" name="GL_DEPTH_BUFFER_FLOAT_MODE_NV"/>
             <unused start="0x8DB0" end="0x8DB8" vendor="NV"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -930,10 +930,10 @@ typedef unsigned int GLhandleARB;
         <enum value="0x1409" name="GL_4_BYTES_NV"/>
         <enum value="0x140A" name="GL_DOUBLE" group="VertexAttribLType,MapTypeNV,SecondaryColorPointerTypeIBM,WeightPointerTypeARB,TangentPointerTypeEXT,BinormalPointerTypeEXT,FogCoordinatePointerType,FogPointerTypeEXT,FogPointerTypeIBM,IndexPointerType,NormalPointerType,TexCoordPointerType,VertexPointerType,VertexAttribType,AttributeType,UniformType,VertexAttribPointerType,GlslTypeToken"/>
         <enum value="0x140A" name="GL_DOUBLE_EXT" group="BinormalPointerTypeEXT,TangentPointerTypeEXT"/>
-        <enum value="0x140B" name="GL_HALF_FLOAT" group="VertexAttribPointerType,VertexAttribType"/>
-        <enum value="0x140B" name="GL_HALF_FLOAT_ARB"/>
-        <enum value="0x140B" name="GL_HALF_FLOAT_NV"/>
-        <enum value="0x140B" name="GL_HALF_APPLE"/>
+        <enum value="0x140B" name="GL_HALF_FLOAT" group="PixelType,VertexAttribPointerType,VertexAttribType"/>
+        <enum value="0x140B" name="GL_HALF_FLOAT_ARB" group="PixelType"/>
+        <enum value="0x140B" name="GL_HALF_FLOAT_NV" group="PixelType"/>
+        <enum value="0x140B" name="GL_HALF_APPLE" group="PixelType"/>
         <enum value="0x140C" name="GL_FIXED" group="VertexAttribPointerType,VertexAttribType"/>
         <enum value="0x140C" name="GL_FIXED_OES"/>
             <unused start="0x140D" comment="Leave gap to preserve even/odd int/uint token values"/>
@@ -2749,10 +2749,10 @@ typedef unsigned int GLhandleARB;
         <enum value="0x84F9" name="GL_DEPTH_STENCIL_EXT" group="InternalFormat"/>
         <enum value="0x84F9" name="GL_DEPTH_STENCIL_NV" group="InternalFormat"/>
         <enum value="0x84F9" name="GL_DEPTH_STENCIL_OES" group="InternalFormat"/>
-        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8"/>
-        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_EXT"/>
-        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_NV"/>
-        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_OES"/>
+        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8" group="PixelType"/>
+        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_EXT" group="PixelType"/>
+        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_NV" group="PixelType"/>
+        <enum value="0x84FA" name="GL_UNSIGNED_INT_24_8_OES" group="PixelType"/>
             <unused start="0x84FB" end="0x84FC" vendor="NV"/>
         <enum value="0x84FD" name="GL_MAX_TEXTURE_LOD_BIAS" group="GetPName"/>
         <enum value="0x84FD" name="GL_MAX_TEXTURE_LOD_BIAS_EXT"/>
@@ -4651,16 +4651,16 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8C3A" name="GL_R11F_G11F_B10F" group="InternalFormat,SizedInternalFormat"/>
         <enum value="0x8C3A" name="GL_R11F_G11F_B10F_APPLE" group="InternalFormat,SizedInternalFormat"/>
         <enum value="0x8C3A" name="GL_R11F_G11F_B10F_EXT" group="InternalFormat,SizedInternalFormat"/>
-        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV" group="VertexAttribPointerType,VertexAttribType"/>
-        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV_APPLE"/>
-        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV_EXT"/>
+        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV" group="PixelType,VertexAttribPointerType,VertexAttribType"/>
+        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV_APPLE" group="PixelType"/>
+        <enum value="0x8C3B" name="GL_UNSIGNED_INT_10F_11F_11F_REV_EXT" group="PixelType"/>
         <enum value="0x8C3C" name="GL_RGBA_SIGNED_COMPONENTS_EXT"/>
         <enum value="0x8C3D" name="GL_RGB9_E5" group="InternalFormat,SizedInternalFormat"/>
         <enum value="0x8C3D" name="GL_RGB9_E5_APPLE" group="InternalFormat,SizedInternalFormat"/>
         <enum value="0x8C3D" name="GL_RGB9_E5_EXT" group="InternalFormat,SizedInternalFormat"/>
-        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV"/>
-        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV_APPLE"/>
-        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV_EXT"/>
+        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV" group="PixelType"/>
+        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV_APPLE" group="PixelType"/>
+        <enum value="0x8C3E" name="GL_UNSIGNED_INT_5_9_9_9_REV_EXT" group="PixelType"/>
         <enum value="0x8C3F" name="GL_TEXTURE_SHARED_SIZE"/>
         <enum value="0x8C3F" name="GL_TEXTURE_SHARED_SIZE_EXT"/>
         <enum value="0x8C40" name="GL_SRGB" group="InternalFormat"/>


### PR DESCRIPTION
Fixes #500 

Adds the `PixelType` group to the following enums
```c
GL_HALF_FLOAT
GL_HALF_FLOAT_ARB
GL_HALF_FLOAT_NV
GL_HALF_APPLE
GL_UNSIGNED_INT_24_8
GL_UNSIGNED_INT_24_8_EXT
GL_UNSIGNED_INT_24_8_NV
GL_UNSIGNED_INT_24_8_OES
GL_UNSIGNED_INT_10F_11F_11F_REV
GL_UNSIGNED_INT_10F_11F_11F_REV_APPLE
GL_UNSIGNED_INT_10F_11F_11F_REV_EXT
GL_UNSIGNED_INT_5_9_9_9_REV
GL_UNSIGNED_INT_5_9_9_9_REV_APPLE
GL_UNSIGNED_INT_5_9_9_9_REV_EXT
GL_FLOAT_32_UNSIGNED_INT_24_8_REV
GL_FLOAT_32_UNSIGNED_INT_24_8_REV_NV
```