### PR TITLE
Rename group attribute for non GLenum parameters not corresponding to any enum group

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8313,45 +8313,45 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>
             <proto>void <name>glClearColorIiEXT</name></proto>
-            <param><ptype>GLint</ptype> <name>red</name></param>
-            <param><ptype>GLint</ptype> <name>green</name></param>
-            <param><ptype>GLint</ptype> <name>blue</name></param>
-            <param><ptype>GLint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4292"/>
         </command>
         <command>
             <proto>void <name>glClearColorIuiEXT</name></proto>
-            <param><ptype>GLuint</ptype> <name>red</name></param>
-            <param><ptype>GLuint</ptype> <name>green</name></param>
-            <param><ptype>GLuint</ptype> <name>blue</name></param>
-            <param><ptype>GLuint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4293"/>
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8361,17 +8361,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped01"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
@@ -8621,16 +8621,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3fVertex3fSUN</name></proto>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glColor3fVertex3fvSUN</name></proto>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -8640,14 +8640,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor3hvNV</name></proto>
-            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4244"/>
         </command>
         <command>
@@ -8712,13 +8712,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3xOES</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
         </command>
         <command>
             <proto>void <name>glColor3xvOES</name></proto>
-            <param len="3">const <ptype>GLfixed</ptype> *<name>components</name></param>
+            <param kind="Color" len="3">const <ptype>GLfixed</ptype> *<name>components</name></param>
         </command>
         <command>
             <proto>void <name>glColor4b</name></proto>
@@ -8756,10 +8756,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fNormal3fVertex3fSUN</name></proto>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -8769,7 +8769,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fNormal3fVertex3fvSUN</name></proto>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -8780,15 +8780,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor4hvNV</name></proto>
-            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4245"/>
         </command>
         <command>
@@ -8827,31 +8827,31 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ubVertex2fSUN</name></proto>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex2fvSUN</name></proto>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex3fSUN</name></proto>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex3fvSUN</name></proto>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -8887,26 +8887,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4x</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glColor4xOES</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glColor4xvOES</name></proto>
-            <param len="4">const <ptype>GLfixed</ptype> *<name>components</name></param>
+            <param kind="Color" len="4">const <ptype>GLfixed</ptype> *<name>components</name></param>
         </command>
         <command>
             <proto>void <name>glColorFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -21546,7 +21546,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2dvEXT</name></proto>
@@ -21554,7 +21554,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2fv</name></proto>
@@ -21702,7 +21702,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x2fv"/>
         </command>
         <command>
@@ -26173,7 +26173,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fv</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7029,7 +7029,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAccum</name></proto>
             <param group="AccumOp"><ptype>GLenum</ptype> <name>op</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>value</name></param>
             <glx type="render" opcode="137"/>
         </command>
         <command>
@@ -7691,14 +7691,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBinormal3fEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>bx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>by</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>bz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>bx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>by</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>bz</name></param>
             <vecequiv name="glBinormal3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glBinormal3fvEXT</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glBinormal3iEXT</name></proto>
@@ -7732,10 +7732,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glBitmap</name></proto>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>xorig</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>yorig</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>xmove</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ymove</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>xorig</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>yorig</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>xmove</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ymove</name></param>
             <param len="COMPSIZE(width,height)">const <ptype>GLubyte</ptype> *<name>bitmap</name></param>
             <glx type="render" opcode="5"/>
             <glx type="render" opcode="311" name="glBitmapPBO" comment="PBO protocol"/>
@@ -10477,19 +10477,19 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeformationMap3fSGIX</name></proto>
             <param group="FfdTargetSGIX"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="2074"/>
         </command>
         <command>
@@ -11716,12 +11716,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord1f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u</name></param>
             <vecequiv name="glEvalCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord1fv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>u</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>u</name></param>
             <glx type="render" opcode="152"/>
         </command>
         <command>
@@ -11745,13 +11745,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v</name></param>
             <vecequiv name="glEvalCoord2fv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>u</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>u</name></param>
             <glx type="render" opcode="154"/>
         </command>
         <command>
@@ -12053,23 +12053,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogCoordf</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>coord</name></param>
             <vecequiv name="glFogCoordfv"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>coord</name></param>
             <alias name="glFogCoordf"/>
             <vecequiv name="glFogCoordfvEXT"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
             <glx type="render" opcode="4124"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfvEXT</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
             <alias name="glFogCoordfv"/>
             <glx type="render" opcode="4124"/>
         </command>
@@ -17252,11 +17252,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap1f</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="144"/>
         </command>
         <command>
@@ -17285,15 +17285,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap2f</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="146"/>
         </command>
         <command>
@@ -17364,8 +17364,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid1f</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <glx type="render" opcode="148"/>
         </command>
         <command>
@@ -17387,11 +17387,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid2f</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>vn</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <glx type="render" opcode="150"/>
         </command>
         <command>
@@ -17464,11 +17464,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib1fAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordF" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib2dAPPLE</name></proto>
@@ -17488,15 +17488,15 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib2fAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialf</name></proto>
@@ -18094,26 +18094,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1fv"/>
             <alias name="glMultiTexCoord1f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="199"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1fv"/>
             <glx type="render" opcode="199"/>
         </command>
@@ -18233,28 +18233,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2fv"/>
             <alias name="glMultiTexCoord2f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="203"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2fv"/>
             <glx type="render" opcode="203"/>
         </command>
@@ -18383,30 +18383,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3fv"/>
             <alias name="glMultiTexCoord3f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="207"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3fv"/>
             <glx type="render" opcode="207"/>
         </command>
@@ -18544,32 +18544,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4fv"/>
             <alias name="glMultiTexCoord4f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="211"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4fv"/>
             <glx type="render" opcode="211"/>
         </command>
@@ -19470,9 +19470,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>nx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ny</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>nz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>nx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ny</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>nz</name></param>
             <vecequiv name="glNormal3fv"/>
         </command>
         <command>
@@ -19491,7 +19491,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="30"/>
         </command>
         <command>
@@ -21921,13 +21921,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="34"/>
         </command>
         <command>
@@ -21975,14 +21975,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="38"/>
         </command>
         <command>
@@ -22034,15 +22034,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="42"/>
         </command>
         <command>
@@ -22186,16 +22186,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRectf</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x2</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y2</name></param>
             <vecequiv name="glRectfv"/>
         </command>
         <command>
             <proto>void <name>glRectfv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v1</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v2</name></param>
             <glx type="render" opcode="46"/>
         </command>
         <command>
@@ -23537,14 +23537,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTangent3fEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>tx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ty</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>tz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>tx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ty</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>tz</name></param>
             <vecequiv name="glTangent3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glTangent3fvEXT</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTangent3iEXT</name></proto>
@@ -23690,12 +23690,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1fv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="50"/>
         </command>
         <command>
@@ -23758,8 +23758,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2fv"/>
         </command>
         <command>
@@ -23851,7 +23851,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="54"/>
         </command>
         <command>
@@ -23920,14 +23920,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3fv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="58"/>
         </command>
         <command>
@@ -24002,10 +24002,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4fv"/>
         </command>
         <command>
@@ -24051,7 +24051,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="62"/>
         </command>
         <command>
@@ -26583,13 +26583,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glVertex2fv"/>
         </command>
         <command>
             <proto>void <name>glVertex2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="66"/>
         </command>
         <command>
@@ -26657,14 +26657,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glVertex3fv"/>
         </command>
         <command>
             <proto>void <name>glVertex3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="70"/>
         </command>
         <command>
@@ -26738,15 +26738,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glVertex4fv"/>
         </command>
         <command>
             <proto>void <name>glVertex4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="74"/>
         </command>
         <command>
@@ -29112,38 +29112,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2fv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fARB</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <alias name="glWindowPos2f"/>
             <vecequiv name="glWindowPos2fvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <alias name="glWindowPos2f"/>
             <vecequiv name="glWindowPos2fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fvARB</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos2fv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fvMESA</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos2fv"/>
         </command>
         <command>
@@ -29259,41 +29259,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3fv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fARB</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <alias name="glWindowPos3f"/>
             <vecequiv name="glWindowPos3fvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <alias name="glWindowPos3f"/>
             <vecequiv name="glWindowPos3fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fvARB</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos3fv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fvMESA</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos3fv"/>
         </command>
         <command>
@@ -29388,15 +29388,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4fvMESA</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4iMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8569,14 +8569,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3b</name></proto>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>red</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>green</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>blue</name></param>
             <vecequiv name="glColor3bv"/>
         </command>
         <command>
             <proto>void <name>glColor3bv</name></proto>
-            <param kind="ColorB" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="6"/>
         </command>
         <command>
@@ -8701,15 +8701,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4b</name></proto>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>red</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>green</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>blue</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4bv"/>
         </command>
         <command>
             <proto>void <name>glColor4bv</name></proto>
-            <param kind="ColorB" len="4">const <ptype>GLbyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLbyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="14"/>
         </command>
         <command>
@@ -22834,27 +22834,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3b</name></proto>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>red</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>green</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3bv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3bEXT</name></proto>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>red</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>green</name></param>
-            <param kind="ColorB"><ptype>GLbyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLbyte</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3b"/>
             <vecequiv name="glSecondaryColor3bvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3bv</name></proto>
-            <param kind="ColorB" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="4126"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3bvEXT</name></proto>
-            <param kind="ColorB" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLbyte</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3bv"/>
             <glx type="render" opcode="4126"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10757,8 +10757,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthBoundsEXT</name></proto>
-            <param kind="ClampedFloat64"><ptype>GLclampd</ptype> <name>zmin</name></param>
-            <param kind="ClampedFloat64"><ptype>GLclampd</ptype> <name>zmax</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampd</ptype> <name>zmin</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampd</ptype> <name>zmax</name></param>
             <glx type="render" opcode="4229"/>
         </command>
         <command>
@@ -20418,7 +20418,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="ClampedFloat32" len="n">const <ptype>GLclampf</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0; 1]" len="n">const <ptype>GLclampf</ptype> *<name>priorities</name></param>
             <alias name="glPrioritizeTextures"/>
             <glx type="render" opcode="4118"/>
         </command>
@@ -22650,7 +22650,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSampleMaskEXT</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>value</name></param>
             <param><ptype>GLboolean</ptype> <name>invert</name></param>
         </command>
         <command>
@@ -22660,7 +22660,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSampleMaskSGIS</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>value</name></param>
             <param><ptype>GLboolean</ptype> <name>invert</name></param>
             <alias name="glSampleMaskEXT"/>
             <glx type="render" opcode="2048"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5889,7 +5889,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x907F" name="GL_PATH_CLIENT_LENGTH_NV" group="PathParameter"/>
         <enum value="0x9080" name="GL_PATH_FILL_MODE_NV" group="PathParameter,PathFillMode"/>
         <enum value="0x9081" name="GL_PATH_FILL_MASK_NV" group="PathParameter"/>
-        <enum value="0x9082" name="GL_PATH_FILL_COVER_MODE_NV" group="PathCoverMode,PathParameter"/>
+        <enum value="0x9082" name="GL_PATH_FILL_COVER_MODE_NV" group="PathCoverMode,InstancedPathCoverMode,PathParameter"/>
         <enum value="0x9083" name="GL_PATH_STROKE_COVER_MODE_NV" group="PathParameter"/>
         <enum value="0x9084" name="GL_PATH_STROKE_MASK_NV" group="PathParameter"/>
             <!-- <enum value="0x9085" name="GL_PATH_SAMPLE_QUALITY_NV"          comment="Removed from extension"/> -->
@@ -5898,9 +5898,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9088" name="GL_COUNT_UP_NV" group="PathFillMode"/>
         <enum value="0x9089" name="GL_COUNT_DOWN_NV" group="PathFillMode"/>
         <enum value="0x908A" name="GL_PATH_OBJECT_BOUNDING_BOX_NV" group="PathGenMode,PathParameter"/>
