### PR TITLE
Update vendor to "QCOM" and fix group for new enums

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6928,9 +6928,9 @@ typedef unsigned int GLhandleARB;
             <unused start="0x9690" end="0x969F" vendor="ANGLE"/>
     </enums>
 
-    <enums namespace="GL" start="0x96A0" end="0x96AF" vendor="Qualcomm" comment="contact Jeff Leger">
+    <enums namespace="GL" start="0x96A0" end="0x96AF" vendor="QCOM" comment="contact Jeff Leger">
         <enum value="0x96A0" name="GL_TEXTURE_FOVEATED_CUTOFF_DENSITY_QCOM" group="TextureParameterName"/>
-            <unused start="0x96A1" end="0x96A1" vendor="Qualcomm"/>
+            <unused start="0x96A1" end="0x96A1" vendor="QCOM"/>
         <enum value="0x96A2" name="GL_FRAMEBUFFER_FETCH_NONCOHERENT_QCOM" group="GetPName,EnableCap"/>
         <enum value="0x96A3" name="GL_VALIDATE_SHADER_BINARY_QCOM"/>
         <enum value="0x96A4" name="GL_SHADING_RATE_QCOM" group="GetPName"/>
@@ -6953,7 +6953,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x96AC" name="GL_SHADING_RATE_4X2_PIXELS_EXT" alias="GL_SHADING_RATE_4X2_PIXELS_QCOM" group="ShadingRate"/>
         <enum value="0x96AD" name="GL_SHADING_RATE_2X4_PIXELS_EXT" alias="GL_SHADING_RATE_2X4_PIXELS_QCOM" group="ShadingRate"/>
         <enum value="0x96AE" name="GL_SHADING_RATE_4X4_PIXELS_EXT" alias="GL_SHADING_RATE_4X4_PIXELS_QCOM" group="ShadingRate"/>
-            <unused start="0x96AF" end="0x96AF" vendor="Qualcomm"/>
+            <unused start="0x96AF" end="0x96AF" vendor="QCOM"/>
     </enums>
 
     <enums namespace="GL" start="0x96B0" end="0x96BF" vendor="ANGLE" comment="github pull request">
@@ -7017,10 +7017,10 @@ typedef unsigned int GLhandleARB;
             <unused start="0x9700" end="0x970F" vendor="Samsung"/>
     </enums>
 
-    <enums namespace="GL" start="0x9710" end="0x971F" vendor="Qualcomm" comment="Reserved for Ashish Mathur">
-        <enum value="0x9710" name="GL_TEXTURE_Y_DEGAMMA_QCOM" group="TexParameterI,GetTexParameter"/>
-        <enum value="0x9711" name="GL_TEXTURE_CBCR_DEGAMMA_QCOM" group="TexParameterI,GetTexParameter"/>
-            <unused start="0x9712" end="0x971F" vendor="Qualcomm"/>
+    <enums namespace="GL" start="0x9710" end="0x971F" vendor="QCOM" comment="Reserved for Ashish Mathur">
+        <enum value="0x9710" name="GL_TEXTURE_Y_DEGAMMA_QCOM" group="TextureParameter,GetTextureParameter"/>
+        <enum value="0x9711" name="GL_TEXTURE_CBCR_DEGAMMA_QCOM" group="TextureParameter,GetTextureParameter"/>
+            <unused start="0x9712" end="0x971F" vendor="QCOM"/>
     </enums>
 
 <!-- Enums reservable for future use. To reserve a new range, allocate one


### PR DESCRIPTION
This updates vendor name from "Qualcomm" to "QCOM" and fix group for new enums 0x9710 and 0x9711.