### PR TITLE
Renamed "cap" parameter of "glEnable", "glDisable", "glIsEnabled" comands to "target"

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10941,7 +10941,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDisable</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>cap</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="138"/>
         </command>
         <command>
@@ -11628,7 +11628,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEnable</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>cap</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="139"/>
         </command>
         <command>
@@ -16742,7 +16742,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLboolean</ptype> <name>glIsEnabled</name></proto>
-            <param group="EnableCap"><ptype>GLenum</ptype> <name>cap</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="single" opcode="140"/>
         </command>
         <command>


### PR DESCRIPTION
The renaming was done to be consistent with "glEnablei", "glDisablei" and "glIsEnabledi" commands (both in this XML and in the specification PDFs). Note that the parameter of "glIsEnabled" command should technically be called "value" (according to the specification PDFs), but it was renamed to "target" for sake of consistency among all the related commands. Alternatively, it can be renamed to "value" again to completely match the specifications