-        <enum value="0x908B" name="GL_CONVEX_HULL_NV" group="PathCoverMode"/>
+        <enum value="0x908B" name="GL_CONVEX_HULL_NV" group="PathCoverMode,InstancedPathCoverMode"/>
             <!-- <enum value="0x908C" name="GL_MULTI_HULLS_NV"                  comment="Removed from extension"/> -->
-        <enum value="0x908D" name="GL_BOUNDING_BOX_NV" group="PathCoverMode"/>
+        <enum value="0x908D" name="GL_BOUNDING_BOX_NV" group="PathCoverMode,InstancedPathCoverMode"/>
         <enum value="0x908E" name="GL_TRANSLATE_X_NV" group="PathTransformType"/>
         <enum value="0x908F" name="GL_TRANSLATE_Y_NV" group="PathTransformType"/>
         <enum value="0x9090" name="GL_TRANSLATE_2D_NV" group="PathTransformType"/>
@@ -5915,7 +5915,7 @@ typedef unsigned int GLhandleARB;
             <!-- <enum value="0x9099" name="GL_TRANSPOSE_PROJECTIVE_3D_NV"      comment="Removed from extension"/> -->
         <enum value="0x909A" name="GL_UTF8_NV" group="PathElementType"/>
         <enum value="0x909B" name="GL_UTF16_NV" group="PathElementType"/>
-        <enum value="0x909C" name="GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV" group="PathCoverMode"/>
+        <enum value="0x909C" name="GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV" group="InstancedPathCoverMode"/>
         <enum value="0x909D" name="GL_PATH_COMMAND_COUNT_NV" group="PathParameter"/>
         <enum value="0x909E" name="GL_PATH_COORD_COUNT_NV" group="PathParameter"/>
         <enum value="0x909F" name="GL_PATH_DASH_ARRAY_COUNT_NV" group="PathParameter"/>
@@ -10197,7 +10197,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -10212,7 +10212,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23467,40 +23467,40 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glStencilThenCoverFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
-            <param><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param>const void *<name>paths</name></param>
-            <param><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
-            <param><ptype>GLenum</ptype> <name>transformType</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
+            <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
+            <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
+            <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverFillPathNV</name></proto>
-            <param><ptype>GLuint</ptype> <name>path</name></param>
-            <param><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
+            <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
+            <param kind="StencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
-            <param><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param>const void *<name>paths</name></param>
-            <param><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param><ptype>GLint</ptype> <name>reference</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
-            <param><ptype>GLenum</ptype> <name>transformType</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
+            <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
+            <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverStrokePathNV</name></proto>
-            <param><ptype>GLuint</ptype> <name>path</name></param>
-            <param><ptype>GLint</ptype> <name>reference</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
         </command>
         <command>
             <proto>void <name>glStopInstrumentsSGIX</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -76,7 +76,10 @@ typedef unsigned int GLhandleARB;
         <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
         <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
         <kind name="String" desc="This parameter represents a string of characters." />
-        <!--ColorIndexValue-->
+        <kind name="DrawBufferIndex" desc="This parameter represents the i in GL_DRAW_BUFFERi." />
+
+        <!-- Applicable to legacy OpenGL functions -->
+        <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
         <!--SelectName  glLoadName-->
         <!--FeedbackElement glPassThrough-->
         
@@ -16503,52 +16506,52 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexd</name></proto>
-            <param kind="ColorIndexValueD"><ptype>GLdouble</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLdouble</ptype> <name>c</name></param>
             <vecequiv name="glIndexdv"/>
         </command>
         <command>
             <proto>void <name>glIndexdv</name></proto>
-            <param kind="ColorIndexValueD" len="1">const <ptype>GLdouble</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLdouble</ptype> *<name>c</name></param>
             <glx type="render" opcode="24"/>
         </command>
         <command>
             <proto>void <name>glIndexf</name></proto>
-            <param kind="ColorIndexValueF"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <vecequiv name="glIndexfv"/>
         </command>
         <command>
             <proto>void <name>glIndexfv</name></proto>
-            <param kind="ColorIndexValueF" len="1">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <glx type="render" opcode="25"/>
         </command>
         <command>
             <proto>void <name>glIndexi</name></proto>
-            <param kind="ColorIndexValueI"><ptype>GLint</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLint</ptype> <name>c</name></param>
             <vecequiv name="glIndexiv"/>
         </command>
         <command>
             <proto>void <name>glIndexiv</name></proto>
-            <param kind="ColorIndexValueI" len="1">const <ptype>GLint</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLint</ptype> *<name>c</name></param>
             <glx type="render" opcode="26"/>
         </command>
         <command>
             <proto>void <name>glIndexs</name></proto>
-            <param kind="ColorIndexValueS"><ptype>GLshort</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLshort</ptype> <name>c</name></param>
             <vecequiv name="glIndexsv"/>
         </command>
         <command>
             <proto>void <name>glIndexsv</name></proto>
-            <param kind="ColorIndexValueS" len="1">const <ptype>GLshort</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLshort</ptype> *<name>c</name></param>
             <glx type="render" opcode="27"/>
         </command>
         <command>
             <proto>void <name>glIndexub</name></proto>
-            <param kind="ColorIndexValueUB"><ptype>GLubyte</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLubyte</ptype> <name>c</name></param>
             <vecequiv name="glIndexubv"/>
         </command>
         <command>
             <proto>void <name>glIndexubv</name></proto>
-            <param kind="ColorIndexValueUB" len="1">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <glx type="render" opcode="194"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8643,14 +8643,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3s</name></proto>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>red</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>green</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>blue</name></param>
             <vecequiv name="glColor3sv"/>
         </command>
         <command>
             <proto>void <name>glColor3sv</name></proto>
-            <param kind="ColorS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="10"/>
         </command>
         <command>
@@ -8785,15 +8785,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4s</name></proto>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>red</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>green</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>blue</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4sv"/>
         </command>
         <command>
             <proto>void <name>glColor4sv</name></proto>
-            <param kind="ColorS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="18"/>
         </command>
         <command>
@@ -22950,27 +22950,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3s</name></proto>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>red</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>green</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3sv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3sEXT</name></proto>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>red</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>green</name></param>
-            <param kind="ColorS"><ptype>GLshort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLshort</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3s"/>
             <vecequiv name="glSecondaryColor3svEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3sv</name></proto>
-            <param kind="ColorS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="4127"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3svEXT</name></proto>
-            <param kind="ColorS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3sv"/>
             <glx type="render" opcode="4127"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8619,14 +8619,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor3hvNV</name></proto>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4244"/>
         </command>
         <command>
@@ -8759,15 +8759,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>blue</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>alpha</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor4hvNV</name></proto>
-            <param kind="Half16NV" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4245"/>
         </command>
         <command>
@@ -12075,12 +12075,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogCoordhNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>fog</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>fog</name></param>
             <vecequiv name="glFogCoordhvNV"/>
         </command>
         <command>
             <proto>void <name>glFogCoordhvNV</name></proto>
-            <param kind="Half16NV" len="1">const <ptype>GLhalfNV</ptype> *<name>fog</name></param>
+            <param len="1">const <ptype>GLhalfNV</ptype> *<name>fog</name></param>
             <glx type="render" opcode="4254"/>
         </command>
         <command>
@@ -18120,13 +18120,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1hNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1hvNV"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1hvNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV" len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4250"/>
         </command>
         <command>
@@ -18261,14 +18261,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2hNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2hvNV"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2hvNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV" len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4251"/>
         </command>
         <command>
@@ -18413,15 +18413,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3hNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>r</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3hvNV"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3hvNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4252"/>
         </command>
         <command>
@@ -18576,16 +18576,16 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4hNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>r</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>q</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>r</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4hvNV"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4hvNV</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Half16NV" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4253"/>
         </command>
         <command>
@@ -19496,14 +19496,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>nx</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>ny</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>nz</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>nx</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>ny</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>nz</name></param>
             <vecequiv name="glNormal3hvNV"/>
         </command>
         <command>
             <proto>void <name>glNormal3hvNV</name></proto>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4243"/>
         </command>
         <command>
@@ -22912,14 +22912,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hvNV</name></proto>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4255"/>
         </command>
         <command>
@@ -23700,12 +23700,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1hvNV"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1hvNV</name></proto>
-            <param kind="Half16NV" len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4246"/>
         </command>
         <command>
@@ -23856,13 +23856,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2hvNV"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2hvNV</name></proto>
-            <param kind="Half16NV" len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4247"/>
         </command>
         <command>
@@ -23932,14 +23932,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>r</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3hvNV"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3hvNV</name></proto>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4248"/>
         </command>
         <command>
@@ -24056,15 +24056,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>s</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>t</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>r</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>q</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>s</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>t</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>r</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4hvNV"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4hvNV</name></proto>
-            <param kind="Half16NV" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4249"/>
         </command>
         <command>
@@ -26594,13 +26594,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
             <vecequiv name="glVertex2hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertex2hvNV</name></proto>
-            <param kind="Half16NV" len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4240"/>
         </command>
         <command>
@@ -26669,14 +26669,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>z</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>z</name></param>
             <vecequiv name="glVertex3hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertex3hvNV</name></proto>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4241"/>
         </command>
         <command>
@@ -26751,15 +26751,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4hNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>z</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>w</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>z</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>w</name></param>
             <vecequiv name="glVertex4hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertex4hvNV</name></proto>
-            <param kind="Half16NV" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4242"/>
         </command>
         <command>
@@ -27114,13 +27114,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib1hNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
             <vecequiv name="glVertexAttrib1hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertexAttrib1hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV" len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="1">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4257"/>
         </command>
         <command>
@@ -27252,14 +27252,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib2hNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
             <vecequiv name="glVertexAttrib2hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertexAttrib2hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV" len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="2">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4258"/>
         </command>
         <command>
@@ -27400,15 +27400,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib3hNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>z</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>z</name></param>
             <vecequiv name="glVertexAttrib3hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertexAttrib3hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4259"/>
         </command>
         <command>
@@ -27654,16 +27654,16 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib4hNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>x</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>y</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>z</name></param>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>w</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>x</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>y</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>z</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>w</name></param>
             <vecequiv name="glVertexAttrib4hvNV"/>
         </command>
         <command>
             <proto>void <name>glVertexAttrib4hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Half16NV" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4260"/>
         </command>
         <command>
@@ -28467,7 +28467,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs1hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param kind="Half16NV" len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4261"/>
         </command>
         <command>
@@ -28495,7 +28495,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs2hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param kind="Half16NV" len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4262"/>
         </command>
         <command>
@@ -28523,7 +28523,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs3hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param kind="Half16NV" len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4263"/>
         </command>
         <command>
@@ -28551,7 +28551,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs4hvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param kind="Half16NV" len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param len="n">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4264"/>
         </command>
         <command>
@@ -28856,12 +28856,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertexWeighthNV</name></proto>
-            <param kind="Half16NV"><ptype>GLhalfNV</ptype> <name>weight</name></param>
+            <param><ptype>GLhalfNV</ptype> <name>weight</name></param>
             <vecequiv name="glVertexWeighthvNV"/>
         </command>
         <command>
             <proto>void <name>glVertexWeighthvNV</name></proto>
-            <param kind="Half16NV" len="1">const <ptype>GLhalfNV</ptype> *<name>weight</name></param>
+            <param len="1">const <ptype>GLhalfNV</ptype> *<name>weight</name></param>
             <glx type="render" opcode="4256"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8264,7 +8264,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearBufferfi</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
             <glx type="render" opcode="360"/>
@@ -8272,21 +8272,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearBufferfv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="361"/>
         </command>
         <command>
             <proto>void <name>glClearBufferiv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
             <glx type="render" opcode="362"/>
         </command>
         <command>
             <proto>void <name>glClearBufferuiv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLuint</ptype> *<name>value</name></param>
             <glx type="render" opcode="363"/>
         </command>
@@ -8401,7 +8401,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferfi</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
         </command>
@@ -8409,21 +8409,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferuiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8097,7 +8097,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBufferDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <param group="BufferUsageARB"><ptype>GLenum</ptype> <name>usage</name></param>
             <alias name="glBufferData"/>
