### PR TITLE
Put some implementation dependent values of FSR under pipeline FSR instead of attachment FSR

### DIFF
--- a/extensions/EXT/EXT_fragment_shading_rate.txt
+++ b/extensions/EXT/EXT_fragment_shading_rate.txt
@@ -633,16 +633,16 @@
                                                                                                   each texel in a fragment shading
                                                                                                   rate attachment
     MAX_FRAGMENT_SHADING_RATE_ATTACHMENT_LAYERS_EXT             Z+    GetIntegerv  1              maximum number of layers in a
-                                                                                                  fragment shading rate attachment    13.X.3     
+                                                                                                  fragment shading rate attachment    13.X.3
+    FRAGMENT_SHADING_RATE_ATTACHMENT_WITH_-                     B    GetBooleanv  -               support for attachment shading      13.X.3
+    DEFAULT_FRAMEBUFFER_SUPPORTED_EXT                                                             rates on the default framebuffer
+[[If GL_EXT_fragment_shading_rate is supported]]
     FRAGMENT_SHADING_RATE_WITH_SHADER_DEPTH_STENCIL_WRITES_SUPPORTED_EXT
                                                                 B     GetBooleanv  -              support for writing FragDepth from  13.X.4
                                                                                                   a fragment shader for multi-pixel
                                                                                                   fragments                                                                                           
     FRAGMENT_SHADING_RATE_WITH_SAMPLE_MASK_SUPPORTED_EXT        B     GetBooleanv  -              support for sample masks with       13.X.4
                                                                                                   multi-pixel fragments
-    FRAGMENT_SHADING_RATE_ATTACHMENT_WITH_-                     B    GetBooleanv  -               support for attachment shading      13.X.3
-    DEFAULT_FRAMEBUFFER_SUPPORTED_EXT                                                             rates on the default framebuffer
-[[If GL_EXT_fragment_shading_rate_primitive or GL_EXT_fragment_shading_rate_attachment is supported]]
     FRAGMENT_SHADING_RATE_NON_TRIVIAL_COMBINERS_SUPPORTED_EXT   B    GetBooleanv  -               support for non-trivial combiners   13.X.4
 
 

--- a/extensions/EXT/EXT_fragment_shading_rate.txt
+++ b/extensions/EXT/EXT_fragment_shading_rate.txt
@@ -606,11 +606,11 @@
     SHADING_RATE_EXT                        E     GetIntegerv  SHADING_RATE_1X1_PIXELS_EXT       draw call shading rate   13.X.1
 
 
-[[If GL_EXT_fragment_shading_rate_attachment is supported]]
     Add to table 21.40, Implementation Dependent Values
 
     Get Value                                                   Type  Get Command  Minimum Value  Description                         Sec
     -------------------------------------                       ----  -----------  -------------  --------------                      ------
+[[If GL_EXT_fragment_shading_rate_attachment is supported]]
     MIN_FRAGMENT_SHADING_RATE_ATTACHMENT_TEXEL_WIDTH_EXT        Z+    GetIntegerv  32 (**)        minimum supported width of the      13.X.3
                                                                                                   portion of the framebuffer
                                                                                                   corresponding to each texel in

--- a/extensions/EXT/EXT_fragment_shading_rate.txt
+++ b/extensions/EXT/EXT_fragment_shading_rate.txt
@@ -642,6 +642,7 @@
                                                                                                   multi-pixel fragments
     FRAGMENT_SHADING_RATE_ATTACHMENT_WITH_-                     B    GetBooleanv  -               support for attachment shading      13.X.3
     DEFAULT_FRAMEBUFFER_SUPPORTED_EXT                                                             rates on the default framebuffer
+[[If GL_EXT_fragment_shading_rate_primitive or GL_EXT_fragment_shading_rate_attachment is supported]]
     FRAGMENT_SHADING_RATE_NON_TRIVIAL_COMBINERS_SUPPORTED_EXT   B    GetBooleanv  -               support for non-trivial combiners   13.X.4
 
 


### PR DESCRIPTION
In Vulkan, `fragmentShadingRateNonTrivialCombinerOps` must be VK_FALSE unless either the `primitiveFragmentShadingRate` or `attachmentFragmentShadingRate` feature is supported. But the table here is under shading_rate_attachment alone. It's a bit confusion.  This MR tries to make the connection between Vulkan/OpenGL ES explicit.