### PR TITLE
extensions: Add GL_MESA_sampler_objects

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -32,7 +32,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20230705
+#define GL_GLEXT_VERSION 20231018
 
 #include <KHR/khrplatform.h>
 

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -15,7 +15,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20230705
+#define GLX_GLXEXT_VERSION 20231018
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20230705
+#define WGL_WGLEXT_VERSION 20231018
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20230929 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: gles2
@@ -2562,6 +2562,33 @@ GL_APICALL void GL_APIENTRY glGetFramebufferParameterivMESA (GLenum target, GLen
 #define GL_MESA_program_binary_formats 1
 #define GL_PROGRAM_BINARY_FORMAT_MESA     0x875F
 #endif /* GL_MESA_program_binary_formats */
+
+#ifndef GL_MESA_sampler_objects
+#define GL_MESA_sampler_objects 1
+#define GL_SAMPLER_BINDING                0x8919
+typedef void (GL_APIENTRYP PFNGLGENSAMPLERSPROC) (GLsizei count, GLuint *samplers);
+typedef void (GL_APIENTRYP PFNGLDELETESAMPLERSPROC) (GLsizei count, const GLuint *samplers);
+typedef GLboolean (GL_APIENTRYP PFNGLISSAMPLERPROC) (GLuint sampler);
+typedef void (GL_APIENTRYP PFNGLBINDSAMPLERPROC) (GLuint unit, GLuint sampler);
+typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERIPROC) (GLuint sampler, GLenum pname, GLint param);
+typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERIVPROC) (GLuint sampler, GLenum pname, const GLint *param);
+typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERFPROC) (GLuint sampler, GLenum pname, GLfloat param);
+typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERFVPROC) (GLuint sampler, GLenum pname, const GLfloat *param);
+typedef void (GL_APIENTRYP PFNGLGETSAMPLERPARAMETERIVPROC) (GLuint sampler, GLenum pname, GLint *params);
+typedef void (GL_APIENTRYP PFNGLGETSAMPLERPARAMETERFVPROC) (GLuint sampler, GLenum pname, GLfloat *params);
+#ifdef GL_GLEXT_PROTOTYPES
+GL_APICALL void GL_APIENTRY glGenSamplers (GLsizei count, GLuint *samplers);
+GL_APICALL void GL_APIENTRY glDeleteSamplers (GLsizei count, const GLuint *samplers);
+GL_APICALL GLboolean GL_APIENTRY glIsSampler (GLuint sampler);
+GL_APICALL void GL_APIENTRY glBindSampler (GLuint unit, GLuint sampler);
+GL_APICALL void GL_APIENTRY glSamplerParameteri (GLuint sampler, GLenum pname, GLint param);
+GL_APICALL void GL_APIENTRY glSamplerParameteriv (GLuint sampler, GLenum pname, const GLint *param);
+GL_APICALL void GL_APIENTRY glSamplerParameterf (GLuint sampler, GLenum pname, GLfloat param);
+GL_APICALL void GL_APIENTRY glSamplerParameterfv (GLuint sampler, GLenum pname, const GLfloat *param);
+GL_APICALL void GL_APIENTRY glGetSamplerParameteriv (GLuint sampler, GLenum pname, GLint *params);
+GL_APICALL void GL_APIENTRY glGetSamplerParameterfv (GLuint sampler, GLenum pname, GLfloat *params);
+#endif
+#endif /* GL_MESA_sampler_objects */
 
 #ifndef GL_MESA_shader_integer_functions
 #define GL_MESA_shader_integer_functions 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLSC2/glsc2.h
+++ b/api/GLSC2/glsc2.h
@@ -21,7 +21,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: glsc2