@@ -8165,7 +8165,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <alias name="glBufferSubData"/>
         </command>
@@ -13049,7 +13049,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">void *<name>data</name></param>
             <alias name="glGetBufferSubData"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17785,16 +17785,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16457,7 +16457,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>
-            <param kind="MaskedColorIndexValueI"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="MaskedColorIndexValue"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="136"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8631,14 +8631,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <vecequiv name="glColor3iv"/>
         </command>
         <command>
             <proto>void <name>glColor3iv</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="9"/>
         </command>
         <command>
@@ -8772,15 +8772,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4iv"/>
         </command>
         <command>
             <proto>void <name>glColor4iv</name></proto>
-            <param kind="ColorI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="17"/>
         </command>
         <command>
@@ -22924,27 +22924,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3iv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3iEXT</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3i"/>
             <vecequiv name="glSecondaryColor3ivEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3iv</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="4128"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ivEXT</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3iv"/>
             <glx type="render" opcode="4128"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10174,7 +10174,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCoverFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
@@ -10189,7 +10189,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCoverStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
@@ -14393,7 +14393,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathMetricMask"><ptype>GLbitfield</ptype> <name>metricQueryMask</name></param>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(metricQueryMask,numPaths,stride)"><ptype>GLfloat</ptype> *<name>metrics</name></param>
@@ -14415,7 +14415,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathListMode"><ptype>GLenum</ptype> <name>pathListMode</name></param>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param><ptype>GLfloat</ptype> <name>advanceScale</name></param>
             <param><ptype>GLfloat</ptype> <name>kerningScale</name></param>
@@ -23355,7 +23355,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
             <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
@@ -23430,7 +23430,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
             <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14362,7 +14362,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetPathCommandsNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
-            <param kind="PathCommand" len="COMPSIZE(path)"><ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="COMPSIZE(path)"><ptype>GLubyte</ptype> *<name>commands</name></param>
         </command>
         <command>
             <proto>void <name>glGetPathCoordsNV</name></proto>
@@ -19791,7 +19791,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPathCommandsNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param><ptype>GLsizei</ptype> <name>numCommands</name></param>
-            <param kind="PathCommand" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
             <param><ptype>GLsizei</ptype> <name>numCoords</name></param>
             <param group="PathCoordType"><ptype>GLenum</ptype> <name>coordType</name></param>
             <param len="COMPSIZE(numCoords,coordType)">const void *<name>coords</name></param>
@@ -19922,7 +19922,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>commandStart</name></param>
             <param><ptype>GLsizei</ptype> <name>commandsToDelete</name></param>
             <param><ptype>GLsizei</ptype> <name>numCommands</name></param>
-            <param kind="PathCommand" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
             <param><ptype>GLsizei</ptype> <name>numCoords</name></param>
             <param group="PathCoordType"><ptype>GLenum</ptype> <name>coordType</name></param>
             <param len="COMPSIZE(numCoords,coordType)">const void *<name>coords</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18158,26 +18158,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1sv"/>
             <alias name="glMultiTexCoord1s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="201"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1sv"/>
             <glx type="render" opcode="201"/>
         </command>
@@ -18302,28 +18302,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2sv"/>
             <alias name="glMultiTexCoord2s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="205"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2sv"/>
             <glx type="render" opcode="205"/>
         </command>
@@ -18457,30 +18457,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3sv"/>
             <alias name="glMultiTexCoord3s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="209"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3sv"/>
             <glx type="render" opcode="209"/>
         </command>
@@ -18623,32 +18623,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4sv"/>
             <alias name="glMultiTexCoord4s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="213"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4sv"/>
             <glx type="render" opcode="213"/>
         </command>
@@ -21943,13 +21943,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="36"/>
         </command>
         <command>
@@ -21999,14 +21999,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="40"/>
         </command>
         <command>
@@ -22060,15 +22060,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="44"/>
         </command>
         <command>
@@ -22214,16 +22214,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRects</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x1</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y1</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x2</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y2</name></param>
             <vecequiv name="glRectsv"/>
         </command>
         <command>
             <proto>void <name>glRectsv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v1</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v2</name></param>
             <glx type="render" opcode="48"/>
         </command>
         <command>
@@ -23720,12 +23720,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1sv</name></proto>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="52"/>
         </command>
         <command>
@@ -23878,13 +23878,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="56"/>
         </command>
         <command>
@@ -23956,14 +23956,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="60"/>
         </command>
         <command>
@@ -24082,15 +24082,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="64"/>
         </command>
         <command>
@@ -26616,13 +26616,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glVertex2sv"/>
         </command>
         <command>
             <proto>void <name>glVertex2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="68"/>
         </command>
         <command>
@@ -26693,14 +26693,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glVertex3sv"/>
         </command>
         <command>
             <proto>void <name>glVertex3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="72"/>
         </command>
         <command>
@@ -26777,15 +26777,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glVertex4sv"/>
         </command>
         <command>
             <proto>void <name>glVertex4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="76"/>
         </command>
         <command>
@@ -29184,38 +29184,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2sv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sARB</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <alias name="glWindowPos2s"/>
             <vecequiv name="glWindowPos2svARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <alias name="glWindowPos2s"/>
             <vecequiv name="glWindowPos2svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2svARB</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos2sv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2svMESA</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos2sv"/>
         </command>
         <command>
@@ -29337,41 +29337,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3sv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sARB</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <alias name="glWindowPos3s"/>
             <vecequiv name="glWindowPos3svARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <alias name="glWindowPos3s"/>
             <vecequiv name="glWindowPos3svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3svARB</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos3sv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3svMESA</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos3sv"/>
         </command>
         <command>
@@ -29412,15 +29412,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4svMESA</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowRectanglesEXT</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -80,9 +80,8 @@ typedef unsigned int GLhandleARB;
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
-        <!--SelectName  glLoadName-->
-        <!--FeedbackElement glPassThrough-->
-        
+        <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode." />
+        <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer." />
     </kinds>
 
     <!-- SECTION: GL enumerant (token) definitions. -->

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7680,14 +7680,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBinormal3dEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>bx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>by</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>bz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>bx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>by</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>bz</name></param>
             <vecequiv name="glBinormal3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glBinormal3dvEXT</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glBinormal3fEXT</name></proto>
@@ -10459,19 +10459,19 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeformationMap3dSGIX</name></proto>
             <param group="FfdTargetSGIX"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="2073"/>
         </command>
         <command>
@@ -11706,12 +11706,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord1d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u</name></param>
             <vecequiv name="glEvalCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord1dv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>u</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>u</name></param>
             <glx type="render" opcode="151"/>
         </command>
         <command>
@@ -11734,13 +11734,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v</name></param>
             <vecequiv name="glEvalCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>u</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>u</name></param>
             <glx type="render" opcode="153"/>
         </command>
         <command>
@@ -12031,23 +12031,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogCoordd</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>coord</name></param>
             <vecequiv name="glFogCoorddv"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>coord</name></param>
             <alias name="glFogCoordd"/>
             <vecequiv name="glFogCoorddvEXT"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
             <glx type="render" opcode="4125"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddvEXT</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
             <alias name="glFogCoorddv"/>
             <glx type="render" opcode="4125"/>
         </command>
@@ -17242,11 +17242,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap1d</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="143"/>
         </command>
         <command>
@@ -17271,15 +17271,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap2d</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="145"/>
         </command>
         <command>
@@ -17357,8 +17357,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid1d</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <glx type="render" opcode="147"/>
         </command>
         <command>
@@ -17377,11 +17377,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid2d</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>vn</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <glx type="render" opcode="149"/>
         </command>
         <command>
@@ -17454,11 +17454,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib1dAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordD" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib1fAPPLE</name></proto>
@@ -17474,15 +17474,15 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib2dAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib2fAPPLE</name></proto>
@@ -18068,26 +18068,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1dv"/>
             <alias name="glMultiTexCoord1d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="198"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1dv"/>
             <glx type="render" opcode="198"/>
         </command>
@@ -18205,28 +18205,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2dv"/>
             <alias name="glMultiTexCoord2d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="202"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2dv"/>
             <glx type="render" opcode="202"/>
         </command>
@@ -18353,30 +18353,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3dv"/>
             <alias name="glMultiTexCoord3d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="206"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3dv"/>
             <glx type="render" opcode="206"/>
         </command>
@@ -18512,32 +18512,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4dv"/>
             <alias name="glMultiTexCoord4d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="210"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4dv"/>
             <glx type="render" opcode="210"/>
         </command>
@@ -19458,14 +19458,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>nx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>ny</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>nz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>nx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>ny</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>nz</name></param>
             <vecequiv name="glNormal3dv"/>
         </command>
         <command>
             <proto>void <name>glNormal3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="29"/>
         </command>
         <command>
@@ -21910,13 +21910,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="33"/>
         </command>
         <command>
@@ -21963,14 +21963,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="37"/>
         </command>
         <command>
@@ -22021,15 +22021,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="41"/>
         </command>
         <command>
@@ -22172,16 +22172,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRectd</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x2</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y2</name></param>
             <vecequiv name="glRectdv"/>
         </command>
         <command>
             <proto>void <name>glRectdv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v1</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v2</name></param>
             <glx type="render" opcode="45"/>
         </command>
         <command>
@@ -23526,14 +23526,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTangent3dEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>tx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>ty</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>tz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>tx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>ty</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>tz</name></param>
             <vecequiv name="glTangent3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glTangent3dvEXT</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTangent3fEXT</name></proto>
@@ -23680,12 +23680,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1dv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="49"/>
         </command>
         <command>
@@ -23747,13 +23747,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="53"/>
         </command>
         <command>
@@ -23908,14 +23908,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="57"/>
         </command>
         <command>
@@ -23989,15 +23989,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="61"/>
         </command>
         <command>
@@ -26572,13 +26572,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glVertex2dv"/>
         </command>
         <command>
             <proto>void <name>glVertex2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="65"/>
         </command>
         <command>
@@ -26645,14 +26645,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glVertex3dv"/>
         </command>
         <command>
             <proto>void <name>glVertex3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="69"/>
         </command>
         <command>
@@ -26725,15 +26725,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glVertex4dv"/>
         </command>
         <command>
             <proto>void <name>glVertex4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="73"/>
         </command>
         <command>
@@ -29076,38 +29076,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2dv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dARB</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <alias name="glWindowPos2d"/>
             <vecequiv name="glWindowPos2dvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <alias name="glWindowPos2d"/>
             <vecequiv name="glWindowPos2dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dvARB</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos2dv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dvMESA</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos2dv"/>
         </command>
         <command>
@@ -29220,41 +29220,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3dv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dARB</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <alias name="glWindowPos3d"/>
             <vecequiv name="glWindowPos3dvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <alias name="glWindowPos3d"/>
             <vecequiv name="glWindowPos3dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dvARB</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos3dv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dvMESA</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos3dv"/>
         </command>
         <command>
@@ -29376,15 +29376,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4dvMESA</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4fMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7801,10 +7801,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8251,18 +8251,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param><ptype>GLfloat</ptype> <name>red</name></param>
-            <param><ptype>GLfloat</ptype> <name>green</name></param>
-            <param><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -9001,22 +9001,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorP3ui</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4uiv</name></proto>
             <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorPointer</name></proto>
@@ -22387,9 +22387,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -22397,16 +22397,16 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -22417,17 +22417,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -22435,7 +22435,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -22478,7 +22478,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -22933,14 +22933,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hvNV</name></proto>
-            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4255"/>
         </command>
         <command>
@@ -23081,13 +23081,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorPointer</name></proto>
@@ -23787,9 +23787,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexCoord2fColor3fVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -23797,17 +23797,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor3fVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoord2fColor4fNormal3fVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -23818,7 +23818,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -23826,10 +23826,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexCoord2fColor4ubVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -23837,7 +23837,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor4ubVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -24035,10 +24035,10 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>p</name></param>
             <param><ptype>GLfloat</ptype> <name>q</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -24050,7 +24050,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord4fColor4fNormal3fVertex4fvSUN</name></proto>
             <param len="4">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7657,7 +7657,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>video_capture_slot</name></param>
             <param><ptype>GLuint</ptype> <name>stream</name></param>
             <param><ptype>GLenum</ptype> <name>frame_region</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBindVideoCaptureStreamTextureNV</name></proto>
