### PR TITLE
[XML] Made `glCreateShaderProgramvEXT` same as `glCreateShaderProgramv`

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10302,7 +10302,7 @@ typedef unsigned int GLhandleARB;
             <proto class="program"><ptype>GLuint</ptype> <name>glCreateShaderProgramvEXT</name></proto>
             <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLchar</ptype> **<name>strings</name></param>
+            <param len="count">const <ptype>GLchar</ptype> *const*<name>strings</name></param>
         </command>
         <command>
             <proto>void <name>glCreateStatesNV</name></proto>


### PR DESCRIPTION
Maybe we should also touch [this](https://github.com/KhronosGroup/OpenGL-Registry/blob/eae1d6dde1e283f6fdf803274a2484007e592599/extensions/EXT/EXT_separate_shader_objects.gles.txt) since related function got changed?