### PR TITLE
[XML] Document GL_NV_half_float commands that require other extensions

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -44174,12 +44174,6 @@ typedef unsigned int GLhandleARB;
                 <command name="glMultiTexCoord3hvNV"/>
                 <command name="glMultiTexCoord4hNV"/>
                 <command name="glMultiTexCoord4hvNV"/>
-                <command name="glFogCoordhNV"/>
-                <command name="glFogCoordhvNV"/>
-                <command name="glSecondaryColor3hNV"/>
-                <command name="glSecondaryColor3hvNV"/>
-                <command name="glVertexWeighthNV"/>
-                <command name="glVertexWeighthvNV"/>
                 <command name="glVertexAttrib1hNV"/>
                 <command name="glVertexAttrib1hvNV"/>
                 <command name="glVertexAttrib2hNV"/>
@@ -44192,6 +44186,18 @@ typedef unsigned int GLhandleARB;
                 <command name="glVertexAttribs2hvNV"/>
                 <command name="glVertexAttribs3hvNV"/>
                 <command name="glVertexAttribs4hvNV"/>
+            </require>
+            <require comment="Supported only if GL_EXT_fog_coord is supported">
+                <command name="glFogCoordhNV"/>
+                <command name="glFogCoordhvNV"/>
+            </require>
+            <require comment="Supported only if GL_EXT_secondary_color is supported">
+                <command name="glSecondaryColor3hNV"/>
+                <command name="glSecondaryColor3hvNV"/>
+            </require>
+            <require comment="Supported only if GL_EXT_vertex_weighting is supported">
+                <command name="glVertexWeighthNV"/>
+                <command name="glVertexWeighthvNV"/>
             </require>
         </extension>
         <extension name="GL_NV_image_formats" supported="gles2"/>


### PR DESCRIPTION
From [NV_half_float.txt](https://github.com/KhronosGroup/OpenGL-Registry/blob/main/extensions/NV/NV_half_float.txt):

```
    (added if EXT_fog_coord is supported)

    void FogCoordhNV(half fog);
    void FogCoordhvNV(const half *fog);

    (added if EXT_secondary_color is supported)

    void SecondaryColor3hNV(half red, half green, half blue);
    void SecondaryColor3hvNV(const half *v);

    (added if EXT_vertex_weighting is supported)

    void VertexWeighthNV(half weight);
    void VertexWeighthvNV(const half *weight);
```