@@ -8164,7 +8164,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
             <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <alias name="glBufferSubData"/>
@@ -13048,7 +13048,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
             <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">void *<name>data</name></param>
             <alias name="glGetBufferSubData"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8175,7 +8175,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCallList</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <glx type="render" opcode="1"/>
         </command>
         <command>
@@ -13820,13 +13820,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetListParameterfvSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetListParameterivSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -17071,7 +17071,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glListBase</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>base</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>base</name></param>
             <glx type="render" opcode="3"/>
         </command>
         <command>
@@ -17086,28 +17086,28 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glListParameterfSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2078"/>
         </command>
         <command>
             <proto>void <name>glListParameterfvSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2079"/>
         </command>
         <command>
             <proto>void <name>glListParameteriSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2080"/>
         </command>
         <command>
             <proto>void <name>glListParameterivSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2081"/>
@@ -19434,7 +19434,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNewList</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <glx type="single" opcode="101"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17044,7 +17044,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glLineStipple</name></proto>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
-            <param kind="LineStipple"><ptype>GLushort</ptype> <name>pattern</name></param>
+            <param><ptype>GLushort</ptype> <name>pattern</name></param>
             <glx type="render" opcode="94"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -47335,4 +47335,3 @@ typedef unsigned int GLhandleARB;
         <extension name="GL_EXT_texture_shadow_lod" supported="gl|glcore|gles2"/>
     </extensions>
 </registry>
-

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8330,10 +8330,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7141,30 +7141,30 @@ typedef unsigned int GLhandleARB;
             <param group="LightTextureModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glAcquireKeyedMutexWin32EXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glAcquireKeyedMutexWin32EXT</name></proto>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>key</name></param>
             <param><ptype>GLuint</ptype> <name>timeout</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glAreProgramsResidentNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glAreProgramsResidentNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="program" len="n">const <ptype>GLuint</ptype> *<name>programs</name></param>
-            <param kind="Boolean" len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
+            <param len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
             <glx type="vendor" opcode="1293"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glAreTexturesResident</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glAreTexturesResident</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Boolean" len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
+            <param len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
             <glx type="single" opcode="143"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glAreTexturesResidentEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glAreTexturesResidentEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Boolean" len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
+            <param len="n"><ptype>GLboolean</ptype> *<name>residences</name></param>
             <glx type="vendor" opcode="11"/>
         </command>
         <command>
@@ -7480,7 +7480,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>unit</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
+            <param><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
             <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -7490,7 +7490,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
+            <param><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
             <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
             <param><ptype>GLint</ptype> <name>format</name></param>
@@ -8107,7 +8107,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glBufferPageCommitmentMemNV</name></proto>
@@ -8116,7 +8116,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>memOffset</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glBufferParameteriAPPLE</name></proto>
@@ -8929,46 +8929,46 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorMask</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>red</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>green</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>blue</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>alpha</name></param>
+            <param><ptype>GLboolean</ptype> <name>red</name></param>
+            <param><ptype>GLboolean</ptype> <name>green</name></param>
+            <param><ptype>GLboolean</ptype> <name>blue</name></param>
+            <param><ptype>GLboolean</ptype> <name>alpha</name></param>
             <glx type="render" opcode="134"/>
         </command>
         <command>
             <proto>void <name>glColorMaskIndexedEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>r</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>g</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>b</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>a</name></param>
+            <param><ptype>GLboolean</ptype> <name>r</name></param>
+            <param><ptype>GLboolean</ptype> <name>g</name></param>
+            <param><ptype>GLboolean</ptype> <name>b</name></param>
+            <param><ptype>GLboolean</ptype> <name>a</name></param>
             <alias name="glColorMaski"/>
             <glx type="render" opcode="352"/>
         </command>
         <command>
             <proto>void <name>glColorMaski</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>r</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>g</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>b</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>a</name></param>
+            <param><ptype>GLboolean</ptype> <name>r</name></param>
+            <param><ptype>GLboolean</ptype> <name>g</name></param>
+            <param><ptype>GLboolean</ptype> <name>b</name></param>
+            <param><ptype>GLboolean</ptype> <name>a</name></param>
         </command>
         <command>
             <proto>void <name>glColorMaskiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>r</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>g</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>b</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>a</name></param>
+            <param><ptype>GLboolean</ptype> <name>r</name></param>
+            <param><ptype>GLboolean</ptype> <name>g</name></param>
+            <param><ptype>GLboolean</ptype> <name>b</name></param>
+            <param><ptype>GLboolean</ptype> <name>a</name></param>
             <alias name="glColorMaski"/>
         </command>
         <command>
             <proto>void <name>glColorMaskiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>r</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>g</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>b</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>a</name></param>
+            <param><ptype>GLboolean</ptype> <name>r</name></param>
+            <param><ptype>GLboolean</ptype> <name>g</name></param>
+            <param><ptype>GLboolean</ptype> <name>b</name></param>
+            <param><ptype>GLboolean</ptype> <name>a</name></param>
             <alias name="glColorMaski"/>
         </command>
         <command>
@@ -9128,9 +9128,9 @@ typedef unsigned int GLhandleARB;
             <param group="CombinerRegisterNV"><ptype>GLenum</ptype> <name>sumOutput</name></param>
             <param group="CombinerScaleNV"><ptype>GLenum</ptype> <name>scale</name></param>
             <param group="CombinerBiasNV"><ptype>GLenum</ptype> <name>bias</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>abDotProduct</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>cdDotProduct</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>muxSum</name></param>
+            <param><ptype>GLboolean</ptype> <name>abDotProduct</name></param>
+            <param><ptype>GLboolean</ptype> <name>cdDotProduct</name></param>
+            <param><ptype>GLboolean</ptype> <name>muxSum</name></param>
             <glx type="render" opcode="4141"/>
         </command>
         <command>
@@ -10202,7 +10202,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCoverageMaskNV</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>mask</name></param>
+            <param><ptype>GLboolean</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glCoverageModulationNV</name></proto>
@@ -10384,7 +10384,7 @@ typedef unsigned int GLhandleARB;
             <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
+            <param><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageControlARB</name></proto>
@@ -10393,7 +10393,7 @@ typedef unsigned int GLhandleARB;
             <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
+            <param><ptype>GLboolean</ptype> <name>enabled</name></param>
             <alias name="glDebugMessageControl"/>
         </command>
         <command>
@@ -10403,7 +10403,7 @@ typedef unsigned int GLhandleARB;
             <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param>const <ptype>GLuint</ptype> *<name>ids</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
+            <param><ptype>GLboolean</ptype> <name>enabled</name></param>
             <alias name="glDebugMessageControl"/>
         </command>
         <command>
@@ -10412,7 +10412,7 @@ typedef unsigned int GLhandleARB;
             <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
+            <param><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsert</name></proto>
@@ -10752,7 +10752,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthMask</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>flag</name></param>
+            <param><ptype>GLboolean</ptype> <name>flag</name></param>
             <glx type="render" opcode="135"/>
         </command>
         <command>
@@ -11503,7 +11503,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEdgeFlag</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>flag</name></param>
+            <param><ptype>GLboolean</ptype> <name>flag</name></param>
             <vecequiv name="glEdgeFlagv"/>
         </command>
         <command>
@@ -11519,7 +11519,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glEdgeFlagPointerEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean" len="COMPSIZE(stride,count)">const <ptype>GLboolean</ptype> *<name>pointer</name></param>
+            <param len="COMPSIZE(stride,count)">const <ptype>GLboolean</ptype> *<name>pointer</name></param>
         </command>
         <command>
             <proto>void <name>glEdgeFlagPointerListIBM</name></proto>
@@ -11529,7 +11529,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEdgeFlagv</name></proto>
-            <param kind="Boolean" len="1">const <ptype>GLboolean</ptype> *<name>flag</name></param>
+            <param len="1">const <ptype>GLboolean</ptype> *<name>flag</name></param>
             <glx type="render" opcode="22"/>
         </command>
         <command>
@@ -11876,7 +11876,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> *<name>numTextures</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glExtIsProgramBinaryQCOM</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glExtIsProgramBinaryQCOM</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
         </command>
         <command>
@@ -12977,7 +12977,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetBooleanIndexedvEXT</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
             <alias name="glGetBooleani_v"/>
             <glx type="single" opcode="210"/>
         </command>
@@ -12985,12 +12985,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetBooleani_v</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetBooleanv</name></proto>
             <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="Boolean" len="COMPSIZE(pname)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLboolean</ptype> *<name>data</name></param>
             <glx type="single" opcode="112"/>
         </command>
         <command>
@@ -13594,7 +13594,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetHistogram</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,format,type)">void *<name>values</name></param>
@@ -13604,7 +13604,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetHistogramEXT</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,format,type)">void *<name>values</name></param>
@@ -13648,7 +13648,7 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint64</ptype> <name>glGetImageHandleARB</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
+            <param><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
         </command>
@@ -13656,7 +13656,7 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint64</ptype> <name>glGetImageHandleNV</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
+            <param><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
         </command>
@@ -13772,7 +13772,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetInvariantBooleanvEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param group="GetVariantValueEXT"><ptype>GLenum</ptype> <name>value</name></param>
-            <param kind="Boolean" len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetInvariantFloatvEXT</name></proto>
@@ -13834,7 +13834,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetLocalConstantBooleanvEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param group="GetVariantValueEXT"><ptype>GLenum</ptype> <name>value</name></param>
-            <param kind="Boolean" len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetLocalConstantFloatvEXT</name></proto>
@@ -13869,7 +13869,7 @@ typedef unsigned int GLhandleARB;
             <param group="MapTypeNV"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>ustride</name></param>
             <param><ptype>GLsizei</ptype> <name>vstride</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>packed</name></param>
+            <param><ptype>GLboolean</ptype> <name>packed</name></param>
             <param len="COMPSIZE(target)">void *<name>points</name></param>
         </command>
         <command>
@@ -13960,7 +13960,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetMinmax</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,format,type)">void *<name>values</name></param>
@@ -13970,7 +13970,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetMinmaxEXT</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,format,type)">void *<name>values</name></param>
@@ -15709,7 +15709,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetVariantBooleanvEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param group="GetVariantValueEXT"><ptype>GLenum</ptype> <name>value</name></param>
-            <param kind="Boolean" len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
+            <param len="COMPSIZE(id)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetVariantFloatvEXT</name></proto>
@@ -16039,7 +16039,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetnHistogram</name></proto>
             <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
@@ -16048,7 +16048,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetnHistogramARB</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
@@ -16099,7 +16099,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetnMinmax</name></proto>
             <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
@@ -16108,7 +16108,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetnMinmaxARB</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
+            <param><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
@@ -16358,7 +16358,7 @@ typedef unsigned int GLhandleARB;
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
+            <param><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4110"/>
         </command>
         <command>
@@ -16366,7 +16366,7 @@ typedef unsigned int GLhandleARB;
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
+            <param><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glHistogram"/>
             <glx type="render" opcode="4110"/>
         </command>
@@ -16636,269 +16636,269 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsAsyncMarkerSGIX</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsAsyncMarkerSGIX</name></proto>
             <param><ptype>GLuint</ptype> <name>marker</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsBuffer</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsBuffer</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsBufferARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsBufferARB</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glIsBuffer"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsBufferResidentNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsBufferResidentNV</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsCommandListNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsCommandListNV</name></proto>
             <param><ptype>GLuint</ptype> <name>list</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabled</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnabled</name></proto>
             <param group="EnableCap"><ptype>GLenum</ptype> <name>cap</name></param>
             <glx type="single" opcode="140"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabledIndexedEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnabledIndexedEXT</name></proto>
             <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
             <glx type="single" opcode="212"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabledi</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnabledi</name></proto>
             <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediEXT</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLuint</ptype> <name>index</name></param>
