### PR TITLE
Clarify copyTex[Sub]Image for GL_QCOM_render_shared_exponent

### DIFF
--- a/extensions/QCOM/QCOM_render_shared_exponent.txt
+++ b/extensions/QCOM/QCOM_render_shared_exponent.txt
@@ -101,7 +101,10 @@ Additions to Chapter 20 of the OpenGL ES 3.2 Specification
 
 Errors
 
-    No new errors.
+    Relaxation of INVALID_OPERATION errors
+    --------------------------------------
+
+    CopyTex[Sub]Image* now accepts RGB9_E5 for <internalformat>
 
 Issues
 


### PR DESCRIPTION
Update GL_QCOM_render_shared_exponent to remove
explicit RGB9_E5 error for copyTex[Sub]Image calls.