### PR TITLE
Fix typo in WGL_EXT_create_context_es2_profile

### DIFF
--- a/extensions/EXT/WGL_EXT_create_context_es2_profile.txt
+++ b/extensions/EXT/WGL_EXT_create_context_es2_profile.txt
@@ -210,7 +210,7 @@ Issues
    support?
 
    RESOLVED: No. This extension has been modified since version #3 to
-   support and requested version of OpenGL-ES that is supported by
+   support any requested version of OpenGL-ES that is supported by
    the desktop OpenGL implementation. This can include more than just
    OpenGL-ES 2.0 that was originally specified.
 


### PR DESCRIPTION
Version 4 in the Revision History section already said "Add support for any OpenGL-ES version, not just version 2.0", which makes the use of "support and requested version of OpenGL-ES" in issue 5 an unambiguous typo.

I assume this doesn't need an additional entry in the history section, as similar typo fixes were made in e.g. d62c37dde0a40148aecc9e9701ba0ae4ab83ee22.