-            <alias name="glIsEnabledi"/>
-        </command>
-        <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnablediEXT</name></proto>
             <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediOES</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnablediNV</name></proto>
             <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsFenceAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsEnablediOES</name></proto>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <alias name="glIsEnabledi"/>
+        </command>
+        <command>
+            <proto><ptype>GLboolean</ptype> <name>glIsFenceAPPLE</name></proto>
             <param kind="FenceNV"><ptype>GLuint</ptype> <name>fence</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsFenceNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsFenceNV</name></proto>
             <param kind="FenceNV"><ptype>GLuint</ptype> <name>fence</name></param>
             <glx type="vendor" opcode="1278"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsFramebuffer</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsFramebuffer</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <glx type="vendor" opcode="1425"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsFramebufferEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsFramebufferEXT</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <alias name="glIsFramebuffer"/>
             <glx type="vendor" opcode="1425"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsFramebufferOES</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsFramebufferOES</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsImageHandleResidentARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsImageHandleResidentARB</name></proto>
             <param><ptype>GLuint64</ptype> <name>handle</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsImageHandleResidentNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsImageHandleResidentNV</name></proto>
             <param><ptype>GLuint64</ptype> <name>handle</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsList</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsList</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <glx type="single" opcode="141"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsMemoryObjectEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsMemoryObjectEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>memoryObject</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsNameAMD</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsNameAMD</name></proto>
             <param><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsNamedBufferResidentNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsNamedBufferResidentNV</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsNamedStringARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsNamedStringARB</name></proto>
             <param><ptype>GLint</ptype> <name>namelen</name></param>
             <param len="namelen">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsObjectBufferATI</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsObjectBufferATI</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsOcclusionQueryNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsOcclusionQueryNV</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsPathNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsPointInFillPathNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsPointInFillPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsPointInStrokePathNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsPointInStrokePathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsProgram</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsProgram</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <glx type="single" opcode="197"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsProgramARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsProgramARB</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <glx type="vendor" opcode="1304"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsProgramNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsProgramNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>id</name></param>
             <alias name="glIsProgramARB"/>
             <glx type="vendor" opcode="1304"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsProgramPipeline</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsProgramPipeline</name></proto>
             <param class="program pipeline"><ptype>GLuint</ptype> <name>pipeline</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsProgramPipelineEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsProgramPipelineEXT</name></proto>
             <param class="program pipeline"><ptype>GLuint</ptype> <name>pipeline</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsQuery</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsQuery</name></proto>
             <param class="query"><ptype>GLuint</ptype> <name>id</name></param>
             <glx type="single" opcode="163"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsQueryARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsQueryARB</name></proto>
             <param class="query"><ptype>GLuint</ptype> <name>id</name></param>
             <alias name="glIsQuery"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsQueryEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsQueryEXT</name></proto>
             <param class="query"><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsRenderbuffer</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsRenderbuffer</name></proto>
             <param class="renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <glx type="vendor" opcode="1422"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsRenderbufferEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsRenderbufferEXT</name></proto>
             <param class="renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <alias name="glIsRenderbuffer"/>
             <glx type="vendor" opcode="1422"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsRenderbufferOES</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsRenderbufferOES</name></proto>
             <param class="renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsSemaphoreEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsSemaphoreEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>semaphore</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsSampler</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsSampler</name></proto>
             <param class="sampler"><ptype>GLuint</ptype> <name>sampler</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsShader</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsShader</name></proto>
             <param class="shader"><ptype>GLuint</ptype> <name>shader</name></param>
             <glx type="single" opcode="196"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsStateNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsStateNV</name></proto>
             <param><ptype>GLuint</ptype> <name>state</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsSync</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsSync</name></proto>
             <param class="sync"><ptype>GLsync</ptype> <name>sync</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsSyncAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsSyncAPPLE</name></proto>
             <param class="sync"><ptype>GLsync</ptype> <name>sync</name></param>
             <alias name="glIsSync"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTexture</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTexture</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <glx type="single" opcode="146"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTextureEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTextureEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <glx type="vendor" opcode="14"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTextureHandleResidentARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTextureHandleResidentARB</name></proto>
             <param><ptype>GLuint64</ptype> <name>handle</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTextureHandleResidentNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTextureHandleResidentNV</name></proto>
             <param><ptype>GLuint64</ptype> <name>handle</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTransformFeedback</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTransformFeedback</name></proto>
             <param class="transform feedback"><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsTransformFeedbackNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsTransformFeedbackNV</name></proto>
             <param class="transform feedback"><ptype>GLuint</ptype> <name>id</name></param>
             <alias name="glIsTransformFeedback"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsVariantEnabledEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsVariantEnabledEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param group="VariantCapEXT"><ptype>GLenum</ptype> <name>cap</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsVertexArray</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsVertexArray</name></proto>
             <param class="vertex array"><ptype>GLuint</ptype> <name>array</name></param>
             <glx type="single" opcode="207"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsVertexArrayAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsVertexArrayAPPLE</name></proto>
             <param class="vertex array"><ptype>GLuint</ptype> <name>array</name></param>
             <alias name="glIsVertexArray"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsVertexArrayOES</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsVertexArrayOES</name></proto>
             <param class="vertex array"><ptype>GLuint</ptype> <name>array</name></param>
             <alias name="glIsVertexArray"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glIsVertexAttribEnabledAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glIsVertexAttribEnabledAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
         </command>
@@ -17351,7 +17351,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>packed</name></param>
+            <param><ptype>GLboolean</ptype> <name>packed</name></param>
             <param len="COMPSIZE(target,uorder,vorder)">const void *<name>points</name></param>
         </command>
         <command>
@@ -17779,14 +17779,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMinmax</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
+            <param><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4111"/>
         </command>
         <command>
             <proto>void <name>glMinmaxEXT</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
+            <param><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glMinmax"/>
             <glx type="render" opcode="4111"/>
         </command>
@@ -19075,14 +19075,14 @@ typedef unsigned int GLhandleARB;
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferPageCommitmentEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferPageCommitmentMemNV</name></proto>
@@ -19091,7 +19091,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>memOffset</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferStorage</name></proto>
@@ -20082,7 +20082,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfixed</ptype> <name>yfactor</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glPointAlongPathNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glPointAlongPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param><ptype>GLsizei</ptype> <name>startSegment</name></param>
             <param><ptype>GLsizei</ptype> <name>numSegments</name></param>
@@ -21512,7 +21512,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21520,7 +21520,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21528,7 +21528,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21536,7 +21536,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2fv"/>
         </command>
@@ -21545,7 +21545,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21553,7 +21553,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21561,7 +21561,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21569,7 +21569,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x3fv"/>
         </command>
@@ -21578,7 +21578,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21586,7 +21586,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21594,7 +21594,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21602,7 +21602,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x4fv"/>
         </command>
@@ -21611,7 +21611,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21619,7 +21619,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21627,7 +21627,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21635,7 +21635,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3fv"/>
         </command>
@@ -21644,7 +21644,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21652,7 +21652,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21660,7 +21660,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21668,7 +21668,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x2fv"/>
         </command>
@@ -21677,7 +21677,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21685,7 +21685,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21693,7 +21693,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21701,7 +21701,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x4fv"/>
         </command>
@@ -21710,7 +21710,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21718,7 +21718,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21726,7 +21726,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21734,7 +21734,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4fv"/>
         </command>
@@ -21743,7 +21743,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21751,7 +21751,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21759,7 +21759,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21767,7 +21767,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x2fv"/>
         </command>
@@ -21776,7 +21776,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21784,7 +21784,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21792,7 +21792,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -21800,7 +21800,7 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x3fv"/>
         </command>
@@ -22085,7 +22085,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glRasterSamplesEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>samples</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glReadBuffer</name></proto>
@@ -22166,7 +22166,7 @@ typedef unsigned int GLhandleARB;
             <alias name="glReadnPixels"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glReleaseKeyedMutexWin32EXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glReleaseKeyedMutexWin32EXT</name></proto>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>key</name></param>
         </command>
@@ -22601,24 +22601,24 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSampleCoverage</name></proto>
             <param><ptype>GLfloat</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
             <glx type="render" opcode="229"/>
         </command>
         <command>
             <proto>void <name>glSampleCoverageARB</name></proto>
             <param><ptype>GLfloat</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
             <alias name="glSampleCoverage"/>
         </command>
         <command>
             <proto>void <name>glSampleCoveragex</name></proto>
             <param><ptype>GLclampx</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
         </command>
         <command>
             <proto>void <name>glSampleCoveragexOES</name></proto>
             <param><ptype>GLclampx</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
         </command>
         <command>
             <proto>void <name>glSampleMapATI</name></proto>
@@ -22629,7 +22629,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSampleMaskEXT</name></proto>
             <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
         </command>
         <command>
             <proto>void <name>glSampleMaskIndexedNV</name></proto>
@@ -22639,7 +22639,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSampleMaskSGIS</name></proto>
             <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>invert</name></param>
+            <param><ptype>GLboolean</ptype> <name>invert</name></param>
             <alias name="glSampleMaskEXT"/>
             <glx type="render" opcode="2048"/>
         </command>
@@ -23100,7 +23100,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSelectPerfMonitorCountersAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>monitor</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>enable</name></param>
+            <param><ptype>GLboolean</ptype> <name>enable</name></param>
             <param><ptype>GLuint</ptype> <name>group</name></param>
             <param><ptype>GLint</ptype> <name>numCounters</name></param>
             <param len="numCounters"><ptype>GLuint</ptype> *<name>counterList</name></param>
@@ -23241,7 +23241,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glShadingRateImageBarrierNV</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>synchronize</name></param>
+            <param><ptype>GLboolean</ptype> <name>synchronize</name></param>
         </command>
         <command>
             <proto>void <name>glShadingRateQCOM</name></proto>
@@ -23587,16 +23587,16 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glTestFenceAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glTestFenceAPPLE</name></proto>
             <param kind="FenceNV"><ptype>GLuint</ptype> <name>fence</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glTestFenceNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glTestFenceNV</name></proto>
             <param kind="FenceNV"><ptype>GLuint</ptype> <name>fence</name></param>
             <glx type="vendor" opcode="1279"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glTestObjectAPPLE</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glTestObjectAPPLE</name></proto>
             <param group="ObjectTypeAPPLE"><ptype>GLenum</ptype> <name>object</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
         </command>
@@ -24371,7 +24371,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage2DMultisampleCoverageNV</name></proto>
@@ -24381,7 +24381,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage3D</name></proto>
@@ -24421,7 +24421,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage3DMultisampleCoverageNV</name></proto>
@@ -24432,7 +24432,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage3DOES</name></proto>
@@ -24472,7 +24472,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glTexPageCommitmentEXT</name></proto>
@@ -24484,7 +24484,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
             <alias name="glTexPageCommitmentARB"/>
         </command>
         <command>
@@ -24500,7 +24500,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterIiv</name></proto>
@@ -24640,7 +24640,7 @@ typedef unsigned int GLhandleARB;
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3D</name></proto>
@@ -24669,7 +24669,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3DMultisampleOES</name></proto>
@@ -24679,7 +24679,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
             <alias name="glTexStorage3DMultisample"/>
         </command>
         <command>
@@ -24727,7 +24727,7 @@ typedef unsigned int GLhandleARB;
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
@@ -24750,7 +24750,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
@@ -24924,10 +24924,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTextureColorMaskSGIS</name></proto>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>red</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>green</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>blue</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>alpha</name></param>
+            <param><ptype>GLboolean</ptype> <name>red</name></param>
+            <param><ptype>GLboolean</ptype> <name>green</name></param>
+            <param><ptype>GLboolean</ptype> <name>blue</name></param>
+            <param><ptype>GLboolean</ptype> <name>alpha</name></param>
             <glx type="render" opcode="2082"/>
         </command>
         <command>