--- a/api/GLSC2/glsc2ext.h
+++ b/api/GLSC2/glsc2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20230705 */
+/* Generated on date 20231018 */
 
 /* Generated C header for:
  * API: glsc2

--- a/extensions/MESA/MESA_sampler_objects.txt
+++ b/extensions/MESA/MESA_sampler_objects.txt
@@ -1,0 +1,105 @@
+Name
+
+    MESA_sampler_objects
+
+Name Strings
+
+    GL_MESA_sampler_objects
+
+Contact
+
+    Adam Jackson <ajax@redhat.com>
+
+Contributors
+
+    Emma Anholt
+    The contributors to ARB_sampler_objects and OpenGL ES 3
+
+Status
+
+    Shipping
+
+Version
+
+    Last Modified Date:         14 Sep 2021
+    Author Revision:            3
+
+Number
+
+    OpenGL ES Extension #344
+
+Dependencies
+
+    OpenGL ES 2.0 is required.
+
+    This extension interacts with:
+      - EXT_shadow_samplers
+      - EXT_texture_filter_anisotropic
+      - EXT_texture_sRGB_decode
+      - OES_texture_border_clamp
+
+Overview
+
+    This extension makes the sampler object subset of OpenGL ES 3.0 available
+    in OpenGL ES 2.0 contexts. As the intent is to allow access to the API
+    without necessarily requiring additional renderer functionality, some
+    sampler state that would be mandatory in GLES 3 is dependent on the
+    presence of additional extensions. Under GLES 3.0 or above this extension's
+    name string may be exposed for compatibility, but it is otherwise without
+    effect.
+
+    Refer to the OpenGL ES 3.0 specification for API details not covered here.
+
+New Procedures and Functions
+
+    void glGenSamplers (GLsizei count, GLuint *samplers);
+    void glDeleteSamplers (GLsizei count, const GLuint *samplers);
+    GLboolean glIsSampler (GLuint sampler);
+    void glBindSampler (GLuint unit, GLuint sampler);
+    void glSamplerParameteri (GLuint sampler, GLenum pname, GLint param);
+    void glSamplerParameteriv (GLuint sampler, GLenum pname, const GLint *param);
+    void glSamplerParameterf (GLuint sampler, GLenum pname, GLfloat param);
+    void glSamplerParameterfv (GLuint sampler, GLenum pname, const GLfloat *param);
+    void glGetSamplerParameteriv (GLuint sampler, GLenum pname, GLint *params);
+    void glGetSamplerParameterfv (GLuint sampler, GLenum pname, GLfloat *params);
+
+    Note that these names are exactly as in ES3, with no MESA suffix.
+
+New Tokens
+
+            SAMPLER_BINDING                                 0x8919
+
+Interactions
+
+    If EXT_shadow_samplers is not supported then TEXTURE_COMPARE_MODE and
+    TEXTURE_COMPARE_FUNC will generate INVALID_ENUM.
+
+    If EXT_texture_filter_anisotropic is not supported then
+    TEXTURE_MAX_ANISOTROPY_EXT will generate INVALID_ENUM.
+
+    If EXT_texture_sRGB_decode is not supported then TEXTURE_SRGB_DECODE_EXT
+    will generate INVALID_ENUM.
+
+    If OES_texture_border_clamp is not supported then TEXTURE_BORDER_COLOR
+    will generate INVALID_ENUM.
+
+Issues
+
+    1) Why bother?
+
+    Sampler objects, at least in Mesa, are generically supported without any
+    driver-dependent requirements, so enabling this is essentially free. This
+    simplifies application support for otherwise GLES2 hardware, and for
+    drivers in development that haven't yet achieved GLES3.
+
+Revision History
+
+    Rev.    Date      Author    Changes
+    ----  --------    --------  ---------------------------------------------
+      1   2019/10/22  ajax      Initial revision
+      2   2019/11/14  ajax      Add extension interactions:
+                                  - EXT_shadow_samplers
+                                  - EXT_texture_filter_anisotropic
+                                  - EXT_texture_sRGB_decode
+                                  - OES_texture_border_clamp
+      3   2021/09/14  ajax      Expand the justification and ES3 interaction

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -717,4 +717,6 @@
 </li>
 <li value=343><a href="extensions/QCOM/QCOM_render_sRGB_R8_RG8.txt">GL_QCOM_render_sRGB_R8_RG8</a>
 </li>
+<li value=344><a href="extensions/MESA/MESA_sampler_objects.txt">GL_MESA_sampler_objects</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3114,6 +3114,12 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/MESA_resize_buffers.txt',
     },
+    'GL_MESA_sampler_objects' : {
+        'esnumber' : 344,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_sampler_objects.txt',
+    },
     'GLX_MESA_set_3dfx_mode' : {
         'number' : 218,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -43420,6 +43420,21 @@ typedef unsigned int GLhandleARB;
                 <command name="glResizeBuffersMESA"/>
             </require>
         </extension>
+        <extension name="GL_MESA_sampler_objects" supported="gles2">
+            <require comment="Reuse (the GLES3 part of) ARB_sampler_objects">
+                <enum name="GL_SAMPLER_BINDING"/>
+                <command name="glGenSamplers"/>
+                <command name="glDeleteSamplers"/>
+                <command name="glIsSampler"/>
+                <command name="glBindSampler"/>
+                <command name="glSamplerParameteri"/>
+                <command name="glSamplerParameteriv"/>
+                <command name="glSamplerParameterf"/>
+                <command name="glSamplerParameterfv"/>
+                <command name="glGetSamplerParameteriv"/>
+                <command name="glGetSamplerParameterfv"/>
+            </require>
+        </extension>
         <extension name="GL_MESA_shader_integer_functions" supported="gl|gles2"/>
         <extension name="GL_MESA_tile_raster_order" supported="gl">
             <require>


### PR DESCRIPTION
Trivial backport of the sampler object API from ES3 to ES2.