### PR TITLE
Added GL_AMBIENT, GL_DIFFUSE and GL_SPECULAR enumerants to LightParameter group

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -942,9 +942,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x1101" name="GL_FASTEST" group="HintMode"/>
         <enum value="0x1102" name="GL_NICEST" group="HintMode"/>
             <unused start="0x1103" end="0x11FF" comment="Unused for HintMode"/>
-        <enum value="0x1200" name="GL_AMBIENT" group="MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
-        <enum value="0x1201" name="GL_DIFFUSE" group="MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
-        <enum value="0x1202" name="GL_SPECULAR" group="MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
+        <enum value="0x1200" name="GL_AMBIENT" group="LightParameter,MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
+        <enum value="0x1201" name="GL_DIFFUSE" group="LightParameter,MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
+        <enum value="0x1202" name="GL_SPECULAR" group="LightParameter,MaterialParameter,FragmentLightParameterSGIX,ColorMaterialParameter"/>
         <enum value="0x1203" name="GL_POSITION" group="LightParameter,FragmentLightParameterSGIX"/>
         <enum value="0x1204" name="GL_SPOT_DIRECTION" group="LightParameter,FragmentLightParameterSGIX"/>
         <enum value="0x1205" name="GL_SPOT_EXPONENT" group="LightParameter,FragmentLightParameterSGIX"/>


### PR DESCRIPTION
Looks like the mentioned enumerants were "lost" from the "LightParameter" group in the commit 8794952a2dfe6332e269191b1288995059df30fd. Here is how the "LightParameter" group looked like just before the changes:
```
        <group name="LightParameter" comment="Deprecated, use the group attributes instead.">
            <enum name="GL_AMBIENT"/>
            <enum name="GL_CONSTANT_ATTENUATION"/>
            <enum name="GL_DIFFUSE"/>
            <enum name="GL_LINEAR_ATTENUATION"/>
            <enum name="GL_POSITION"/>
            <enum name="GL_QUADRATIC_ATTENUATION"/>
            <enum name="GL_SPECULAR"/>
            <enum name="GL_SPOT_CUTOFF"/>
            <enum name="GL_SPOT_DIRECTION"/>
            <enum name="GL_SPOT_EXPONENT"/>
        </group>
```
Re-adding the missing enumerants.

Related PR: https://github.com/KhronosGroup/OpenGL-Registry/pull/579