@@ -24975,7 +24975,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureImage2DMultisampleNV</name></proto>
@@ -24985,7 +24985,7 @@ typedef unsigned int GLhandleARB;
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureImage3DEXT</name></proto>
@@ -25011,7 +25011,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureImage3DMultisampleNV</name></proto>
@@ -25022,7 +25022,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureLightEXT</name></proto>
@@ -25047,7 +25047,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glTexturePageCommitmentMemNV</name></proto>
@@ -25062,7 +25062,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>commit</name></param>
+            <param><ptype>GLboolean</ptype> <name>commit</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterIiv</name></proto>
@@ -25195,7 +25195,7 @@ typedef unsigned int GLhandleARB;
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage2DMultisampleEXT</name></proto>
@@ -25205,7 +25205,7 @@ typedef unsigned int GLhandleARB;
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage3D</name></proto>
@@ -25234,7 +25234,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage3DMultisampleEXT</name></proto>
@@ -25245,7 +25245,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorageMem1DEXT</name></proto>
@@ -25273,7 +25273,7 @@ typedef unsigned int GLhandleARB;
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
@@ -25296,7 +25296,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
             <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
@@ -26139,21 +26139,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix2dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2fv"/>
         </command>
@@ -26161,14 +26161,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix2x3dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="305"/>
         </command>
@@ -26176,7 +26176,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix2x3fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x3fv"/>
         </command>
@@ -26184,14 +26184,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix2x4dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="307"/>
         </command>
@@ -26199,7 +26199,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix2x4fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x4fv"/>
         </command>
@@ -26207,21 +26207,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix3dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3fv"/>
         </command>
@@ -26229,14 +26229,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix3x2dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="306"/>
         </command>
@@ -26244,7 +26244,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix3x2fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x2fv"/>
         </command>
@@ -26252,14 +26252,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix3x4dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="309"/>
         </command>
@@ -26267,7 +26267,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix3x4fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x4fv"/>
         </command>
@@ -26275,21 +26275,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix4dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4fv"/>
         </command>
@@ -26297,14 +26297,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix4x2dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="308"/>
         </command>
@@ -26312,7 +26312,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix4x2fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x2fv"/>
         </command>
@@ -26320,14 +26320,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix4x3dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="310"/>
         </command>
@@ -26335,7 +26335,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniformMatrix4x3fvNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>transpose</name></param>
+            <param><ptype>GLboolean</ptype> <name>transpose</name></param>
             <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x3fv"/>
         </command>
@@ -26360,25 +26360,25 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUnlockArraysEXT</name></proto>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glUnmapBuffer</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glUnmapBuffer</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glUnmapBufferARB</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glUnmapBufferARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glUnmapBuffer"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glUnmapBufferOES</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glUnmapBufferOES</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glUnmapBuffer"/>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glUnmapNamedBuffer</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glUnmapNamedBuffer</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glUnmapNamedBufferEXT</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glUnmapNamedBufferEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
@@ -26445,7 +26445,7 @@ typedef unsigned int GLhandleARB;
             <param>const void *<name>getProcAddress</name></param>
         </command>
         <command>
-            <proto kind="Boolean"><ptype>GLboolean</ptype> <name>glVDPAUIsSurfaceNV</name></proto>
+            <proto><ptype>GLboolean</ptype> <name>glVDPAUIsSurfaceNV</name></proto>
             <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
         </command>
         <command>
@@ -26473,7 +26473,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>isFrameStructure</name></param>
+            <param><ptype>GLboolean</ptype> <name>isFrameStructure</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUSurfaceAccessNV</name></proto>
@@ -26810,7 +26810,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -26949,7 +26949,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -26995,7 +26995,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
@@ -27781,7 +27781,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLuint</ptype> <name>offset</name></param>
@@ -27825,7 +27825,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -27833,7 +27833,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
@@ -28364,56 +28364,56 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribP1ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP1uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -28427,7 +28427,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
         </command>
@@ -28436,7 +28436,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param kind="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
+            <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
             <alias name="glVertexAttribPointer"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18132,26 +18132,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1iv"/>
             <alias name="glMultiTexCoord1i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="200"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1iv"/>
             <glx type="render" opcode="200"/>
         </command>
@@ -18274,28 +18274,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2iv"/>
             <alias name="glMultiTexCoord2i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="204"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2iv"/>
             <glx type="render" opcode="204"/>
         </command>
@@ -18427,30 +18427,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3iv"/>
             <alias name="glMultiTexCoord3i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="208"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3iv"/>
             <glx type="render" opcode="208"/>
         </command>
@@ -18591,32 +18591,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4iv"/>
             <alias name="glMultiTexCoord4i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="212"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4iv"/>
             <glx type="render" opcode="212"/>
         </command>
@@ -21932,13 +21932,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="35"/>
         </command>
         <command>
@@ -21987,14 +21987,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="39"/>
         </command>
         <command>
@@ -22047,15 +22047,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="43"/>
         </command>
         <command>
@@ -22200,16 +22200,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRecti</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x1</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y1</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x2</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y2</name></param>
             <vecequiv name="glRectiv"/>
         </command>
         <command>
             <proto>void <name>glRectiv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v1</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v2</name></param>
             <glx type="render" opcode="47"/>
         </command>
         <command>
@@ -23710,12 +23710,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1iv</name></proto>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="51"/>
         </command>
         <command>
@@ -23867,13 +23867,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="55"/>
         </command>
         <command>
@@ -23944,14 +23944,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="59"/>
         </command>
         <command>
@@ -24069,15 +24069,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="63"/>
         </command>
         <command>
@@ -26605,13 +26605,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glVertex2iv"/>
         </command>
         <command>
             <proto>void <name>glVertex2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="67"/>
         </command>
         <command>
@@ -26681,14 +26681,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glVertex3iv"/>
         </command>
         <command>
             <proto>void <name>glVertex3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="71"/>
         </command>
         <command>
@@ -26764,15 +26764,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glVertex4iv"/>
         </command>
         <command>
             <proto>void <name>glVertex4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="75"/>
         </command>
         <command>
@@ -29148,38 +29148,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2iv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iARB</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <alias name="glWindowPos2i"/>
             <vecequiv name="glWindowPos2ivARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <alias name="glWindowPos2i"/>
             <vecequiv name="glWindowPos2ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2ivARB</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos2iv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2ivMESA</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos2iv"/>
         </command>
         <command>
@@ -29298,41 +29298,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3iv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iARB</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <alias name="glWindowPos3i"/>
             <vecequiv name="glWindowPos3ivARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <alias name="glWindowPos3i"/>
             <vecequiv name="glWindowPos3ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3ivARB</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos3iv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3ivMESA</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos3iv"/>
         </command>
         <command>
@@ -29400,15 +29400,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4ivMESA</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4sMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17785,16 +17785,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16781,7 +16781,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto><ptype>GLboolean</ptype> <name>glIsPointInFillPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
@@ -19927,7 +19927,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPathStencilFuncNV</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glPathStringNV</name></proto>
@@ -23378,7 +23378,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23386,13 +23386,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFillPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilFunc</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="162"/>
         </command>
         <command>
@@ -23400,24 +23400,24 @@ typedef unsigned int GLhandleARB;
             <param group="StencilFaceDirection"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilFuncSeparateATI</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>frontfunc</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>backfunc</name></param>
             <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilMask</name></proto>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="133"/>
         </command>
         <command>
             <proto>void <name>glStencilMaskSeparate</name></proto>
             <param group="StencilFaceDirection"><ptype>GLenum</ptype> <name>face</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilOp</name></proto>
@@ -23453,7 +23453,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23461,7 +23461,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilStrokePathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverFillPathInstancedNV</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9001,17 +9001,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
@@ -23082,12 +23082,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8655,38 +8655,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <vecequiv name="glColor3ubv"/>
         </command>
         <command>
             <proto>void <name>glColor3ubv</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="11"/>
         </command>
         <command>
             <proto>void <name>glColor3ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <vecequiv name="glColor3uiv"/>
         </command>
         <command>
             <proto>void <name>glColor3uiv</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="12"/>
         </command>
         <command>
             <proto>void <name>glColor3us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <vecequiv name="glColor3usv"/>
         </command>
         <command>
             <proto>void <name>glColor3usv</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="13"/>
         </command>
         <command>
@@ -8798,10 +8798,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4ubv"/>
         </command>
         <command>
@@ -8835,33 +8835,33 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ubv</name></proto>
-            <param kind="ColorUB" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="19"/>
         </command>
         <command>
             <proto>void <name>glColor4ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4uiv"/>
         </command>
         <command>
             <proto>void <name>glColor4uiv</name></proto>
-            <param kind="ColorUI" len="4">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="20"/>
         </command>
         <command>
             <proto>void <name>glColor4us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4usv"/>
         </command>
         <command>
             <proto>void <name>glColor4usv</name></proto>
-            <param kind="ColorUS" len="4">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="21"/>
         </command>
         <command>
@@ -22976,79 +22976,79 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3ubv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubEXT</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3ub"/>
             <vecequiv name="glSecondaryColor3ubvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubv</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="4131"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubvEXT</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3ubv"/>
             <glx type="render" opcode="4131"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3uiv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uiEXT</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3ui"/>
             <vecequiv name="glSecondaryColor3uivEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uiv</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="4133"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uivEXT</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3uiv"/>
             <glx type="render" opcode="4133"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3usv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usEXT</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3us"/>
             <vecequiv name="glSecondaryColor3usvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usv</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="4132"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usvEXT</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3usv"/>
             <glx type="render" opcode="4132"/>
         </command>
@@ -27729,10 +27729,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib4ubNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>x</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>y</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>z</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>w</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>x</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>y</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>z</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>w</name></param>
             <alias name="glVertexAttrib4Nub"/>
             <vecequiv name="glVertexAttrib4ubvNV"/>
         </command>
@@ -27750,7 +27750,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib4ubvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="ColorUB" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <alias name="glVertexAttrib4Nubv"/>
             <glx type="render" opcode="4201"/>
         </command>
@@ -28565,7 +28565,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs4ubvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="ColorUB" len="count*4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="count*4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="4214"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8581,14 +8581,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <vecequiv name="glColor3dv"/>
         </command>
         <command>
             <proto>void <name>glColor3dv</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="7"/>
         </command>
         <command>
@@ -8714,15 +8714,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4dv"/>
         </command>
         <command>
             <proto>void <name>glColor4dv</name></proto>
-            <param kind="ColorD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="15"/>
         </command>
         <command>
@@ -22860,27 +22860,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3dv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dEXT</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3d"/>
             <vecequiv name="glSecondaryColor3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dv</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="4130"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dvEXT</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3dv"/>
             <glx type="render" opcode="4130"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -82,6 +82,7 @@ typedef unsigned int GLhandleARB;
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
+        <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter." />
         <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode." />
         <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer." />
     </kinds>
@@ -8378,7 +8379,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="MaskedColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexMask"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>
@@ -16477,7 +16478,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>
-            <param kind="MaskedColorIndexValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="ColorIndexMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="136"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -66,6 +66,22 @@ typedef unsigned int GLhandleARB;
         <type>typedef void (<apientry/> *<name>GLVULKANPROCNV</name>)(void);</type>
     </types>
 
+    <kinds>
+        <kind name="Color" desc="This parameter represents part of or a complete color." />
+        <kind name="Coord" desc="This parameter represents a coordinate." />
+        <kind name="WinCoord" desc="This parameter represents a window coordinate." />
+        <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="StencilValue" desc="" />
+        <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
+        <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
+        <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
+        <kind name="String" desc="This parameter represents a string of characters." />
+        <!--ColorIndexValue-->
+        <!--SelectName  glLoadName-->
+        <!--FeedbackElement glPassThrough-->
+        
+    </kinds>
+
     <!-- SECTION: GL enumerant (token) definitions. -->
 
     <!-- Bitmasks each have their own namespace, although bits are

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7148,7 +7148,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7801,10 +7801,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8259,10 +8259,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -8344,10 +8344,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
@@ -8375,7 +8375,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10855,8 +10855,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20425,7 +20425,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="ClampedFixed" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped01" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7763,18 +7763,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
@@ -8292,10 +8292,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>
@@ -8593,9 +8593,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <vecequiv name="glColor3fv"/>
         </command>
         <command>
