### PR TITLE
Clarify that PLS doesn't allow leak from outside framebuffer

### DIFF
--- a/extensions/EXT/EXT_shader_pixel_local_storage.txt
+++ b/extensions/EXT/EXT_shader_pixel_local_storage.txt
@@ -14,6 +14,7 @@ Contributors
     Alexander Galazin, ARM
     Tobias Hector, Imagination Technologies
     Ilya Zaytsev, ARM
+    Shahbaz Youssefi, Google
 
 Contact
 
@@ -25,8 +26,8 @@ Status
 
 Version
 
-    Revision 6
-    Last Modified Date: Mar 12, 2014
+    Revision 7
+    Last Modified Date: Sep 06, 2022
 
 Number
 
@@ -723,7 +724,8 @@ Issues
 
         It simply means that the value has no well-defined meaning to an
         application. It does _not_ mean that the value is random nor that it
-        could have been leaked from other contexts or processes.
+	could have been leaked from other contexts, processes, or memory other
+	than the framebuffer attachments.
 
      (15) Do we need a built-in function to pack unit vectors?
 
@@ -774,6 +776,10 @@ Issues
         these variables can be read or written safely in any order.
 
 Revision History
+
+    Revision 7, 06/09/2022 (Shahbaz Youssefi)
+	Clarified that undefined value does not allow leaks between draw calls
+	from memory outside of the framebuffer attachments.
 
     Revision 6, 12/03/2014 (Jan-Harald Fredriksen)
         Added Issue 16.

--- a/extensions/EXT/EXT_shader_pixel_local_storage2.txt
+++ b/extensions/EXT/EXT_shader_pixel_local_storage2.txt
@@ -520,12 +520,12 @@ Additions to Chapter 4 ("Variables and Types") of the OpenGL ES Shading Language
       error to declare a user-defined output variable where the format qualifier
       does not match the variable type and the number of components.
 
-      If EXT_pixel_local_storage2 is enabled, the format of every user-defined
-      fragment output variable should be specified in order to use pixel local
-      storage blocks. Any outputs set as implementation_defined (the default)
-      behave as if consuming all available local storage, leaving no space for
-      pixel local variables, causing a compile time error if pixel local storage
-      blocks also exist in the shader.
+      If EXT_shader_pixel_local_storage2 is enabled, the format of every
+      user-defined fragment output variable should be specified in order to use
+      pixel local storage blocks. Any outputs set as implementation_defined
+      (the default) behave as if consuming all available local storage, leaving
+      no space for pixel local variables, causing a compile time error if pixel
+      local storage blocks also exist in the shader.
 
       The specified output-format-qualifier does not need to be constant
       between shader invocations, but any resolves to the final framebuffer will


### PR DESCRIPTION
Per internal issue #168