### PR TITLE
Removed "len" XML attribute from "pointer" parameter declarations of "glVertexAttribIPointerEXT", "glVertexAttribLPointerEXT" and "glVertexAttribPointerARB" commands

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -28208,7 +28208,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribIType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
-            <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
+            <param>const void *<name>pointer</name></param>
             <alias name="glVertexAttribIPointer"/>
         </command>
         <command>
@@ -28441,7 +28441,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
-            <param len="size">const void *<name>pointer</name></param>
+            <param>const void *<name>pointer</name></param>
             <alias name="glVertexAttribLPointer"/>
         </command>
         <command>
@@ -28522,7 +28522,7 @@ typedef unsigned int GLhandleARB;
             <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
-            <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
+            <param>const void *<name>pointer</name></param>
             <alias name="glVertexAttribPointer"/>
         </command>
         <command>


### PR DESCRIPTION
The removal was done because the "pointer" parameter is not mean to act as an array, but simply as a relative integer offset when defining vertex attributes. An equivalent fix was done previously for the related commands: "glVertexAttribIPointer", "glVertexAttribLPointer" and "glVertexAttribPointer" (related PR: https://github.com/KhronosGroup/OpenGL-Registry/pull/592)