@@ -8614,7 +8614,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3fv</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="8"/>
         </command>
         <command>
@@ -8727,10 +8727,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4fv"/>
         </command>
         <command>
@@ -8754,7 +8754,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fv</name></proto>
-            <param kind="ColorF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="16"/>
         </command>
         <command>
@@ -17763,16 +17763,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
@@ -22886,27 +22886,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3fv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fEXT</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3f"/>
             <vecequiv name="glSecondaryColor3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fv</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="4129"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fvEXT</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3fv"/>
             <glx type="render" opcode="4129"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -26433,7 +26433,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVDPAUGetSurfaceivNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -26446,29 +26446,29 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLboolean</ptype> <name>glVDPAUIsSurfaceNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUMapSurfacesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numSurfaces</name></param>
-            <param kind="vdpauSurfaceNV" len="numSurfaces">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
+            <param len="numSurfaces">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterOutputSurfaceNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterOutputSurfaceNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
@@ -26477,17 +26477,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVDPAUSurfaceAccessNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
             <param><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUUnmapSurfacesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numSurface</name></param>
-            <param kind="vdpauSurfaceNV" len="numSurface">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
+            <param len="numSurface">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUUnregisterSurfaceNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
         </command>
         <command>
             <proto>void <name>glValidateProgram</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22365,7 +22365,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
             <param><ptype>GLfloat</ptype> <name>g</name></param>
             <param><ptype>GLfloat</ptype> <name>b</name></param>
@@ -22375,13 +22375,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
             <param><ptype>GLfloat</ptype> <name>g</name></param>
             <param><ptype>GLfloat</ptype> <name>b</name></param>
@@ -22395,14 +22395,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLubyte</ptype> <name>r</name></param>
             <param><ptype>GLubyte</ptype> <name>g</name></param>
             <param><ptype>GLubyte</ptype> <name>b</name></param>
