### PR TITLE
Update EXT_texture_format_BGRA8888.txt

### DIFF
--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -140,6 +140,30 @@ Interactions with the OpenGL ES 2.0 specification
     --------------- ----------        ---- ---- ---- ---- ---- ----
     BGRA_EXT        color-renderable  8    8    8    8
 
+Interactions with the OpenGL ES 3.0 specification
+
+    Add the following entries to Table 3.2: Valid combinations of format,
+    type, and sized internalformat:
+
+    Format    Type           External Bytes per Pixel Internal Format
+    ------    ----           ------------------------ ---------------
+    BGRA_EXT  UNSIGNED_BYTE  4                        BGRA_EXT, BGRA8_EXT
+
+
+    Modify Section 3.8.3 (Texture Image Specification), p 128
+
+    (add the following required Texture and renderbuffer color formats, p 128)
+
+    - BGRA_EXT
+
+    (add the following to Table 3.13: "Correspondence of sized internal color
+    formats to base internal formats...", beginning on p 130)
+
+    Sized           Base            R    G    B    A    Shared Color-     Texture-
+    Internal Format Internal Format bits bits bits bits bits   renderable filterable
+    --------------- --------------- ---- ---- ---- ---- ------ ---------- ----------
+    BGRA_EXT        BGRA_EXT        8    8    8    8           x          x
+
 Revision History
 
     0.1,  26/04/2005  sks:  Initial revision.

--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -20,7 +20,7 @@ Status
 
 Version
 
-    1.3, 12 September 2016
+    1.4, 21 February 2024
 
 Number
 
@@ -58,6 +58,7 @@ Overview
     Internal Format     External Format Type                    Bytes per Pixel
     ---------------     --------------- ----                    ---------------
     BGRA_EXT            BGRA_EXT        UNSIGNED_BYTE           4
+    BGRA8_EXT           BGRA_EXT        UNSIGNED_BYTE           4
     RGBA                RGBA            UNSIGNED_BYTE           4
     RGB                 RGB             UNSIGNED_BYTE           3
     RGBA                RGBA            UNSIGNED_SHORT_4_4_4_4  2
@@ -87,6 +88,11 @@ New Tokens
     and the <format> parameter of TexSubImage2D:
 
         GL_BGRA_EXT                                     0x80E1
+
+    Accepted by the <internalformat> parameter of TexImage2D, unless using
+    OpenGL ES versions prior to 3.0:
+
+        GL_BGRA8_EXT                                    0x93A1
 
 Additions to Chapter 2 of the OpenGL 1.3 Specification (OpenGL Operation)
 
@@ -154,7 +160,7 @@ Interactions with the OpenGL ES 3.0 specification
 
     (add the following required Texture and renderbuffer color formats, p 128)
 
-    - BGRA_EXT
+    - BGRA_EXT and BGRA8_EXT
 
     (add the following to Table 3.13: "Correspondence of sized internal color
     formats to base internal formats...", beginning on p 130)
@@ -163,6 +169,7 @@ Interactions with the OpenGL ES 3.0 specification
     Internal Format Internal Format bits bits bits bits bits   renderable filterable
     --------------- --------------- ---- ---- ---- ---- ------ ---------- ----------
     BGRA_EXT        BGRA_EXT        8    8    8    8           x          x
+    BGRA8_EXT       BGRA_EXT        8    8    8    8           x          x
 
 Revision History
 
@@ -173,3 +180,4 @@ Revision History
     1.2,  26/10/2009  Benj Lipchak: add EXT suffix to BGRA token.
     1.3,  12/09/2016  Tobias Hector: Added interaction with ES 2.0 (made it renderable).
                       Also made revision dates use the same (dd/mm/yyyy) format.
+    1.4,  14/02/2024  Erik Faye-Lund: Add GL_BGRA8_EXT for ES 3.0.

--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -43,14 +43,14 @@ Overview
 
     Internal Format     External Format Type                    Bytes per Pixel
     ---------------     --------------- ----                    ---------------
-    RGBA                RGBA             UNSIGNED_BYTE          4
-    RGB                 RGB              UNSIGNED_BYTE          3
-    RGBA                RGBA             UNSIGNED_SHORT_4_4_4_4 2
-    RGBA                RGBA             UNSIGNED_SHORT_5_5_5_1 2
-    RGB                 RGB              UNSIGNED_SHORT_5_6_5   2
-    LUMINANCE_ALPHA     LUMINANCE_ALPHA  UNSIGNED_BYTE          2
-    LUMINANCE           LUMINANCE        UNSIGNED_BYTE          1
-    ALPHA               ALPHA            UNSIGNED_BYTE          1
+    RGBA                RGBA            UNSIGNED_BYTE           4
+    RGB                 RGB             UNSIGNED_BYTE           3
+    RGBA                RGBA            UNSIGNED_SHORT_4_4_4_4  2
+    RGBA                RGBA            UNSIGNED_SHORT_5_5_5_1  2
+    RGB                 RGB             UNSIGNED_SHORT_5_6_5    2
+    LUMINANCE_ALPHA     LUMINANCE_ALPHA UNSIGNED_BYTE           2
+    LUMINANCE           LUMINANCE       UNSIGNED_BYTE           1
+    ALPHA               ALPHA           UNSIGNED_BYTE           1
 
 
    This table is extended to include format BGRA_EXT and type UNSIGNED_BYTE:

--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -139,7 +139,7 @@ Interactions with the OpenGL ES 2.0 specification
     | Sized           | Renderable       | R    | G    | B    | A    | D    | S    |
     | Internal Format | Type             | bits | bits | bits | bits | bits | bits |
     |-----------------|------------------|------|------|------|------|------|------|
-    | GL_BGRA_EXT     | color-renderable | 8    | 8    | 8    | 8    |      |      |
+    | BGRA_EXT        | color-renderable | 8    | 8    | 8    | 8    |      |      |
     |-----------------|------------------|------|------|------|------|------|------|
 
 Revision History

--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -90,7 +90,7 @@ New Tokens
         GL_BGRA_EXT                                     0x80E1
 
     Accepted by the <internalformat> parameter of TexImage2D, unless using
-    OpenGL ES versions prior to 3.0:
+    OpenGL ES versions prior to 2.0:
 
         GL_BGRA8_EXT                                    0x93A1
 
@@ -145,6 +145,7 @@ Interactions with the OpenGL ES 2.0 specification
     Internal Format Type              bits bits bits bits bits bits
     --------------- ----------        ---- ---- ---- ---- ---- ----
     BGRA_EXT        color-renderable  8    8    8    8
+    BGRA8_EXT       color-renderable  8    8    8    8
 
 Interactions with the OpenGL ES 3.0 specification
 
@@ -180,4 +181,4 @@ Revision History
     1.2,  26/10/2009  Benj Lipchak: add EXT suffix to BGRA token.
     1.3,  12/09/2016  Tobias Hector: Added interaction with ES 2.0 (made it renderable).
                       Also made revision dates use the same (dd/mm/yyyy) format.
-    1.4,  14/02/2024  Erik Faye-Lund: Add GL_BGRA8_EXT for ES 3.0.
+    1.4,  23/06/2024  Erik Faye-Lund: Add GL_BGRA8_EXT for ES 2.0 and later.

--- a/extensions/EXT/EXT_texture_format_BGRA8888.txt
+++ b/extensions/EXT/EXT_texture_format_BGRA8888.txt
@@ -135,12 +135,10 @@ Interactions with the OpenGL ES 2.0 specification
     and the number of bits each format contains for color (R, G, B, A),
     depth (D), and stencil (S) components:
     
-    |-----------------|------------------|------|------|------|------|------|------|
-    | Sized           | Renderable       | R    | G    | B    | A    | D    | S    |
-    | Internal Format | Type             | bits | bits | bits | bits | bits | bits |
-    |-----------------|------------------|------|------|------|------|------|------|
-    | BGRA_EXT        | color-renderable | 8    | 8    | 8    | 8    |      |      |
-    |-----------------|------------------|------|------|------|------|------|------|
+    Sized           Renderable        R    G    B    A    D    S
+    Internal Format Type              bits bits bits bits bits bits
+    --------------- ----------        ---- ---- ---- ---- ---- ----
+    BGRA_EXT        color-renderable  8    8    8    8
 
 Revision History
 


### PR DESCRIPTION
As agreed on today's call, let's make GL_BGRA8_EXT an allowed internalformat as well.