### PR TITLE
Add missing len attributes to GL commands

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8410,21 +8410,21 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param len="COMPSIZE(buffer)">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
-            <param>const <ptype>GLint</ptype> *<name>value</name></param>
+            <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferuiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param len="COMPSIZE(buffer)">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearPixelLocalStorageuiEXT</name></proto>
@@ -13220,7 +13220,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>pixels</name></param>
+            <param len="bufSize">void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetCompressedTextureImageEXT</name></proto>
@@ -13240,7 +13240,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>pixels</name></param>
+            <param len="bufSize">void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetConvolutionFilter</name></proto>
@@ -15385,7 +15385,7 @@ typedef unsigned int GLhandleARB;
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>pixels</name></param>
+            <param len="bufSize">void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetTextureImageEXT</name></proto>
@@ -15507,7 +15507,7 @@ typedef unsigned int GLhandleARB;
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>pixels</name></param>
+            <param len="bufSize">void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetTrackMatrixivNV</name></proto>
@@ -16597,13 +16597,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glInvalidateNamedFramebufferData</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param group="FramebufferAttachment" len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
         </command>
         <command>
             <proto>void <name>glInvalidateNamedFramebufferSubData</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param group="FramebufferAttachment" len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
             <param><ptype>GLint</ptype> <name>x</name></param>
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -19060,7 +19060,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedBufferData</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param>const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
             <param group="VertexBufferObjectUsage"><ptype>GLenum</ptype> <name>usage</name></param>
         </command>
         <command>
@@ -19128,7 +19128,7 @@ typedef unsigned int GLhandleARB;
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param len="COMPSIZE(size)">const void *<name>data</name></param>
+            <param len="size">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferSubDataEXT</name></proto>
@@ -19155,7 +19155,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedFramebufferDrawBuffers</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param group="ColorBuffer">const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param group="ColorBuffer" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferParameteri</name></proto>
@@ -23292,8 +23292,8 @@ typedef unsigned int GLhandleARB;
             <param class="shader"><ptype>GLuint</ptype> <name>shader</name></param>
             <param>const <ptype>GLchar</ptype> *<name>pEntryPoint</name></param>
             <param><ptype>GLuint</ptype> <name>numSpecializationConstants</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>pConstantIndex</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>pConstantValue</name></param>
+            <param len="numSpecializationConstants">const <ptype>GLuint</ptype> *<name>pConstantIndex</name></param>
+            <param len="numSpecializationConstants">const <ptype>GLuint</ptype> *<name>pConstantValue</name></param>
         </command>
         <command>
             <proto>void <name>glSpecializeShaderARB</name></proto>
@@ -25068,7 +25068,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureParameterIiv</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterIivEXT</name></proto>
@@ -25081,7 +25081,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureParameterIuiv</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterIuivEXT</name></proto>
@@ -25108,7 +25108,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureParameterfv</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>param</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterfvEXT</name></proto>
@@ -25135,7 +25135,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureParameteriv</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param>const <ptype>GLint</ptype> *<name>param</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterivEXT</name></proto>
@@ -27018,9 +27018,9 @@ typedef unsigned int GLhandleARB;
             <param class="vertex array"><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param class="buffer">const <ptype>GLuint</ptype> *<name>buffers</name></param>
-            <param>const <ptype>GLintptr</ptype> *<name>offsets</name></param>
-            <param>const <ptype>GLsizei</ptype> *<name>strides</name></param>
+            <param class="buffer" len="count">const <ptype>GLuint</ptype> *<name>buffers</name></param>
+            <param len="count">const <ptype>GLintptr</ptype> *<name>offsets</name></param>
+            <param len="count">const <ptype>GLsizei</ptype> *<name>strides</name></param>
         </command>
         <command>
             <proto>void <name>glVertexArrayVertexOffsetEXT</name></proto>


### PR DESCRIPTION
Add missing "len=" attribs to about ten XML core API command definitions
Correct one "len=" attrib from unnecessary COMPSIZE to size in bytes

Found these while trying to autogenerate a Python API for the Core OpenGL 4.6 commands directly from the XML