### PR TITLE
[XML] Add missing WebGL enums

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6258,7 +6258,12 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9242" name="GL_CONTEXT_LOST_WEBGL"/>
         <enum value="0x9243" name="GL_UNPACK_COLORSPACE_CONVERSION_WEBGL"/>
         <enum value="0x9244" name="GL_BROWSER_DEFAULT_WEBGL"/>
-            <unused start="0x9245" end="0x924F" vendor="WEBGL"/>
+        <enum value="0x9245" name="GL_UNMASKED_VENDOR_WEBGL" comment="From the WEBGL_debug_renderer_info extension"/>
+        <enum value="0x9246" name="GL_UNMASKED_RENDERER_WEBGL" comment="From the WEBGL_debug_renderer_info extension"/>
+        <enum value="0x9247" name="GL_MAX_CLIENT_WAIT_TIMEOUT_WEBGL"/>
+        <enum value="0x9248" name="GL_TEXTURE_VIDEO_IMAGE_WEBGL" comment="From the WEBGL_video_texture extension"/>
+        <enum value="0x9249" name="GL_SAMPLER_VIDEO_IMAGE_WEBGL" comment="From the WEBGL_video_texture extension"/>
+            <unused start="0x924A" end="0x924F" vendor="WEBGL"/>
     </enums>
 
     <enums namespace="GL" start="0x9250" end="0x925F" vendor="DMP" comment="For Eisaku Ohbuchi via email">


### PR DESCRIPTION
This enum block is not referenced by any interface definitions (which makes since gl.xml doesn't really concern itself with WebGL) but it might still be useful to add these missing enums for the sake of posterity.

- `GL_UNMASKED_VENDOR_WEBGL` and `GL_UNMASKED_RENDERER_WEBGL` from [WEBGL_debug_renderer_info](https://registry.khronos.org/webgl/extensions/WEBGL_debug_renderer_info/)
- `GL_MAX_CLIENT_WAIT_TIMEOUT_WEBGL` from the [WebGL 2.0 Specification](https://registry.khronos.org/webgl/specs/latest/2.0/)
- `GL_TEXTURE_VIDEO_IMAGE_WEBGL` and `GL_SAMPLER_VIDEO_IMAGE_WEBGL` from [WEBGL_video_texture](https://registry.khronos.org/webgl/extensions/proposals/WEBGL_video_texture/)
  - This extension is still in the "Proposed" state but https://github.com/KhronosGroup/WebGL/pull/2956 suggests they have been allocated.