### PR TITLE
update ARB_shader_viewport_layer_array and OES_viewport_array

### DIFF
--- a/extensions/ARB/ARB_shader_viewport_layer_array.txt
+++ b/extensions/ARB/ARB_shader_viewport_layer_array.txt
@@ -36,8 +36,8 @@ Status
 
 Version
 
-    Last Modified Date: February 12, 2019
-    Revision: 2
+    Last Modified Date: September 13, 2023
+    Revision: 3
 
 Number
 
@@ -194,10 +194,10 @@ Modifications to the OpenGL Shading Language Specification, Version 4.50
     gl_Layer, the value of gl_Layer in the fragment stage will be undefined.
     If the final VTG stage makes no static assignment to gl_Layer, the input
     gl_Value in the fragment stage will be zero. Otherwise, the fragment stage
-    will read the same value written by the final VTG stage, even if that value
-    is out of range. If a fragment shader contains a static access to gl_Layer,
-    it will count against the implementation defined limit for the maximum
-    number of inputs to the fragment stage.
+    will read the same value written by the final VTG stage, unless it is out of
+    range, in which case it is undefined. If a fragment shader contains a
+    static access to gl_Layer, it will count against the implementation defined
+    limit for the maximum number of inputs to the fragment stage.
 
     Modify the language introducing "gl_ViewportIndex" on p.128 as follows:
 
@@ -304,3 +304,5 @@ Revision History
                                 and AMD_vertex_shader_layer
      2    02/12/2019  dkoch     opengl/api/44: clarify that builtins should be
                                 part of the "out gl_PerVertex" block.
+     3    09/13/2023  zmike     opengl/api/196: Clarify gl_ViewportIndex and gl_Layer
+                                out of range values in fragment shader

--- a/extensions/OES/OES_viewport_array.txt
+++ b/extensions/OES/OES_viewport_array.txt
@@ -38,8 +38,8 @@ Status
 
 Version
 
-    Last Modified Date:         2016/04/19
-    Author Revision:            5
+    Last Modified Date:         2023/09/13
+    Author Revision:            6
 
 Number
 
@@ -457,10 +457,10 @@ Additions to Chapter 7 of the OpenGL ES Shading Language Specification
     value of gl_ViewportIndex in the fragment shader will be undefined. If the
     geometry stage makes no static assignment to gl_ViewportIndex, the value
     in the fragment stage is undefined. Otherwise, the fragment stage will read
-    the same value written by the geometry stage, even if that value is out of
-    range. If a fragment shader contains a static access to gl_ViewportIndex,
-    it will count against the implementation defined limit for the maximum
-    number of inputs to the fragment stage.
+    the same value written by the geometry stage, unless it is out of range,
+    in which case it is undefined. If a fragment shader contains a static
+    access to gl_ViewportIndex, it will count against the implementation
+    defined limit for the maximum number of inputs to the fragment stage.
 
     Add the following built-in to section 7.2 "Built-In Constants":
 
@@ -570,3 +570,5 @@ Revision History
                                 Allowed dependency on OES_geometry_shader as well as EXT_geometry_shader
      5    19/04/2016  dkoch     Typographical fixes.
                                 Sync some additional language with GL 4.5 and GLSL 4.50.
+     6    13/09/2023  zmike     opengl/api/196: Clarify gl_ViewportIndex and gl_Layer
+                                out of range values in fragment shader


### PR DESCRIPTION
gitlab/opengl/api/issue/44

clarify that out-of-range values for gl_Layer and gl_ViewportIndex are undefined