### PR TITLE
Document memory object <size> parameter requirements

### DIFF
--- a/extensions/EXT/EXT_external_objects_win32.txt
+++ b/extensions/EXT/EXT_external_objects_win32.txt
@@ -24,8 +24,8 @@ Status
 
 Version
 
-    Last Modified Date: June 2, 2017
-    Revision: 8
+    Last Modified Date: August 29, 2023
+    Revision: 10
 
 Number
 
@@ -257,8 +257,7 @@ Additions to Chapter 6 of the OpenGL 4.5 Specification (Memory Objects)
             HANDLE_TYPE_D3D11_IMAGE_EXT
             HANDLE_TYPE_D3D11_KMT_IMAGE_EXT
 
-        <size> is ignored[fn1] and the implementation must query the actual
-        size of the memory object from the OS.
+        <size> is ignored[fn1].
 
         [fn1] Some implementations incorrectly require <size> be set to '0'
         when importing such handles, so applications should set <size> to
@@ -293,6 +292,10 @@ Issues
        prototype and define its type through spec language.
 
 Revision History
+
+    Revision 10, 2023-08-29 (James Jones)
+        - Clarify that the <size> parameter is ignored in the
+          ImportMemoryWin32* calls for some handle types.
 
     Revision 9, 2022-07-15 (James Jones)
         - Added commands to the list of commands not permitted in display

--- a/extensions/EXT/EXT_external_objects_win32.txt
+++ b/extensions/EXT/EXT_external_objects_win32.txt
@@ -251,6 +251,18 @@ Additions to Chapter 6 of the OpenGL 4.5 Specification (Memory Objects)
         transfer ownership of the handle to the GL implementation.  For
         handle types defined as NT handles, the application must release the
         handle using an appropriate system call when it is no longer needed.
+        If <handleType> is one of:
+
+            HANDLE_TYPE_D3D12_RESOURCE_EXT
+            HANDLE_TYPE_D3D11_IMAGE_EXT
+            HANDLE_TYPE_D3D11_KMT_IMAGE_EXT
+
+        <size> is ignored[fn1] and the implementation must query the actual
+        size of the memory object from the OS.
+
+        [fn1] Some implementations incorrectly require <size> be set to '0'
+        when importing such handles, so applications should set <size> to
+        '0' for broader compatibility.
 
 Additions to Chapter 21 of the OpenGL 4.5 Specification (Special Functions)
 


### PR DESCRIPTION
For certain external handle types representing
objects from non-Khronos APIs, it's difficult or
impossible for an application to know the actual
size of the associated memory object. The Vulkan
external memory specifications acknowledge this
in section 11.2.3. "Device Memory Allocation,"
with this language:

"If the parameters define an import operation and
the external handle type is
VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT, or
VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, allocationSize is ignored. The implementation must query the size of these allocations from the OS."

But the OpenGL external object specs lacked
equivalent language. This change adds such
language.

Additionally, while investigating this spec issue
internally, it was found current NVIDIA drivers
actually expect a <size> of zero when these handle types are used. This is documented in a footnote
to help applications achieve better compatibility
with drivers in the field.

Fixes #575