@@ -22413,13 +22413,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -22429,7 +22429,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -22439,7 +22439,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
@@ -22455,7 +22455,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
@@ -22463,7 +22463,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
@@ -22475,14 +22475,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
@@ -22491,20 +22491,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,7 +70,8 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color." />
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
-        <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[0, 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[-1, 1]" desc="This parameter will get clamped to the -1 to 1 range." />
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
@@ -7148,7 +7149,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7784,27 +7785,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8251,18 +8252,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -8337,21 +8338,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param kind="Clamped01"><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8361,21 +8362,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param kind="Clamped01"><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="Clamped01"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10855,8 +10856,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20425,7 +20426,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Clamped01" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0, 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22672,7 +22672,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSampleMaskIndexedNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="SampleMaskNV"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glSampleMaskSGIS</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -80,6 +80,17 @@ typedef unsigned int GLhandleARB;
         <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
         <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
         
+        <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix." />
+        <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix." />
+        <kind name="Matrix2x4" desc="This parameter represents a 2x4 matrix." />
+
+        <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
+        <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />>
+
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />>
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />>
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />>
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
@@ -21551,7 +21562,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2fvEXT</name></proto>
@@ -21559,7 +21570,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2fv"/>
         </command>
         <command>
@@ -21568,7 +21579,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3dvEXT</name></proto>
@@ -21576,7 +21587,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fv</name></proto>
@@ -21584,7 +21595,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fvEXT</name></proto>
@@ -21592,7 +21603,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -21601,7 +21612,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4dvEXT</name></proto>
@@ -21609,7 +21620,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fv</name></proto>
@@ -21617,7 +21628,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fvEXT</name></proto>
@@ -21625,7 +21636,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -21634,7 +21645,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3dvEXT</name></proto>
@@ -21642,7 +21653,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fv</name></proto>
@@ -21650,7 +21661,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fvEXT</name></proto>
@@ -21658,7 +21669,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3fv"/>
         </command>
         <command>
@@ -21667,7 +21678,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2dvEXT</name></proto>
@@ -21675,7 +21686,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fv</name></proto>
@@ -21683,7 +21694,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fvEXT</name></proto>
@@ -21700,7 +21711,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4dvEXT</name></proto>
@@ -21708,7 +21719,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fv</name></proto>
@@ -21716,7 +21727,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fvEXT</name></proto>
@@ -21724,7 +21735,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -21733,7 +21744,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4dvEXT</name></proto>
@@ -21741,7 +21752,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fv</name></proto>
@@ -21749,7 +21760,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fvEXT</name></proto>
@@ -21757,7 +21768,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4fv"/>
         </command>
         <command>
@@ -21766,7 +21777,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2dvEXT</name></proto>
@@ -21774,7 +21785,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fv</name></proto>
@@ -21782,7 +21793,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fvEXT</name></proto>
@@ -21790,7 +21801,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -21799,7 +21810,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3dvEXT</name></proto>
@@ -21807,7 +21818,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fv</name></proto>
@@ -21815,7 +21826,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fvEXT</name></proto>
@@ -21823,7 +21834,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x3fv"/>
         </command>
         <command>
@@ -26169,14 +26180,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2fv"/>
         </command>
         <command>
@@ -26184,14 +26195,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="305"/>
         </command>
         <command>
@@ -26199,7 +26210,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -26207,14 +26218,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="307"/>
         </command>
         <command>
@@ -26222,7 +26233,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -26230,21 +26241,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3fv"/>
         </command>
         <command>
@@ -26252,14 +26263,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="306"/>
         </command>
         <command>
@@ -26267,7 +26278,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x2fv"/>
         </command>
         <command>
@@ -26275,14 +26286,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="309"/>
         </command>
         <command>
@@ -26290,7 +26301,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -26298,21 +26309,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4fv"/>
         </command>
         <command>
@@ -26320,14 +26331,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="308"/>
         </command>
         <command>
@@ -26335,7 +26346,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -26343,14 +26354,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="310"/>
         </command>
         <command>
@@ -26358,7 +26369,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x3fv"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14812,7 +14812,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetProgramStringNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>id</name></param>
             <param group="VertexAttribEnumNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="ProgramCharacterNV" len="COMPSIZE(id,pname)"><ptype>GLubyte</ptype> *<name>program</name></param>
+            <param kind="String" len="COMPSIZE(id,pname)"><ptype>GLubyte</ptype> *<name>program</name></param>
             <glx type="vendor" opcode="1299"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8330,10 +8330,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -71,12 +71,14 @@ typedef unsigned int GLhandleARB;
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
         <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
-        <kind name="StencilValue" desc="" />
+        <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
+        <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
         <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
         <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
-        <kind name="String" desc="This parameter represents a string of characters." />
-        <kind name="DrawBufferIndex" desc="This parameter represents the i in GL_DRAW_BUFFERi." />
+        <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
+        <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
+        
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -86,12 +86,17 @@ typedef unsigned int GLhandleARB;
 
         <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
         <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
-        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />>
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />
 
-        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />>
-        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />>
-        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />>
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />
 
+        <kind name="Vector1" desc="This parameter represents a vector with 1 components" />
+        <kind name="Vector2" desc="This parameter represents a vector with 2 components" />
+        <kind name="Vector3" desc="This parameter represents a vector with 3 components" />
+        <kind name="Vector4" desc="This parameter represents a vector with 4 components" />
+        
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
         <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter." />
@@ -20796,14 +20801,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1f</name></proto>
@@ -20823,14 +20828,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1fv"/>
         </command>
         <command>
@@ -20856,14 +20861,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1iEXT</name></proto>
@@ -20877,14 +20882,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1iv"/>
         </command>
         <command>
@@ -20910,14 +20915,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1uiEXT</name></proto>
@@ -20931,14 +20936,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1uiv"/>
         </command>
         <command>
@@ -20960,14 +20965,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2f</name></proto>
@@ -20989,14 +20994,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2fv"/>
         </command>
         <command>
@@ -21025,14 +21030,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2iEXT</name></proto>
@@ -21047,14 +21052,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2iv"/>
         </command>
         <command>
@@ -21083,14 +21088,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2uiEXT</name></proto>
@@ -21105,14 +21110,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2uiv"/>
         </command>
         <command>
@@ -21136,14 +21141,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3f</name></proto>
@@ -21167,14 +21172,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3fv"/>
         </command>
         <command>
@@ -21206,14 +21211,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3iEXT</name></proto>
@@ -21229,14 +21234,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3iv"/>
         </command>
         <command>
@@ -21268,14 +21273,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3uiEXT</name></proto>
@@ -21291,14 +21296,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3uiv"/>
         </command>
         <command>
@@ -21324,14 +21329,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4f</name></proto>
@@ -21357,14 +21362,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4fv"/>
         </command>
         <command>
@@ -21399,14 +21404,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4iEXT</name></proto>
@@ -21423,14 +21428,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4iv"/>
         </command>
         <command>
@@ -21465,14 +21470,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4uiEXT</name></proto>
@@ -21489,14 +21494,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4uiv"/>
         </command>
         <command>
@@ -25555,7 +25560,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1f</name></proto>
@@ -25572,13 +25577,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform1fv"/>
         </command>
         <command>
@@ -25600,13 +25605,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1iARB</name></proto>
@@ -25618,13 +25623,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform1iv"/>
         </command>
         <command>
@@ -25646,13 +25651,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1uiEXT</name></proto>
@@ -25664,13 +25669,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform1uiv"/>
         </command>
         <command>
@@ -25683,7 +25688,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2f</name></proto>
@@ -25702,13 +25707,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform2fv"/>
         </command>
         <command>
@@ -25733,13 +25738,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2iARB</name></proto>
@@ -25752,13 +25757,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform2iv"/>
         </command>
         <command>
@@ -25783,13 +25788,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2uiEXT</name></proto>
@@ -25802,13 +25807,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform2uiv"/>
         </command>
         <command>
@@ -25822,7 +25827,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3f</name></proto>
@@ -25843,13 +25848,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform3fv"/>
         </command>
         <command>
@@ -25877,13 +25882,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3iARB</name></proto>
@@ -25897,13 +25902,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform3iv"/>
         </command>
         <command>
@@ -25931,13 +25936,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3uiEXT</name></proto>
@@ -25951,13 +25956,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform3uiv"/>
         </command>
         <command>
@@ -25972,7 +25977,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4f</name></proto>
@@ -25995,13 +26000,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform4fv"/>
         </command>
         <command>
@@ -26032,13 +26037,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4iARB</name></proto>
@@ -26053,13 +26058,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform4iv"/>
         </command>
         <command>
@@ -26090,13 +26095,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4uiEXT</name></proto>
@@ -26111,13 +26116,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform4uiv"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7784,18 +7784,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8379,7 +8379,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="ColorIndexMask"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>
@@ -8402,17 +8402,17 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedBufferSubData</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param>const void *<name>data</name></param>
+            <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedBufferSubDataEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLsizeiptr</ptype> <name>offset</name></param>
             <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -8424,7 +8424,7 @@ typedef unsigned int GLhandleARB;
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
-            <param><ptype>GLint</ptype> <name>stencil</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>stencil</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
@@ -8437,7 +8437,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -9000,17 +9000,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
@@ -19927,7 +19927,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPathStencilFuncNV</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
             <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
@@ -23407,7 +23407,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFuncSeparateATI</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>frontfunc</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>backfunc</name></param>
-            <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
             <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -1719,9 +1719,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8149" name="GL_SPRITE_MODE_SGIX" group="GetPName,SpriteParameterNameSGIX"/>
         <enum value="0x814A" name="GL_SPRITE_AXIS_SGIX" group="GetPName"/>
         <enum value="0x814B" name="GL_SPRITE_TRANSLATION_SGIX" group="GetPName"/>
-        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX" group="SpriteModeSGIX"/>
-        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX" group="SpriteModeSGIX"/>
-        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX"/>
+        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX"/>
+        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX"/>
         <enum value="0x814F" name="GL_TEXTURE_4D_BINDING_SGIS" group="GetPName"/>
     </enums>
 
@@ -23329,25 +23329,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2060"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfvSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2061"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameteriSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX"><ptype>GLint</ptype> <name>param</name></param>
+            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2062"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterivSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2063"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -11524,7 +11524,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glEdgeFlagPointerListIBM</name></proto>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="BooleanPointer" len="COMPSIZE(stride)">const <ptype>GLboolean</ptype> **<name>pointer</name></param>
+            <param len="COMPSIZE(stride)">const <ptype>GLboolean</ptype> **<name>pointer</name></param>
             <param><ptype>GLint</ptype> <name>ptrstride</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16475,7 +16475,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glIndexFuncEXT</name></proto>
             <param group="IndexFunctionEXT"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>ref</name></param>
+            <param kind="ColorIndexValue"><ptype>GLclampf</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -1719,9 +1719,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8149" name="GL_SPRITE_MODE_SGIX" group="GetPName,SpriteParameterNameSGIX"/>
         <enum value="0x814A" name="GL_SPRITE_AXIS_SGIX" group="GetPName"/>
         <enum value="0x814B" name="GL_SPRITE_TRANSLATION_SGIX" group="GetPName"/>
-        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX"/>
-        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX"/>
-        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX"/>
+        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX" group="SpriteModeSGIX"/>
         <enum value="0x814F" name="GL_TEXTURE_4D_BINDING_SGIS" group="GetPName"/>
     </enums>
 
@@ -23329,25 +23329,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param group="SpriteModeSGIX"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2060"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfvSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2061"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameteriSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param group="SpriteModeSGIX"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2062"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterivSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2063"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8358,7 +8358,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="MaskedColorIndexValueF"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="MaskedColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22464,10 +22464,10 @@ typedef unsigned int GLhandleARB;
             <param group="TriangleListSUN"><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,8 +70,8 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color." />
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
-        <kind name="Clamped[0, 1]" desc="This parameter will get clamped to the 0 to 1 range." />
-        <kind name="Clamped[-1, 1]" desc="This parameter will get clamped to the -1 to 1 range." />
+        <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
@@ -7149,7 +7149,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7785,27 +7785,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8338,21 +8338,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8362,21 +8362,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10844,8 +10844,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangefOES</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>n</name></param>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>f</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>n</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>f</name></param>
             <glx type="render" opcode="4309"/>
             <alias name="glDepthRangef"/>
         </command>
@@ -10856,8 +10856,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20426,7 +20426,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Clamped[0, 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0; 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -67,41 +67,41 @@ typedef unsigned int GLhandleARB;
     </types>
 
     <kinds>
-        <kind name="Color" desc="This parameter represents part of or a complete color." />
-        <kind name="Coord" desc="This parameter represents a coordinate." />
-        <kind name="WinCoord" desc="This parameter represents a window coordinate." />
-        <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
-        <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
-        <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
-        <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
-        <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
-        <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
-        <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
-        <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
-        <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
+        <kind name="Color" desc="This parameter represents part of or a complete color."/>
+        <kind name="Coord" desc="This parameter represents a coordinate."/>
+        <kind name="WinCoord" desc="This parameter represents a window coordinate."/>
+        <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range."/>
+        <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range."/>
+        <kind name="StencilValue" desc="This parameter represents an unmasked stencil value."/>
+        <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values."/>
+        <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data."/>
+        <kind name="BufferOffset" desc="This parameter represents an offset into a buffer."/>
+        <kind name="BufferSize" desc="This parameter represents the size of a buffer."/>
+        <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar."/>
+        <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS"/>
         
-        <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix." />
-        <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix." />
-        <kind name="Matrix2x4" desc="This parameter represents a 2x4 matrix." />
+        <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix."/>
+        <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix."/>
+        <kind name="Matrix2x4" desc="This parameter represents a 2x4 matrix."/>
 
-        <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
-        <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
-        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />
+        <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix."/>
+        <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix."/>
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix."/>
 
-        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />
-        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />
-        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix."/>
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix."/>
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix."/>
 
-        <kind name="Vector1" desc="This parameter represents a vector with 1 components" />
-        <kind name="Vector2" desc="This parameter represents a vector with 2 components" />
-        <kind name="Vector3" desc="This parameter represents a vector with 3 components" />
-        <kind name="Vector4" desc="This parameter represents a vector with 4 components" />
+        <kind name="Vector1" desc="This parameter represents a vector with 1 components"/>
+        <kind name="Vector2" desc="This parameter represents a vector with 2 components"/>
+        <kind name="Vector3" desc="This parameter represents a vector with 3 components"/>
+        <kind name="Vector4" desc="This parameter represents a vector with 4 components"/>
         
         <!-- Applicable to legacy OpenGL functions -->
-        <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
-        <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter." />
-        <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode." />
-        <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer." />
+        <kind name="ColorIndexValue" desc="This parameter represents a color in the color index."/>
+        <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter."/>
+        <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode."/>
+        <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer."/>
     </kinds>
 
     <!-- SECTION: GL enumerant (token) definitions. -->

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8252,18 +8252,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>

--- a/xml/readme.tex
+++ b/xml/readme.tex
@@ -184,7 +184,7 @@ Zero or more of each of the following tags, normally in this order
 \item \tag{kinds} (see section~\ref{tag:kinds}) - defines tags
       that can be used for parameter validation and more expressive types
        in API bindings for languages other than C. 
-       One parameter can be of multiple kinds.
+       One parameter can be of multiple kinds, separated by commas.
 \item \tag{groups} (see section~\ref{tag:groups}) - defines named groups
       of tokens for possible parameter validation in API bindings for
       languages other than C. Usually only one tag is used.
@@ -287,7 +287,7 @@ Each \{kind} tag defines a single kind annotation.
 \subsection{Attributes of \tag{kind} tag}
 
 \begin{itemize}
-\item \attr{name} - kind name, an arbitrary string used
+\item \attr{name} - kind name, an arbitrary string without commas (',') used
       to identify this kind.
 \item \attr{desc} - kind description, a description of what it
       means for a parameter or return value to be annotated with this kind.
@@ -301,10 +301,11 @@ None.
 \label{tag:kind:meaning}
 
 If a \tag{proto} or \tag{param} tag of a \tag{command} has a
-\attr{kind} attribute defined, and that attribute matches a \tag{kind}
-name, then the return type or parameter type is considered to be
-further defined by the description provided by the \tag{kind} tag
-with the matching name. C language bindings do not attempt to
+\attr{kind} attribute defined, and and the comma separated elemenst
+if the attribute matches a \tag{kind} name, 
+then the return type or parameter type is considered to be
+further defined by the description provided by the \tag{kind} tags
+with the matching names. C language bindings do not attempt to
 enforce this constraint in any way, but other language bindings 
 may try to do so.
 
@@ -599,6 +600,8 @@ The \tag{param} tag defines the type and name of a parameter.
 
 \begin{itemize}
 \item \attr{group} - group name, an arbitrary string.
+\item \attr{kind} - kind list, a comma separated list of names of
+      previously defined \tag{kind} tags.
 \item \attr{len} - parameter length, either an integer specifying the
       number of elements of the parameter \tag{ptype}, or a complex
       string expression with poorly defined syntax, usually representing

--- a/xml/readme.tex
+++ b/xml/readme.tex
@@ -181,6 +181,10 @@ Zero or more of each of the following tags, normally in this order
       statement. Unused.
 \item \tag{types} (see section~\ref{tag:types}) - defines API types.
       Usually only one tag is used.
+\item \tag{kinds} (see section~\ref{tag:kinds}) - defines tags
+      that can be used for parameter validation and more expressive types
+       in API bindings for languages other than C. 
+       One parameter can be of multiple kinds.
 \item \tag{groups} (see section~\ref{tag:groups}) - defines named groups
       of tokens for possible parameter validation in API bindings for
       languages other than C. Usually only one tag is used.
@@ -247,6 +251,62 @@ the following declarations:
 typedef ptrdiff_t GLintptr;
 \end{verbatim}
 
+\section{Kinds (\tag{kinds} tag)}
+\label{tag:kinds}
+
+The \tag{kinds} tag contain individual \tag{kind} tags describing
+some metadata not captured by the \tag{types} tag (see section~\ref{tag:types}) 
+or \tag{enums} tag (see section~\ref{tag:groups}).
+
+\subsection{Attributes of (\tag{kinds} tag)}
+
+\begin{itemize}
+\item \attr{name} - the name of the kind.
+\item \attr{desc} - a description of what the kind indicates.
+\end{itemize}
+
+\subsection{Contents of \tag{kinds} tags}
+
+Each \tag{kinds} block contains zero or more \tag{kind} tags, in
+arbitrary order.
+
+\subsection{Example of a \tag{kinds} tag}
+
+\begin{verbatim}
+<kinds>
+    <kind name="Color" desc="This parameter represents part of or a complete color." />
+    <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+</kinds>
+\end{verbatim}
+
+\section{Kind (\tag{kind} tag)}
+\label{tag:kind}
+
+Each \{kind} tag defines a single kind annotation.
+
+\subsection{Attributes of \tag{kind} tag}
+
+\begin{itemize}
+\item \attr{name} - kind name, an arbitrary string used
+      to identify this kind.
+\item \attr{desc} - kind description, a description of what it
+      means for a parameter or return value to be annotated with this kind.
+\end{itemize}
+
+\subsection{Contents of \tag{kind} tag}
+
+None.
+
+\subsection{Meaning of \tag{kind} tags}
+\label{tag:kind:meaning}
+
+If a \tag{proto} or \tag{param} tag of a \tag{command} has a
+\attr{kind} attribute defined, and that attribute matches a \tag{kind}
+name, then the return type or parameter type is considered to be
+further defined by the description provided by the \tag{kind} tag
+with the matching name. C language bindings do not attempt to
+enforce this constraint in any way, but other language bindings 
+may try to do so.
 
 \section{Enumerant Groups (\tag{groups} tag)}
 \label{tag:groups}
@@ -506,6 +566,8 @@ The \tag{proto} tag defines the return type and name of a command.
 
 \begin{itemize}
 \item \attr{group} - group name, an arbitrary string.
+\item \attr{kind} - kind list, a comma separated list of names of
+      previously defined \tag{kind} tags.
 \end{itemize}
 
 If the group name is defined, it may be interpreted as described in

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -60,7 +60,7 @@ Kinds = element kinds {
 # <kind> defines a description for a single kind.
 Kind = element kind {
     Name ,
-    attribute desc
+    attribute desc { text }
 }
 
 # <groups> defines a group of enum groups

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -15,6 +15,7 @@ start = element registry {
     (
         element comment { text } ? |
         Types      * |
+        Kinds      * |
         Groups     * |
         Enums      * |
         Commands   * |
@@ -49,6 +50,17 @@ Type = element type {
     text ,
     element name { TypeName } ? ,
     text
+}
+
+# <kinds> defines descriptions for kinds.
+Kinds = element kinds {
+    Kind *
+}
+
+# <kind> defines a description for a single kind.
+Kind = element kind {
+    Name ,
+    attribute desc
 }
 
 # <groups> defines a group of enum groups
@@ -141,6 +153,7 @@ Command = element command {
     Comment ? ,
     element proto {
         attribute group { text } ? ,
+        attribute kind { text } ? ,
         attribute class { text } ? ,
         text ,
         element ptype { TypeName } ? ,
@@ -150,6 +163,7 @@ Command = element command {
     } ,
     element param {
         attribute group { text } ? ,
+        attribute kind { text } ? ,
         attribute class { text } ? ,
         attribute len { text } ? ,
         text ,


### PR DESCRIPTION
Fixes #517 

I've used the word `kind` here to indicate that the label indicates the kind if value the parameter is (eg `ClampedFloat32` or `CoordF`). 
I was thinking about other words to use such as "attrib", "category", "variety", "set" or "label", but personally it seemed like "kind" was the best, most descriptive name.

@Perksey @SunSerega comments?