### PR TITLE
Remove the last of the old kind attributes

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8313,45 +8313,45 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>
             <proto>void <name>glClearColorIiEXT</name></proto>
-            <param><ptype>GLint</ptype> <name>red</name></param>
-            <param><ptype>GLint</ptype> <name>green</name></param>
-            <param><ptype>GLint</ptype> <name>blue</name></param>
-            <param><ptype>GLint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4292"/>
         </command>
         <command>
             <proto>void <name>glClearColorIuiEXT</name></proto>
-            <param><ptype>GLuint</ptype> <name>red</name></param>
-            <param><ptype>GLuint</ptype> <name>green</name></param>
-            <param><ptype>GLuint</ptype> <name>blue</name></param>
-            <param><ptype>GLuint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4293"/>
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8361,17 +8361,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped01"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
@@ -8621,16 +8621,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3fVertex3fSUN</name></proto>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glColor3fVertex3fvSUN</name></proto>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -8640,14 +8640,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor3hvNV</name></proto>
-            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4244"/>
         </command>
         <command>
@@ -8712,13 +8712,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3xOES</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
         </command>
         <command>
             <proto>void <name>glColor3xvOES</name></proto>
-            <param len="3">const <ptype>GLfixed</ptype> *<name>components</name></param>
+            <param kind="Color" len="3">const <ptype>GLfixed</ptype> *<name>components</name></param>
         </command>
         <command>
             <proto>void <name>glColor4b</name></proto>
@@ -8756,10 +8756,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fNormal3fVertex3fSUN</name></proto>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -8769,7 +8769,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fNormal3fVertex3fvSUN</name></proto>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -8780,15 +8780,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4hvNV"/>
         </command>
         <command>
             <proto>void <name>glColor4hvNV</name></proto>
-            <param len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4245"/>
         </command>
         <command>
@@ -8827,31 +8827,31 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ubVertex2fSUN</name></proto>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex2fvSUN</name></proto>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex3fSUN</name></proto>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glColor4ubVertex3fvSUN</name></proto>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -8887,26 +8887,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4x</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glColor4xOES</name></proto>
-            <param><ptype>GLfixed</ptype> <name>red</name></param>
-            <param><ptype>GLfixed</ptype> <name>green</name></param>
-            <param><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glColor4xvOES</name></proto>
-            <param len="4">const <ptype>GLfixed</ptype> *<name>components</name></param>
+            <param kind="Color" len="4">const <ptype>GLfixed</ptype> *<name>components</name></param>
         </command>
         <command>
             <proto>void <name>glColorFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -21546,7 +21546,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2dvEXT</name></proto>
@@ -21554,7 +21554,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2fv</name></proto>
@@ -21702,7 +21702,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x2fv"/>
         </command>
         <command>
@@ -26173,7 +26173,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fv</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7029,7 +7029,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAccum</name></proto>
             <param group="AccumOp"><ptype>GLenum</ptype> <name>op</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>value</name></param>
             <glx type="render" opcode="137"/>
         </command>
         <command>
@@ -7691,14 +7691,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBinormal3fEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>bx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>by</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>bz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>bx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>by</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>bz</name></param>
             <vecequiv name="glBinormal3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glBinormal3fvEXT</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glBinormal3iEXT</name></proto>
@@ -7732,10 +7732,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glBitmap</name></proto>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>xorig</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>yorig</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>xmove</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ymove</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>xorig</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>yorig</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>xmove</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ymove</name></param>
             <param len="COMPSIZE(width,height)">const <ptype>GLubyte</ptype> *<name>bitmap</name></param>
             <glx type="render" opcode="5"/>
             <glx type="render" opcode="311" name="glBitmapPBO" comment="PBO protocol"/>
@@ -10477,19 +10477,19 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeformationMap3fSGIX</name></proto>
             <param group="FfdTargetSGIX"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="2074"/>
         </command>
         <command>
@@ -11716,12 +11716,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord1f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u</name></param>
             <vecequiv name="glEvalCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord1fv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>u</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>u</name></param>
             <glx type="render" opcode="152"/>
         </command>
         <command>
@@ -11745,13 +11745,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v</name></param>
             <vecequiv name="glEvalCoord2fv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>u</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>u</name></param>
             <glx type="render" opcode="154"/>
         </command>
         <command>
@@ -12053,23 +12053,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogCoordf</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>coord</name></param>
             <vecequiv name="glFogCoordfv"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>coord</name></param>
             <alias name="glFogCoordf"/>
             <vecequiv name="glFogCoordfvEXT"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
             <glx type="render" opcode="4124"/>
         </command>
         <command>
             <proto>void <name>glFogCoordfvEXT</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>coord</name></param>
             <alias name="glFogCoordfv"/>
             <glx type="render" opcode="4124"/>
         </command>
@@ -17252,11 +17252,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap1f</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="144"/>
         </command>
         <command>
@@ -17285,15 +17285,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap2f</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="146"/>
         </command>
         <command>
@@ -17364,8 +17364,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid1f</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <glx type="render" opcode="148"/>
         </command>
         <command>
@@ -17387,11 +17387,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid2f</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>vn</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <glx type="render" opcode="150"/>
         </command>
         <command>
@@ -17464,11 +17464,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib1fAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordF" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib2dAPPLE</name></proto>
@@ -17488,15 +17488,15 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib2fAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordF" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialf</name></proto>
@@ -18094,26 +18094,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1fv"/>
             <alias name="glMultiTexCoord1f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="199"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1fv"/>
             <glx type="render" opcode="199"/>
         </command>
@@ -18233,28 +18233,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2fv"/>
             <alias name="glMultiTexCoord2f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="203"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2fv"/>
             <glx type="render" opcode="203"/>
         </command>
@@ -18383,30 +18383,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3fv"/>
             <alias name="glMultiTexCoord3f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="207"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3fv"/>
             <glx type="render" opcode="207"/>
         </command>
@@ -18544,32 +18544,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4f</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4fv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4fv"/>
             <alias name="glMultiTexCoord4f"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="211"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4fvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4fv"/>
             <glx type="render" opcode="211"/>
         </command>
@@ -19470,9 +19470,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>nx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ny</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>nz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>nx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ny</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>nz</name></param>
             <vecequiv name="glNormal3fv"/>
         </command>
         <command>
@@ -19491,7 +19491,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="30"/>
         </command>
         <command>
@@ -21921,13 +21921,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="34"/>
         </command>
         <command>
@@ -21975,14 +21975,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="38"/>
         </command>
         <command>
@@ -22034,15 +22034,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4fv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="42"/>
         </command>
         <command>
@@ -22186,16 +22186,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRectf</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y1</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x2</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y2</name></param>
             <vecequiv name="glRectfv"/>
         </command>
         <command>
             <proto>void <name>glRectfv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v1</name></param>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v2</name></param>
             <glx type="render" opcode="46"/>
         </command>
         <command>
@@ -23537,14 +23537,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTangent3fEXT</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>tx</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>ty</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>tz</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>tx</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>ty</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>tz</name></param>
             <vecequiv name="glTangent3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glTangent3fvEXT</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTangent3iEXT</name></proto>
@@ -23690,12 +23690,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1fv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1fv</name></proto>
-            <param kind="CoordF" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="50"/>
         </command>
         <command>
@@ -23758,8 +23758,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2fv"/>
         </command>
         <command>
@@ -23851,7 +23851,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="54"/>
         </command>
         <command>
@@ -23920,14 +23920,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3fv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="58"/>
         </command>
         <command>
@@ -24002,10 +24002,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>s</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>t</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>r</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4fv"/>
         </command>
         <command>
@@ -24051,7 +24051,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="62"/>
         </command>
         <command>
@@ -26583,13 +26583,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glVertex2fv"/>
         </command>
         <command>
             <proto>void <name>glVertex2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="66"/>
         </command>
         <command>
@@ -26657,14 +26657,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glVertex3fv"/>
         </command>
         <command>
             <proto>void <name>glVertex3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="70"/>
         </command>
         <command>
@@ -26738,15 +26738,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glVertex4fv"/>
         </command>
         <command>
             <proto>void <name>glVertex4fv</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="74"/>
         </command>
         <command>
@@ -29112,38 +29112,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2fv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fARB</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <alias name="glWindowPos2f"/>
             <vecequiv name="glWindowPos2fvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
             <alias name="glWindowPos2f"/>
             <vecequiv name="glWindowPos2fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fv</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fvARB</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos2fv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2fvMESA</name></proto>
-            <param kind="CoordF" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos2fv"/>
         </command>
         <command>
@@ -29259,41 +29259,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3f</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3fv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fARB</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <alias name="glWindowPos3f"/>
             <vecequiv name="glWindowPos3fvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
             <alias name="glWindowPos3f"/>
             <vecequiv name="glWindowPos3fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fv</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fvARB</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos3fv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3fvMESA</name></proto>
-            <param kind="CoordF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glWindowPos3fv"/>
         </command>
         <command>
@@ -29388,15 +29388,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4fMESA</name></proto>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>x</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>y</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>z</name></param>
-            <param kind="CoordF"><ptype>GLfloat</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLfloat</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4fvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4fvMESA</name></proto>
-            <param kind="CoordF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4iMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9180,7 +9180,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCombinerParameterfvNV</name></proto>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="4137"/>
         </command>
         <command>
@@ -9199,7 +9199,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCombinerStageParameterfvNV</name></proto>
             <param group="CombinerStageNV"><ptype>GLenum</ptype> <name>stage</name></param>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glCommandListSegmentsNV</name></proto>
@@ -9660,14 +9660,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameterf</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>params</name></param>
+            <param><ptype>GLfloat</ptype> <name>params</name></param>
             <glx type="render" opcode="4103"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterfEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>params</name></param>
+            <param><ptype>GLfloat</ptype> <name>params</name></param>
             <alias name="glConvolutionParameterf"/>
             <glx type="render" opcode="4103"/>
         </command>
@@ -9675,14 +9675,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameterfv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="4104"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterfvEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glConvolutionParameterfv"/>
             <glx type="render" opcode="4104"/>
         </command>
@@ -9690,14 +9690,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameteri</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>params</name></param>
+            <param><ptype>GLint</ptype> <name>params</name></param>
             <glx type="render" opcode="4105"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameteriEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>params</name></param>
+            <param><ptype>GLint</ptype> <name>params</name></param>
             <alias name="glConvolutionParameteri"/>
             <glx type="render" opcode="4105"/>
         </command>
@@ -12130,25 +12130,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glFogf</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="80"/>
         </command>
         <command>
             <proto>void <name>glFogfv</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="81"/>
         </command>
         <command>
             <proto>void <name>glFogi</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="82"/>
         </command>
         <command>
             <proto>void <name>glFogiv</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="83"/>
         </command>
         <command>
@@ -12183,70 +12183,70 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glFragmentLightModelfSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModelfvSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModeliSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModelivSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightfSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightfvSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightiSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightivSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialfSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialfvSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialiSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialivSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFrameTerminatorGREMEDY</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10757,8 +10757,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthBoundsEXT</name></proto>
-            <param kind="ClampedFloat64"><ptype>GLclampd</ptype> <name>zmin</name></param>
-            <param kind="ClampedFloat64"><ptype>GLclampd</ptype> <name>zmax</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampd</ptype> <name>zmin</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampd</ptype> <name>zmax</name></param>
             <glx type="render" opcode="4229"/>
         </command>
         <command>
@@ -20418,7 +20418,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="ClampedFloat32" len="n">const <ptype>GLclampf</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0; 1]" len="n">const <ptype>GLclampf</ptype> *<name>priorities</name></param>
             <alias name="glPrioritizeTextures"/>
             <glx type="render" opcode="4118"/>
         </command>
@@ -22650,7 +22650,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSampleMaskEXT</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>value</name></param>
             <param><ptype>GLboolean</ptype> <name>invert</name></param>
         </command>
         <command>
@@ -22660,7 +22660,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSampleMaskSGIS</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>value</name></param>
             <param><ptype>GLboolean</ptype> <name>invert</name></param>
             <alias name="glSampleMaskEXT"/>
             <glx type="render" opcode="2048"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -5889,7 +5889,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x907F" name="GL_PATH_CLIENT_LENGTH_NV" group="PathParameter"/>
         <enum value="0x9080" name="GL_PATH_FILL_MODE_NV" group="PathParameter,PathFillMode"/>
         <enum value="0x9081" name="GL_PATH_FILL_MASK_NV" group="PathParameter"/>
-        <enum value="0x9082" name="GL_PATH_FILL_COVER_MODE_NV" group="PathCoverMode,PathParameter"/>
+        <enum value="0x9082" name="GL_PATH_FILL_COVER_MODE_NV" group="PathCoverMode,InstancedPathCoverMode,PathParameter"/>
         <enum value="0x9083" name="GL_PATH_STROKE_COVER_MODE_NV" group="PathParameter"/>
         <enum value="0x9084" name="GL_PATH_STROKE_MASK_NV" group="PathParameter"/>
             <!-- <enum value="0x9085" name="GL_PATH_SAMPLE_QUALITY_NV"          comment="Removed from extension"/> -->
@@ -5898,9 +5898,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9088" name="GL_COUNT_UP_NV" group="PathFillMode"/>
         <enum value="0x9089" name="GL_COUNT_DOWN_NV" group="PathFillMode"/>
         <enum value="0x908A" name="GL_PATH_OBJECT_BOUNDING_BOX_NV" group="PathGenMode,PathParameter"/>
-        <enum value="0x908B" name="GL_CONVEX_HULL_NV" group="PathCoverMode"/>
+        <enum value="0x908B" name="GL_CONVEX_HULL_NV" group="PathCoverMode,InstancedPathCoverMode"/>
             <!-- <enum value="0x908C" name="GL_MULTI_HULLS_NV"                  comment="Removed from extension"/> -->
-        <enum value="0x908D" name="GL_BOUNDING_BOX_NV" group="PathCoverMode"/>
+        <enum value="0x908D" name="GL_BOUNDING_BOX_NV" group="PathCoverMode,InstancedPathCoverMode"/>
         <enum value="0x908E" name="GL_TRANSLATE_X_NV" group="PathTransformType"/>
         <enum value="0x908F" name="GL_TRANSLATE_Y_NV" group="PathTransformType"/>
         <enum value="0x9090" name="GL_TRANSLATE_2D_NV" group="PathTransformType"/>
@@ -5915,7 +5915,7 @@ typedef unsigned int GLhandleARB;
             <!-- <enum value="0x9099" name="GL_TRANSPOSE_PROJECTIVE_3D_NV"      comment="Removed from extension"/> -->
         <enum value="0x909A" name="GL_UTF8_NV" group="PathElementType"/>
         <enum value="0x909B" name="GL_UTF16_NV" group="PathElementType"/>
-        <enum value="0x909C" name="GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV" group="PathCoverMode"/>
+        <enum value="0x909C" name="GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV" group="InstancedPathCoverMode"/>
         <enum value="0x909D" name="GL_PATH_COMMAND_COUNT_NV" group="PathParameter"/>
         <enum value="0x909E" name="GL_PATH_COORD_COUNT_NV" group="PathParameter"/>
         <enum value="0x909F" name="GL_PATH_DASH_ARRAY_COUNT_NV" group="PathParameter"/>
@@ -10197,7 +10197,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -10212,7 +10212,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23467,40 +23467,40 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glStencilThenCoverFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
-            <param><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param>const void *<name>paths</name></param>
-            <param><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
-            <param><ptype>GLenum</ptype> <name>transformType</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
+            <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
+            <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
+            <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverFillPathNV</name></proto>
-            <param><ptype>GLuint</ptype> <name>path</name></param>
-            <param><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
+            <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
+            <param kind="StencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
-            <param><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param>const void *<name>paths</name></param>
-            <param><ptype>GLuint</ptype> <name>pathBase</name></param>
-            <param><ptype>GLint</ptype> <name>reference</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
-            <param><ptype>GLenum</ptype> <name>transformType</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
+            <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="InstancedPathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
+            <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverStrokePathNV</name></proto>
-            <param><ptype>GLuint</ptype> <name>path</name></param>
-            <param><ptype>GLint</ptype> <name>reference</name></param>
-            <param><ptype>GLuint</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>coverMode</name></param>
+            <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
         </command>
         <command>
             <proto>void <name>glStopInstrumentsSGIX</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -76,7 +76,10 @@ typedef unsigned int GLhandleARB;
         <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
         <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
         <kind name="String" desc="This parameter represents a string of characters." />
-        <!--ColorIndexValue-->
+        <kind name="DrawBufferIndex" desc="This parameter represents the i in GL_DRAW_BUFFERi." />
+
+        <!-- Applicable to legacy OpenGL functions -->
+        <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
         <!--SelectName  glLoadName-->
         <!--FeedbackElement glPassThrough-->
         
@@ -16503,52 +16506,52 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexd</name></proto>
-            <param kind="ColorIndexValueD"><ptype>GLdouble</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLdouble</ptype> <name>c</name></param>
             <vecequiv name="glIndexdv"/>
         </command>
         <command>
             <proto>void <name>glIndexdv</name></proto>
-            <param kind="ColorIndexValueD" len="1">const <ptype>GLdouble</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLdouble</ptype> *<name>c</name></param>
             <glx type="render" opcode="24"/>
         </command>
         <command>
             <proto>void <name>glIndexf</name></proto>
-            <param kind="ColorIndexValueF"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <vecequiv name="glIndexfv"/>
         </command>
         <command>
             <proto>void <name>glIndexfv</name></proto>
-            <param kind="ColorIndexValueF" len="1">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <glx type="render" opcode="25"/>
         </command>
         <command>
             <proto>void <name>glIndexi</name></proto>
-            <param kind="ColorIndexValueI"><ptype>GLint</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLint</ptype> <name>c</name></param>
             <vecequiv name="glIndexiv"/>
         </command>
         <command>
             <proto>void <name>glIndexiv</name></proto>
-            <param kind="ColorIndexValueI" len="1">const <ptype>GLint</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLint</ptype> *<name>c</name></param>
             <glx type="render" opcode="26"/>
         </command>
         <command>
             <proto>void <name>glIndexs</name></proto>
-            <param kind="ColorIndexValueS"><ptype>GLshort</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLshort</ptype> <name>c</name></param>
             <vecequiv name="glIndexsv"/>
         </command>
         <command>
             <proto>void <name>glIndexsv</name></proto>
-            <param kind="ColorIndexValueS" len="1">const <ptype>GLshort</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLshort</ptype> *<name>c</name></param>
             <glx type="render" opcode="27"/>
         </command>
         <command>
             <proto>void <name>glIndexub</name></proto>
-            <param kind="ColorIndexValueUB"><ptype>GLubyte</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLubyte</ptype> <name>c</name></param>
             <vecequiv name="glIndexubv"/>
         </command>
         <command>
             <proto>void <name>glIndexubv</name></proto>
-            <param kind="ColorIndexValueUB" len="1">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="ColorIndexValue" len="1">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <glx type="render" opcode="194"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8264,7 +8264,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearBufferfi</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
             <glx type="render" opcode="360"/>
@@ -8272,21 +8272,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearBufferfv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="361"/>
         </command>
         <command>
             <proto>void <name>glClearBufferiv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
             <glx type="render" opcode="362"/>
         </command>
         <command>
             <proto>void <name>glClearBufferuiv</name></proto>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param kind="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLuint</ptype> *<name>value</name></param>
             <glx type="render" opcode="363"/>
         </command>
@@ -8401,7 +8401,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferfi</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
         </command>
@@ -8409,21 +8409,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferuiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8097,7 +8097,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBufferDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <param group="BufferUsageARB"><ptype>GLenum</ptype> <name>usage</name></param>
             <alias name="glBufferData"/>
@@ -8165,7 +8165,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <alias name="glBufferSubData"/>
         </command>
@@ -13049,7 +13049,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
-            <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
+            <param kind="BufferSize"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">void *<name>data</name></param>
             <alias name="glGetBufferSubData"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17785,16 +17785,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16457,7 +16457,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>
-            <param kind="MaskedColorIndexValueI"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="MaskedColorIndexValue"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="136"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9193,7 +9193,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCombinerParameterivNV</name></proto>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="4139"/>
         </command>
         <command>
@@ -17473,13 +17473,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapParameterfvNV</name></proto>
             <param group="EvalTargetNV"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="MapParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(target,pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(target,pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMapParameterivNV</name></proto>
             <param group="EvalTargetNV"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="MapParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(target,pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(target,pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void *<name>glMapTexture2DINTEL</name></proto>
@@ -17541,28 +17541,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMaterialf</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="96"/>
         </command>
         <command>
             <proto>void <name>glMaterialfv</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="97"/>
         </command>
         <command>
             <proto>void <name>glMateriali</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="98"/>
         </command>
         <command>
             <proto>void <name>glMaterialiv</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="99"/>
         </command>
         <command>
@@ -18773,7 +18773,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexEnvfvEXT"/>
         </command>
         <command>
@@ -18781,14 +18781,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexEnviEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexEnvivEXT"/>
         </command>
         <command>
@@ -18796,7 +18796,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexGendEXT</name></proto>
@@ -18818,7 +18818,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexGenfvEXT"/>
         </command>
         <command>
@@ -18826,14 +18826,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexGeniEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexGenivEXT"/>
         </command>
         <command>
@@ -18841,7 +18841,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexImage1DEXT</name></proto>
@@ -18901,7 +18901,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexParameterfvEXT"/>
         </command>
         <command>
@@ -18909,14 +18909,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexParameteriEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexParameterivEXT"/>
         </command>
         <command>
@@ -18924,7 +18924,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexRenderbufferEXT</name></proto>
@@ -20027,13 +20027,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelStoref</name></proto>
             <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="single" opcode="109"/>
         </command>
         <command>
             <proto>void <name>glPixelStorei</name></proto>
             <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="single" opcode="110"/>
         </command>
         <command>
@@ -20044,22 +20044,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelTexGenParameterfSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameterfvSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameteriSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameterivSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenSGIX</name></proto>
@@ -20069,13 +20069,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelTransferf</name></proto>
             <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="166"/>
         </command>
         <command>
             <proto>void <name>glPixelTransferi</name></proto>
             <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="167"/>
         </command>
         <command>
@@ -20134,51 +20134,51 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPointParameterf</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2065"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfARB</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
             <glx type="render" opcode="2065"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfEXT</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfSGIS</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfv</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2066"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvARB</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
             <glx type="render" opcode="2066"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvEXT</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvSGIS</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
         </command>
         <command>
@@ -20229,7 +20229,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPointSize</name></proto>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>size</name></param>
+            <param><ptype>GLfloat</ptype> <name>size</name></param>
             <glx type="render" opcode="100"/>
         </command>
         <command>
@@ -23346,25 +23346,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2060"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfvSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2061"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameteriSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2062"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterivSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2063"/>
         </command>
         <command>
@@ -24222,28 +24222,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexEnvf</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="111"/>
         </command>
         <command>
             <proto>void <name>glTexEnvfv</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="112"/>
         </command>
         <command>
             <proto>void <name>glTexEnvi</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="113"/>
         </command>
         <command>
             <proto>void <name>glTexEnviv</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="114"/>
         </command>
         <command>
@@ -24316,7 +24316,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGenf</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="117"/>
         </command>
         <command>
@@ -24329,7 +24329,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGenfv</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="118"/>
         </command>
         <command>
@@ -24587,14 +24587,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexParameterf</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="105"/>
         </command>
         <command>
             <proto>void <name>glTexParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="106"/>
         </command>
         <command>
@@ -24974,11 +24974,11 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLuint</ptype> <name>layer</name></param>
             <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param><ptype>GLfloat</ptype> <name>foveaArea</name></param>
         </command>
         <command>
             <proto>void <name>glTextureImage1DEXT</name></proto>
@@ -25140,7 +25140,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glTextureParameterfvEXT"/>
         </command>
         <command>
@@ -25154,7 +25154,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameteri</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8631,14 +8631,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <vecequiv name="glColor3iv"/>
         </command>
         <command>
             <proto>void <name>glColor3iv</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="9"/>
         </command>
         <command>
@@ -8772,15 +8772,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4iv"/>
         </command>
         <command>
             <proto>void <name>glColor4iv</name></proto>
-            <param kind="ColorI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="17"/>
         </command>
         <command>
@@ -22924,27 +22924,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3i</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3iv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3iEXT</name></proto>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>red</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>green</name></param>
-            <param kind="ColorI"><ptype>GLint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLint</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3i"/>
             <vecequiv name="glSecondaryColor3ivEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3iv</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="4128"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ivEXT</name></proto>
-            <param kind="ColorI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3iv"/>
             <glx type="render" opcode="4128"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -10174,7 +10174,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCoverFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
@@ -10189,7 +10189,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCoverStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathCoverMode"><ptype>GLenum</ptype> <name>coverMode</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
@@ -14393,7 +14393,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathMetricMask"><ptype>GLbitfield</ptype> <name>metricQueryMask</name></param>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(metricQueryMask,numPaths,stride)"><ptype>GLfloat</ptype> *<name>metrics</name></param>
@@ -14415,7 +14415,7 @@ typedef unsigned int GLhandleARB;
             <param group="PathListMode"><ptype>GLenum</ptype> <name>pathListMode</name></param>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param><ptype>GLfloat</ptype> <name>advanceScale</name></param>
             <param><ptype>GLfloat</ptype> <name>kerningScale</name></param>
@@ -23355,7 +23355,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFillPathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
             <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
@@ -23430,7 +23430,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilStrokePathInstancedNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numPaths</name></param>
             <param group="PathElementType"><ptype>GLenum</ptype> <name>pathNameType</name></param>
-            <param kind="PathElement" len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
+            <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
             <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14362,7 +14362,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetPathCommandsNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
-            <param kind="PathCommand" len="COMPSIZE(path)"><ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="COMPSIZE(path)"><ptype>GLubyte</ptype> *<name>commands</name></param>
         </command>
         <command>
             <proto>void <name>glGetPathCoordsNV</name></proto>
@@ -19791,7 +19791,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPathCommandsNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param><ptype>GLsizei</ptype> <name>numCommands</name></param>
-            <param kind="PathCommand" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
             <param><ptype>GLsizei</ptype> <name>numCoords</name></param>
             <param group="PathCoordType"><ptype>GLenum</ptype> <name>coordType</name></param>
             <param len="COMPSIZE(numCoords,coordType)">const void *<name>coords</name></param>
@@ -19922,7 +19922,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>commandStart</name></param>
             <param><ptype>GLsizei</ptype> <name>commandsToDelete</name></param>
             <param><ptype>GLsizei</ptype> <name>numCommands</name></param>
-            <param kind="PathCommand" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
+            <param group="PathCoordType" len="numCommands">const <ptype>GLubyte</ptype> *<name>commands</name></param>
             <param><ptype>GLsizei</ptype> <name>numCoords</name></param>
             <param group="PathCoordType"><ptype>GLenum</ptype> <name>coordType</name></param>
             <param len="COMPSIZE(numCoords,coordType)">const void *<name>coords</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18158,26 +18158,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1sv"/>
             <alias name="glMultiTexCoord1s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="201"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1sv"/>
             <glx type="render" opcode="201"/>
         </command>
@@ -18302,28 +18302,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2sv"/>
             <alias name="glMultiTexCoord2s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="205"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2sv"/>
             <glx type="render" opcode="205"/>
         </command>
@@ -18457,30 +18457,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3sv"/>
             <alias name="glMultiTexCoord3s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="209"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3sv"/>
             <glx type="render" opcode="209"/>
         </command>
@@ -18623,32 +18623,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4s</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4sv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4sARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4sv"/>
             <alias name="glMultiTexCoord4s"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4sv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="213"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4svARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4sv"/>
             <glx type="render" opcode="213"/>
         </command>
@@ -21943,13 +21943,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="36"/>
         </command>
         <command>
@@ -21999,14 +21999,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="40"/>
         </command>
         <command>
@@ -22060,15 +22060,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4sv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="44"/>
         </command>
         <command>
@@ -22214,16 +22214,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRects</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x1</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y1</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x2</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y2</name></param>
             <vecequiv name="glRectsv"/>
         </command>
         <command>
             <proto>void <name>glRectsv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v1</name></param>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v2</name></param>
             <glx type="render" opcode="48"/>
         </command>
         <command>
@@ -23720,12 +23720,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1sv</name></proto>
-            <param kind="CoordS" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="52"/>
         </command>
         <command>
@@ -23878,13 +23878,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="56"/>
         </command>
         <command>
@@ -23956,14 +23956,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="60"/>
         </command>
         <command>
@@ -24082,15 +24082,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>s</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>t</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>r</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4sv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="64"/>
         </command>
         <command>
@@ -26616,13 +26616,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glVertex2sv"/>
         </command>
         <command>
             <proto>void <name>glVertex2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="68"/>
         </command>
         <command>
@@ -26693,14 +26693,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glVertex3sv"/>
         </command>
         <command>
             <proto>void <name>glVertex3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="72"/>
         </command>
         <command>
@@ -26777,15 +26777,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glVertex4sv"/>
         </command>
         <command>
             <proto>void <name>glVertex4sv</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="76"/>
         </command>
         <command>
@@ -29184,38 +29184,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2sv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sARB</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <alias name="glWindowPos2s"/>
             <vecequiv name="glWindowPos2svARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
             <alias name="glWindowPos2s"/>
             <vecequiv name="glWindowPos2svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2sv</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2svARB</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos2sv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2svMESA</name></proto>
-            <param kind="CoordS" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos2sv"/>
         </command>
         <command>
@@ -29337,41 +29337,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3s</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3sv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sARB</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <alias name="glWindowPos3s"/>
             <vecequiv name="glWindowPos3svARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
             <alias name="glWindowPos3s"/>
             <vecequiv name="glWindowPos3svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3sv</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3svARB</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos3sv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3svMESA</name></proto>
-            <param kind="CoordS" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLshort</ptype> *<name>v</name></param>
             <alias name="glWindowPos3sv"/>
         </command>
         <command>
@@ -29412,15 +29412,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4sMESA</name></proto>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>x</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>y</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>z</name></param>
-            <param kind="CoordS"><ptype>GLshort</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLshort</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4svMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4svMESA</name></proto>
-            <param kind="CoordS" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLshort</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowRectanglesEXT</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -80,9 +80,8 @@ typedef unsigned int GLhandleARB;
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
-        <!--SelectName  glLoadName-->
-        <!--FeedbackElement glPassThrough-->
-        
+        <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode." />
+        <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer." />
     </kinds>
 
     <!-- SECTION: GL enumerant (token) definitions. -->

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -73,6 +73,7 @@ typedef unsigned int GLhandleARB;
         <kind name="NDCCoord" desc="This parameter represents a normalized device coordinates (NDC)."/>
         <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
         <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
+        <kind name="Clamped[0; 65536]" desc="This parameter will get clamped to the 0 to 65536 (2^16) range, effectively making it a 16-bit value."/>
         <kind name="Range[0; x]" desc="This parameter must be greater or equal to 0. An upper bound may exist but it might vary."/>
         <kind name="Range[1; x]" desc="This parameter must be greater or equal to 1. An upper bound may exist but it might vary."/>
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
@@ -10504,15 +10505,15 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>w1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>worder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="2073"/>
         </command>
@@ -10522,15 +10523,15 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>w1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>worder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="2074"/>
         </command>
@@ -11813,17 +11814,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glEvalMesh1</name></proto>
             <param group="MeshMode1"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i2</name></param>
+            <param><ptype>GLint</ptype> <name>i1</name></param>
+            <param><ptype>GLint</ptype> <name>i2</name></param>
             <glx type="render" opcode="155"/>
         </command>
         <command>
             <proto>void <name>glEvalMesh2</name></proto>
             <param group="MeshMode2"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i2</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j2</name></param>
+            <param><ptype>GLint</ptype> <name>i1</name></param>
+            <param><ptype>GLint</ptype> <name>i2</name></param>
+            <param><ptype>GLint</ptype> <name>j1</name></param>
+            <param><ptype>GLint</ptype> <name>j2</name></param>
             <glx type="render" opcode="157"/>
         </command>
         <command>
@@ -11833,8 +11834,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalPoint2</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j</name></param>
+            <param><ptype>GLint</ptype> <name>i</name></param>
+            <param><ptype>GLint</ptype> <name>j</name></param>
             <glx type="render" opcode="158"/>
         </command>
         <command>
@@ -12483,7 +12484,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -12491,7 +12492,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -12499,7 +12500,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
         </command>
         <command>
@@ -12507,7 +12508,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
             <alias name="glFramebufferTextureFaceARB"/>
         </command>
@@ -12516,8 +12517,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <glx type="render" opcode="237"/>
         </command>
         <command>
@@ -12525,8 +12526,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <alias name="glFramebufferTextureLayer"/>
         </command>
         <command>
@@ -12534,8 +12535,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <alias name="glFramebufferTextureLayer"/>
         </command>
         <command>
@@ -12543,8 +12544,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <param><ptype>GLint</ptype> <name>xscale</name></param>
             <param><ptype>GLint</ptype> <name>yscale</name></param>
         </command>
@@ -12553,7 +12554,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>baseViewIndex</name></param>
             <param><ptype>GLsizei</ptype> <name>numViews</name></param>
@@ -12563,7 +12564,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>baseViewIndex</name></param>
             <param><ptype>GLsizei</ptype> <name>numViews</name></param>
         </command>
@@ -12572,7 +12573,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -13238,13 +13239,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetCompressedMultiTexImageEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>lod</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>lod</name></param>
             <param len="COMPSIZE(target,lod)">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetCompressedTexImage</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param kind="CompressedTextureARB" len="COMPSIZE(target,level)">void *<name>img</name></param>
             <glx type="single" opcode="160"/>
             <glx type="render" opcode="335" name="glGetCompressedTexImagePBO" comment="PBO protocol"/>
@@ -13252,7 +13253,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetCompressedTexImageARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param kind="CompressedTextureARB" len="COMPSIZE(target,level)">void *<name>img</name></param>
             <alias name="glGetCompressedTexImage"/>
             <glx type="single" opcode="160"/>
@@ -13260,7 +13261,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetCompressedTextureImage</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>pixels</name></param>
         </command>
@@ -13268,13 +13269,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetCompressedTextureImageEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>lod</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>lod</name></param>
             <param len="COMPSIZE(target,lod)">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetCompressedTextureSubImage</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -14085,7 +14086,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexImageEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -14094,7 +14095,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexLevelParameterfvEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
@@ -14102,7 +14103,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexLevelParameterivEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -15303,7 +15304,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexImage</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -15313,7 +15314,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="138"/>
@@ -15321,7 +15322,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="139"/>
@@ -15329,7 +15330,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameterxvOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
@@ -15433,7 +15434,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureImageEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -15449,7 +15450,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameterfvEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
@@ -15464,7 +15465,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameterivEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -17049,14 +17050,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glLighti</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="88"/>
         </command>
         <command>
             <proto>void <name>glLightiv</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="89"/>
         </command>
         <command>
@@ -17085,7 +17086,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLineStipple</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
+            <param kind="Clamped[0; 65536]"><ptype>GLint</ptype> <name>factor</name></param>
             <param><ptype>GLushort</ptype> <name>pattern</name></param>
             <glx type="render" opcode="94"/>
         </command>
@@ -17287,7 +17288,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="143"/>
         </command>
@@ -17297,17 +17298,17 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="144"/>
         </command>
         <command>
             <proto>void <name>glMap1xOES</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLfixed</ptype> <name>u1</name></param>
-            <param><ptype>GLfixed</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param><ptype>GLfixed</ptype> <name>points</name></param>
         </command>
         <command>
@@ -17316,11 +17317,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="145"/>
         </command>
@@ -17330,25 +17331,25 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="146"/>
         </command>
         <command>
             <proto>void <name>glMap2xOES</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLfixed</ptype> <name>u1</name></param>
-            <param><ptype>GLfixed</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param><ptype>GLint</ptype> <name>uorder</name></param>
-            <param><ptype>GLfixed</ptype> <name>v1</name></param>
-            <param><ptype>GLfixed</ptype> <name>v2</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param><ptype>GLfixed</ptype> <name>points</name></param>
         </command>
         <command>
@@ -17391,8 +17392,8 @@ typedef unsigned int GLhandleARB;
             <param group="MapTypeNV"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>ustride</name></param>
             <param><ptype>GLsizei</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param><ptype>GLboolean</ptype> <name>packed</name></param>
             <param len="COMPSIZE(target,uorder,vorder)">const void *<name>points</name></param>
         </command>
@@ -17499,7 +17500,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17509,7 +17510,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17519,11 +17520,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17533,11 +17534,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -18850,10 +18851,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -18862,11 +18863,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -18875,12 +18876,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -18890,7 +18891,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexParameterIuivEXT</name></proto>
@@ -18939,8 +18940,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -18950,9 +18951,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -18963,10 +18964,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -19249,7 +19250,7 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferSamplePositionsfvAMD</name></proto>
@@ -19264,7 +19265,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTexture2DEXT</name></proto>
@@ -19272,7 +19273,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTexture3DEXT</name></proto>
@@ -19280,22 +19281,22 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTextureEXT</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTextureFaceEXT</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
         </command>
         <command>
@@ -19311,8 +19312,8 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
         </command>
         <command>
             <proto>void <name>glNamedProgramLocalParameter4dEXT</name></proto>
@@ -20000,7 +20001,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapfv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLfloat</ptype> *<name>values</name></param>
             <glx type="render" opcode="168"/>
             <glx type="render" opcode="323" name="glPixelMapfvPBO" comment="PBO protocol"/>
@@ -20008,7 +20009,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapuiv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLuint</ptype> *<name>values</name></param>
             <glx type="render" opcode="169"/>
             <glx type="render" opcode="324" name="glPixelMapuivPBO" comment="PBO protocol"/>
@@ -20016,7 +20017,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapusv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLushort</ptype> *<name>values</name></param>
             <glx type="render" opcode="170"/>
             <glx type="render" opcode="325" name="glPixelMapusvPBO" comment="PBO protocol"/>
@@ -24345,7 +24346,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGeni</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="119"/>
         </command>
         <command>
@@ -24358,7 +24359,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGeniv</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="120"/>
         </command>
         <command>
@@ -24604,14 +24605,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexParameteri</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="107"/>
         </command>
         <command>
             <proto>void <name>glTexParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="108"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7680,14 +7680,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBinormal3dEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>bx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>by</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>bz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>bx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>by</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>bz</name></param>
             <vecequiv name="glBinormal3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glBinormal3dvEXT</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glBinormal3fEXT</name></proto>
@@ -10459,19 +10459,19 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeformationMap3dSGIX</name></proto>
             <param group="FfdTargetSGIX"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="2073"/>
         </command>
         <command>
@@ -11706,12 +11706,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord1d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u</name></param>
             <vecequiv name="glEvalCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord1dv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>u</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>u</name></param>
             <glx type="render" opcode="151"/>
         </command>
         <command>
@@ -11734,13 +11734,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalCoord2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v</name></param>
             <vecequiv name="glEvalCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glEvalCoord2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>u</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>u</name></param>
             <glx type="render" opcode="153"/>
         </command>
         <command>
@@ -12031,23 +12031,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogCoordd</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>coord</name></param>
             <vecequiv name="glFogCoorddv"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>coord</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>coord</name></param>
             <alias name="glFogCoordd"/>
             <vecequiv name="glFogCoorddvEXT"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
             <glx type="render" opcode="4125"/>
         </command>
         <command>
             <proto>void <name>glFogCoorddvEXT</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>coord</name></param>
             <alias name="glFogCoorddv"/>
             <glx type="render" opcode="4125"/>
         </command>
@@ -17242,11 +17242,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap1d</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="143"/>
         </command>
         <command>
@@ -17271,15 +17271,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMap2d</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="145"/>
         </command>
         <command>
@@ -17357,8 +17357,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid1d</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <glx type="render" opcode="147"/>
         </command>
         <command>
@@ -17377,11 +17377,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMapGrid2d</name></proto>
             <param><ptype>GLint</ptype> <name>un</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>vn</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <glx type="render" opcode="149"/>
         </command>
         <command>
@@ -17454,11 +17454,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib1dAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
-            <param kind="CoordD" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib1fAPPLE</name></proto>
@@ -17474,15 +17474,15 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapVertexAttrib2dAPPLE</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>size</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>v2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
-            <param kind="CoordD" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
+            <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
             <proto>void <name>glMapVertexAttrib2fAPPLE</name></proto>
@@ -18068,26 +18068,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1dv"/>
             <alias name="glMultiTexCoord1d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="198"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1dv"/>
             <glx type="render" opcode="198"/>
         </command>
@@ -18205,28 +18205,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2dv"/>
             <alias name="glMultiTexCoord2d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="202"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2dv"/>
             <glx type="render" opcode="202"/>
         </command>
@@ -18353,30 +18353,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3dv"/>
             <alias name="glMultiTexCoord3d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="206"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3dv"/>
             <glx type="render" opcode="206"/>
         </command>
@@ -18512,32 +18512,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4d</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4dv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4dv"/>
             <alias name="glMultiTexCoord4d"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="210"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4dvARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4dv"/>
             <glx type="render" opcode="210"/>
         </command>
@@ -19458,14 +19458,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormal3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>nx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>ny</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>nz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>nx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>ny</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>nz</name></param>
             <vecequiv name="glNormal3dv"/>
         </command>
         <command>
             <proto>void <name>glNormal3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="29"/>
         </command>
         <command>
@@ -21910,13 +21910,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="33"/>
         </command>
         <command>
@@ -21963,14 +21963,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="37"/>
         </command>
         <command>
@@ -22021,15 +22021,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4dv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="41"/>
         </command>
         <command>
@@ -22172,16 +22172,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRectd</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y1</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x2</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y2</name></param>
             <vecequiv name="glRectdv"/>
         </command>
         <command>
             <proto>void <name>glRectdv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v1</name></param>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v2</name></param>
             <glx type="render" opcode="45"/>
         </command>
         <command>
@@ -23526,14 +23526,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTangent3dEXT</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>tx</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>ty</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>tz</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>tx</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>ty</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>tz</name></param>
             <vecequiv name="glTangent3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glTangent3dvEXT</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTangent3fEXT</name></proto>
@@ -23680,12 +23680,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1dv</name></proto>
-            <param kind="CoordD" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="49"/>
         </command>
         <command>
@@ -23747,13 +23747,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="53"/>
         </command>
         <command>
@@ -23908,14 +23908,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="57"/>
         </command>
         <command>
@@ -23989,15 +23989,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>s</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>t</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>r</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4dv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="61"/>
         </command>
         <command>
@@ -26572,13 +26572,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glVertex2dv"/>
         </command>
         <command>
             <proto>void <name>glVertex2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="65"/>
         </command>
         <command>
@@ -26645,14 +26645,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glVertex3dv"/>
         </command>
         <command>
             <proto>void <name>glVertex3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="69"/>
         </command>
         <command>
@@ -26725,15 +26725,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glVertex4dv"/>
         </command>
         <command>
             <proto>void <name>glVertex4dv</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="73"/>
         </command>
         <command>
@@ -29076,38 +29076,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2dv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dARB</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <alias name="glWindowPos2d"/>
             <vecequiv name="glWindowPos2dvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
             <alias name="glWindowPos2d"/>
             <vecequiv name="glWindowPos2dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dv</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dvARB</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos2dv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2dvMESA</name></proto>
-            <param kind="CoordD" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos2dv"/>
         </command>
         <command>
@@ -29220,41 +29220,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3d</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3dv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dARB</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <alias name="glWindowPos3d"/>
             <vecequiv name="glWindowPos3dvARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
             <alias name="glWindowPos3d"/>
             <vecequiv name="glWindowPos3dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dv</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dvARB</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos3dv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3dvMESA</name></proto>
-            <param kind="CoordD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glWindowPos3dv"/>
         </command>
         <command>
@@ -29376,15 +29376,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4dMESA</name></proto>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>x</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>y</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>z</name></param>
-            <param kind="CoordD"><ptype>GLdouble</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLdouble</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4dvMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4dvMESA</name></proto>
-            <param kind="CoordD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4fMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7801,10 +7801,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8251,18 +8251,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param><ptype>GLfloat</ptype> <name>red</name></param>
-            <param><ptype>GLfloat</ptype> <name>green</name></param>
-            <param><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -9001,22 +9001,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorP3ui</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4uiv</name></proto>
             <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorPointer</name></proto>
@@ -22387,9 +22387,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -22397,16 +22397,16 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -22417,17 +22417,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fSUN</name></proto>
             <param><ptype>GLuint</ptype> <name>rc</name></param>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -22435,7 +22435,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -22478,7 +22478,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -22933,14 +22933,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hNV</name></proto>
-            <param><ptype>GLhalfNV</ptype> <name>red</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>green</name></param>
-            <param><ptype>GLhalfNV</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLhalfNV</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3hvNV"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3hvNV</name></proto>
-            <param len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLhalfNV</ptype> *<name>v</name></param>
             <glx type="render" opcode="4255"/>
         </command>
         <command>
@@ -23081,13 +23081,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLuint</ptype> <name>color</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorPointer</name></proto>
@@ -23787,9 +23787,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexCoord2fColor3fVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -23797,17 +23797,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor3fVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoord2fColor4fNormal3fVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -23818,7 +23818,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -23826,10 +23826,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexCoord2fColor4ubVertex3fSUN</name></proto>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLubyte</ptype> <name>r</name></param>
-            <param><ptype>GLubyte</ptype> <name>g</name></param>
-            <param><ptype>GLubyte</ptype> <name>b</name></param>
-            <param><ptype>GLubyte</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
@@ -23837,7 +23837,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord2fColor4ubVertex3fvSUN</name></proto>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -24035,10 +24035,10 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>p</name></param>
             <param><ptype>GLfloat</ptype> <name>q</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -24050,7 +24050,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexCoord4fColor4fNormal3fVertex4fvSUN</name></proto>
             <param len="4">const <ptype>GLfloat</ptype> *<name>tc</name></param>
-            <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7657,7 +7657,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>video_capture_slot</name></param>
             <param><ptype>GLuint</ptype> <name>stream</name></param>
             <param><ptype>GLenum</ptype> <name>frame_region</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBindVideoCaptureStreamTextureNV</name></proto>
@@ -8164,7 +8164,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
             <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
             <alias name="glBufferSubData"/>
@@ -13048,7 +13048,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetBufferSubDataARB</name></proto>
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="BufferOffsetARB"><ptype>GLintptrARB</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptrARB</ptype> <name>offset</name></param>
             <param kind="BufferSizeARB"><ptype>GLsizeiptrARB</ptype> <name>size</name></param>
             <param len="size">void *<name>data</name></param>
             <alias name="glGetBufferSubData"/>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8175,7 +8175,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCallList</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <glx type="render" opcode="1"/>
         </command>
         <command>
@@ -13820,13 +13820,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetListParameterfvSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetListParameterivSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -17071,7 +17071,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glListBase</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>base</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>base</name></param>
             <glx type="render" opcode="3"/>
         </command>
         <command>
@@ -17086,28 +17086,28 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glListParameterfSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2078"/>
         </command>
         <command>
             <proto>void <name>glListParameterfvSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2079"/>
         </command>
         <command>
             <proto>void <name>glListParameteriSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2080"/>
         </command>
         <command>
             <proto>void <name>glListParameterivSGIX</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2081"/>
@@ -19434,7 +19434,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNewList</name></proto>
-            <param kind="List"><ptype>GLuint</ptype> <name>list</name></param>
+            <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <glx type="single" opcode="101"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17044,7 +17044,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glLineStipple</name></proto>
             <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
-            <param kind="LineStipple"><ptype>GLushort</ptype> <name>pattern</name></param>
+            <param><ptype>GLushort</ptype> <name>pattern</name></param>
             <glx type="render" opcode="94"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -47335,4 +47335,3 @@ typedef unsigned int GLhandleARB;
         <extension name="GL_EXT_texture_shadow_lod" supported="gl|glcore|gles2"/>
     </extensions>
 </registry>
-

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8330,10 +8330,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamp01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17127,28 +17127,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glListParameterfSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2078"/>
         </command>
         <command>
             <proto>void <name>glListParameterfvSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Clamped[0; 1]" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2079"/>
         </command>
         <command>
             <proto>void <name>glListParameteriSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2080"/>
         </command>
         <command>
             <proto>void <name>glListParameterivSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2081"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -18132,26 +18132,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord1i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glMultiTexCoord1iv"/>
             <alias name="glMultiTexCoord1i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="200"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord1iv"/>
             <glx type="render" opcode="200"/>
         </command>
@@ -18274,28 +18274,28 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord2i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glMultiTexCoord2iv"/>
             <alias name="glMultiTexCoord2i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="204"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord2iv"/>
             <glx type="render" opcode="204"/>
         </command>
@@ -18427,30 +18427,30 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord3i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glMultiTexCoord3iv"/>
             <alias name="glMultiTexCoord3i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="208"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord3iv"/>
             <glx type="render" opcode="208"/>
         </command>
@@ -18591,32 +18591,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMultiTexCoord4i</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4iv"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4iARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glMultiTexCoord4iv"/>
             <alias name="glMultiTexCoord4i"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4iv</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="212"/>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4ivARB</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glMultiTexCoord4iv"/>
             <glx type="render" opcode="212"/>
         </command>
@@ -21932,13 +21932,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glRasterPos2iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="35"/>
         </command>
         <command>
@@ -21987,14 +21987,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glRasterPos3iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="39"/>
         </command>
         <command>
@@ -22047,15 +22047,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRasterPos4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glRasterPos4iv"/>
         </command>
         <command>
             <proto>void <name>glRasterPos4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="43"/>
         </command>
         <command>
@@ -22200,16 +22200,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRecti</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x1</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y1</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x2</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y2</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x1</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y1</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x2</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y2</name></param>
             <vecequiv name="glRectiv"/>
         </command>
         <command>
             <proto>void <name>glRectiv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v1</name></param>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v2</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v1</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v2</name></param>
             <glx type="render" opcode="47"/>
         </command>
         <command>
@@ -23710,12 +23710,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord1i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
             <vecequiv name="glTexCoord1iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord1iv</name></proto>
-            <param kind="CoordI" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="1">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="51"/>
         </command>
         <command>
@@ -23867,13 +23867,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
             <vecequiv name="glTexCoord2iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="55"/>
         </command>
         <command>
@@ -23944,14 +23944,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
             <vecequiv name="glTexCoord3iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="59"/>
         </command>
         <command>
@@ -24069,15 +24069,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoord4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>s</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>t</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>r</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>q</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>s</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>t</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>r</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>q</name></param>
             <vecequiv name="glTexCoord4iv"/>
         </command>
         <command>
             <proto>void <name>glTexCoord4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="63"/>
         </command>
         <command>
@@ -26605,13 +26605,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glVertex2iv"/>
         </command>
         <command>
             <proto>void <name>glVertex2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="67"/>
         </command>
         <command>
@@ -26681,14 +26681,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glVertex3iv"/>
         </command>
         <command>
             <proto>void <name>glVertex3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="71"/>
         </command>
         <command>
@@ -26764,15 +26764,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVertex4i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glVertex4iv"/>
         </command>
         <command>
             <proto>void <name>glVertex4iv</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="75"/>
         </command>
         <command>
@@ -29148,38 +29148,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos2i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <vecequiv name="glWindowPos2iv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iARB</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <alias name="glWindowPos2i"/>
             <vecequiv name="glWindowPos2ivARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
             <alias name="glWindowPos2i"/>
             <vecequiv name="glWindowPos2ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2iv</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2ivARB</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos2iv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos2ivMESA</name></proto>
-            <param kind="CoordI" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="2">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos2iv"/>
         </command>
         <command>
@@ -29298,41 +29298,41 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos3i</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <vecequiv name="glWindowPos3iv"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iARB</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <alias name="glWindowPos3i"/>
             <vecequiv name="glWindowPos3ivARB"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
             <alias name="glWindowPos3i"/>
             <vecequiv name="glWindowPos3ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3iv</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3ivARB</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos3iv"/>
             <glx type="render" opcode="230"/>
         </command>
         <command>
             <proto>void <name>glWindowPos3ivMESA</name></proto>
-            <param kind="CoordI" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="3">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glWindowPos3iv"/>
         </command>
         <command>
@@ -29400,15 +29400,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glWindowPos4iMESA</name></proto>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>x</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>y</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>z</name></param>
-            <param kind="CoordI"><ptype>GLint</ptype> <name>w</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>z</name></param>
+            <param kind="Coord"><ptype>GLint</ptype> <name>w</name></param>
             <vecequiv name="glWindowPos4ivMESA"/>
         </command>
         <command>
             <proto>void <name>glWindowPos4ivMESA</name></proto>
-            <param kind="CoordI" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
+            <param kind="Coord" len="4">const <ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glWindowPos4sMESA</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17785,16 +17785,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="Color,Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16781,7 +16781,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto><ptype>GLboolean</ptype> <name>glIsPointInFillPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
         </command>
@@ -19927,7 +19927,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPathStencilFuncNV</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glPathStringNV</name></proto>
@@ -23378,7 +23378,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23386,13 +23386,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFillPathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param group="PathFillMode"><ptype>GLenum</ptype> <name>fillMode</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilFunc</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="162"/>
         </command>
         <command>
@@ -23400,24 +23400,24 @@ typedef unsigned int GLhandleARB;
             <param group="StencilFaceDirection"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilFuncSeparateATI</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>frontfunc</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>backfunc</name></param>
             <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilMask</name></proto>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="133"/>
         </command>
         <command>
             <proto>void <name>glStencilMaskSeparate</name></proto>
             <param group="StencilFaceDirection"><ptype>GLenum</ptype> <name>face</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilOp</name></proto>
@@ -23453,7 +23453,7 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(numPaths,pathNameType,paths)">const void *<name>paths</name></param>
             <param kind="Path"><ptype>GLuint</ptype> <name>pathBase</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <param group="PathTransformType"><ptype>GLenum</ptype> <name>transformType</name></param>
             <param len="COMPSIZE(numPaths,transformType)">const <ptype>GLfloat</ptype> *<name>transformValues</name></param>
         </command>
@@ -23461,7 +23461,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilStrokePathNV</name></proto>
             <param kind="Path"><ptype>GLuint</ptype> <name>path</name></param>
             <param kind="StencilValue"><ptype>GLint</ptype> <name>reference</name></param>
-            <param kind="MaskedStencilValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glStencilThenCoverFillPathInstancedNV</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9001,17 +9001,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
@@ -23082,12 +23082,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color"><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param kind="Color" len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8655,38 +8655,38 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <vecequiv name="glColor3ubv"/>
         </command>
         <command>
             <proto>void <name>glColor3ubv</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="11"/>
         </command>
         <command>
             <proto>void <name>glColor3ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <vecequiv name="glColor3uiv"/>
         </command>
         <command>
             <proto>void <name>glColor3uiv</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="12"/>
         </command>
         <command>
             <proto>void <name>glColor3us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <vecequiv name="glColor3usv"/>
         </command>
         <command>
             <proto>void <name>glColor3usv</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="13"/>
         </command>
         <command>
@@ -8798,10 +8798,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4ubv"/>
         </command>
         <command>
@@ -8835,33 +8835,33 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4ubv</name></proto>
-            <param kind="ColorUB" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="19"/>
         </command>
         <command>
             <proto>void <name>glColor4ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4uiv"/>
         </command>
         <command>
             <proto>void <name>glColor4uiv</name></proto>
-            <param kind="ColorUI" len="4">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="20"/>
         </command>
         <command>
             <proto>void <name>glColor4us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4usv"/>
         </command>
         <command>
             <proto>void <name>glColor4usv</name></proto>
-            <param kind="ColorUS" len="4">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="21"/>
         </command>
         <command>
@@ -22976,79 +22976,79 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ub</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3ubv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubEXT</name></proto>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>red</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>green</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3ub"/>
             <vecequiv name="glSecondaryColor3ubvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubv</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="4131"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ubvEXT</name></proto>
-            <param kind="ColorUB" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3ubv"/>
             <glx type="render" opcode="4131"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3ui</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3uiv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uiEXT</name></proto>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>red</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>green</name></param>
-            <param kind="ColorUI"><ptype>GLuint</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLuint</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3ui"/>
             <vecequiv name="glSecondaryColor3uivEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uiv</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <glx type="render" opcode="4133"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3uivEXT</name></proto>
-            <param kind="ColorUI" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLuint</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3uiv"/>
             <glx type="render" opcode="4133"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3us</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3usv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usEXT</name></proto>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>red</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>green</name></param>
-            <param kind="ColorUS"><ptype>GLushort</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLushort</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3us"/>
             <vecequiv name="glSecondaryColor3usvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usv</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <glx type="render" opcode="4132"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3usvEXT</name></proto>
-            <param kind="ColorUS" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLushort</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3usv"/>
             <glx type="render" opcode="4132"/>
         </command>
@@ -27729,10 +27729,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib4ubNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>x</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>y</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>z</name></param>
-            <param kind="ColorUB"><ptype>GLubyte</ptype> <name>w</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>x</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>y</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>z</name></param>
+            <param kind="Color"><ptype>GLubyte</ptype> <name>w</name></param>
             <alias name="glVertexAttrib4Nub"/>
             <vecequiv name="glVertexAttrib4ubvNV"/>
         </command>
@@ -27750,7 +27750,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttrib4ubvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param kind="ColorUB" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <alias name="glVertexAttrib4Nubv"/>
             <glx type="render" opcode="4201"/>
         </command>
@@ -28565,7 +28565,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribs4ubvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param kind="ColorUB" len="count*4">const <ptype>GLubyte</ptype> *<name>v</name></param>
+            <param kind="Color" len="count*4">const <ptype>GLubyte</ptype> *<name>v</name></param>
             <glx type="render" opcode="4214"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8581,14 +8581,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <vecequiv name="glColor3dv"/>
         </command>
         <command>
             <proto>void <name>glColor3dv</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="7"/>
         </command>
         <command>
@@ -8714,15 +8714,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4dv"/>
         </command>
         <command>
             <proto>void <name>glColor4dv</name></proto>
-            <param kind="ColorD" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="15"/>
         </command>
         <command>
@@ -22860,27 +22860,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3d</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3dv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dEXT</name></proto>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>red</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>green</name></param>
-            <param kind="ColorD"><ptype>GLdouble</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLdouble</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3d"/>
             <vecequiv name="glSecondaryColor3dvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dv</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <glx type="render" opcode="4130"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3dvEXT</name></proto>
-            <param kind="ColorD" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLdouble</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3dv"/>
             <glx type="render" opcode="4130"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -73,6 +73,8 @@ typedef unsigned int GLhandleARB;
         <kind name="NDCCoord" desc="This parameter represents a normalized device coordinates (NDC)."/>
         <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
         <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
+        <kind name="Range[0; x]" desc="This parameter must be greater or equal to 0. An upper bound may exist but it might vary."/>
+        <kind name="Range[1; x]" desc="This parameter must be greater or equal to 1. An upper bound may exist but it might vary."/>
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
@@ -80,6 +82,7 @@ typedef unsigned int GLhandleARB;
         <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
         <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
         <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
+        <kind name="Zero" desc="This parameter must be zero."/>
         
         <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix." />
         <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix." />
@@ -9231,10 +9234,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9242,11 +9245,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9254,12 +9257,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9267,8 +9270,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9278,9 +9281,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9291,10 +9294,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9305,10 +9308,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="214"/>
@@ -9317,10 +9320,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage1D"/>
@@ -9329,11 +9332,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="215"/>
@@ -9342,11 +9345,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage2D"/>
@@ -9355,12 +9358,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="216"/>
@@ -9369,12 +9372,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage3D"/>
@@ -9383,20 +9386,20 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9407,8 +9410,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9419,9 +9422,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9433,9 +9436,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9447,10 +9450,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9463,10 +9466,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9479,7 +9482,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -9494,10 +9497,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9505,11 +9508,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9517,19 +9520,19 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
         <command>
             <proto>void <name>glCompressedTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9540,8 +9543,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9550,7 +9553,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9563,9 +9566,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9575,7 +9578,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -9590,10 +9593,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9706,14 +9709,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameteriv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="4106"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterivEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glConvolutionParameteriv"/>
             <glx type="render" opcode="4106"/>
         </command>
@@ -9903,31 +9906,31 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9936,9 +9939,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9948,10 +9951,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9982,56 +9985,56 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <glx type="render" opcode="4119"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <alias name="glCopyTexImage1D"/>
             <glx type="render" opcode="4119"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <glx type="render" opcode="4120"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <alias name="glCopyTexImage2D"/>
             <glx type="render" opcode="4120"/>
         </command>
         <command>
             <proto>void <name>glCopyTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10040,8 +10043,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10051,9 +10054,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10063,9 +10066,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10076,10 +10079,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10089,10 +10092,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10102,8 +10105,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCopyTexSubImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -10116,47 +10119,47 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureLevelsAPPLE</name></proto>
-            <param><ptype>GLuint</ptype> <name>destinationTexture</name></param>
-            <param><ptype>GLuint</ptype> <name>sourceTexture</name></param>
-            <param><ptype>GLint</ptype> <name>sourceBaseLevel</name></param>
-            <param><ptype>GLsizei</ptype> <name>sourceLevelCount</name></param>
+            <param class="texture"><ptype>GLuint</ptype> <name>destinationTexture</name></param>
+            <param class="texture"><ptype>GLuint</ptype> <name>sourceTexture</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>sourceBaseLevel</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>sourceLevelCount</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10164,11 +10167,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -10176,9 +10179,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10187,12 +10190,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -10200,10 +10203,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12425,8 +12428,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleIMG</name></proto>
@@ -12434,8 +12437,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DOES</name></proto>
@@ -24379,10 +24382,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -24392,11 +24395,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -24406,7 +24409,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage2DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24425,12 +24428,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -24440,12 +24443,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -24455,7 +24458,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24476,7 +24479,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24489,13 +24492,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLsizei</ptype> <name>size4d</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth,size4d)">const void *<name>pixels</name></param>
@@ -24503,8 +24506,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexPageCommitmentARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24515,8 +24518,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexPageCommitmentEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24529,7 +24532,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexPageCommitmentMemNV</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
@@ -24643,14 +24646,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <alias name="glTexStorage1D"/>
@@ -24658,7 +24661,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24666,7 +24669,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24675,7 +24678,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24684,7 +24687,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24693,7 +24696,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24703,7 +24706,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24713,7 +24716,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DMultisampleOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24724,7 +24727,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageAttribs2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24733,7 +24736,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageAttribs3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24743,7 +24746,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
@@ -24752,7 +24755,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24762,7 +24765,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem2DMultisampleEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24773,7 +24776,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24784,7 +24787,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem3DMultisampleEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24800,14 +24803,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLsizei</ptype> <name>layers</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>layers</name></param>
             <param group="TextureStorageMaskAMD"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -24818,8 +24821,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -24830,9 +24833,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24844,9 +24847,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24858,10 +24861,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -24874,10 +24877,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -24890,7 +24893,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24904,11 +24907,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>woffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param><ptype>GLint</ptype> <name>woffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -24984,10 +24987,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -24996,11 +24999,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -25030,12 +25033,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -25114,7 +25117,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterIuiv</name></proto>
@@ -25167,7 +25170,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glTextureParameterivEXT"/>
         </command>
         <command>
@@ -25181,7 +25184,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureRangeAPPLE</name></proto>
@@ -25198,22 +25201,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25222,7 +25225,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25230,7 +25233,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage2DMultisample</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25240,7 +25243,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25249,7 +25252,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25259,7 +25262,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25268,7 +25271,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage3DMultisample</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25279,7 +25282,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25289,7 +25292,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
@@ -25298,7 +25301,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25308,7 +25311,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem2DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25319,7 +25322,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25330,7 +25333,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem3DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25342,7 +25345,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageSparseAMD</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25353,7 +25356,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25364,8 +25367,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -25374,7 +25377,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -25387,9 +25390,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25399,7 +25402,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -25414,10 +25417,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -82,6 +82,7 @@ typedef unsigned int GLhandleARB;
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
+        <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter." />
         <kind name="SelectName" desc="This parameter represents a name on the name stack used in the GL_SELECT render mode." />
         <kind name="FeedbackElement" desc="This parameter represents a marker to be placed in the feedback buffer." />
     </kinds>
@@ -8378,7 +8379,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="MaskedColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexMask"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>
@@ -16477,7 +16478,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>
-            <param kind="MaskedColorIndexValue"><ptype>GLuint</ptype> <name>mask</name></param>
+            <param kind="ColorIndexMask"><ptype>GLuint</ptype> <name>mask</name></param>
             <glx type="render" opcode="136"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -66,6 +66,22 @@ typedef unsigned int GLhandleARB;
         <type>typedef void (<apientry/> *<name>GLVULKANPROCNV</name>)(void);</type>
     </types>
 
+    <kinds>
+        <kind name="Color" desc="This parameter represents part of or a complete color." />
+        <kind name="Coord" desc="This parameter represents a coordinate." />
+        <kind name="WinCoord" desc="This parameter represents a window coordinate." />
+        <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="StencilValue" desc="" />
+        <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
+        <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
+        <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
+        <kind name="String" desc="This parameter represents a string of characters." />
+        <!--ColorIndexValue-->
+        <!--SelectName  glLoadName-->
+        <!--FeedbackElement glPassThrough-->
+        
+    </kinds>
+
     <!-- SECTION: GL enumerant (token) definitions. -->
 
     <!-- Bitmasks each have their own namespace, although bits are

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7148,7 +7148,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7801,10 +7801,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8259,10 +8259,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -8344,10 +8344,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
@@ -8375,7 +8375,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10855,8 +10855,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="ClampedFixed"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20425,7 +20425,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="ClampedFixed" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped01" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7763,18 +7763,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
@@ -8292,10 +8292,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>
@@ -8593,9 +8593,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <vecequiv name="glColor3fv"/>
         </command>
         <command>
@@ -8614,7 +8614,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor3fv</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="8"/>
         </command>
         <command>
@@ -8727,10 +8727,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <vecequiv name="glColor4fv"/>
         </command>
         <command>
@@ -8754,7 +8754,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColor4fv</name></proto>
-            <param kind="ColorF" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="16"/>
         </command>
         <command>
@@ -17763,16 +17763,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingARB</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
             <proto>void <name>glMinSampleShadingOES</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>value</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>value</name></param>
             <alias name="glMinSampleShading"/>
         </command>
         <command>
@@ -22886,27 +22886,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glSecondaryColor3f</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <vecequiv name="glSecondaryColor3fv"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fEXT</name></proto>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ColorF"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
             <alias name="glSecondaryColor3f"/>
             <vecequiv name="glSecondaryColor3fvEXT"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fv</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <glx type="render" opcode="4129"/>
         </command>
         <command>
             <proto>void <name>glSecondaryColor3fvEXT</name></proto>
-            <param kind="ColorF" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param kind="Color" len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
             <alias name="glSecondaryColor3fv"/>
             <glx type="render" opcode="4129"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -26433,7 +26433,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVDPAUGetSurfaceivNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -26446,29 +26446,29 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLboolean</ptype> <name>glVDPAUIsSurfaceNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUMapSurfacesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numSurfaces</name></param>
-            <param kind="vdpauSurfaceNV" len="numSurfaces">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
+            <param len="numSurfaces">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterOutputSurfaceNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterOutputSurfaceNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
         </command>
         <command>
-            <proto kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
+            <proto><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
             <param>const void *<name>vdpSurface</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
@@ -26477,17 +26477,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glVDPAUSurfaceAccessNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
             <param><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUUnmapSurfacesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>numSurface</name></param>
-            <param kind="vdpauSurfaceNV" len="numSurface">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
+            <param len="numSurface">const <ptype>GLvdpauSurfaceNV</ptype> *<name>surfaces</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUUnregisterSurfaceNV</name></proto>
-            <param kind="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
+            <param><ptype>GLvdpauSurfaceNV</ptype> <name>surface</name></param>
         </command>
         <command>
             <proto>void <name>glValidateProgram</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22365,7 +22365,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
             <param><ptype>GLfloat</ptype> <name>g</name></param>
             <param><ptype>GLfloat</ptype> <name>b</name></param>
@@ -22375,13 +22375,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
             <param><ptype>GLfloat</ptype> <name>g</name></param>
             <param><ptype>GLfloat</ptype> <name>b</name></param>
@@ -22395,14 +22395,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLubyte</ptype> <name>r</name></param>
             <param><ptype>GLubyte</ptype> <name>g</name></param>
             <param><ptype>GLubyte</ptype> <name>b</name></param>
@@ -22413,13 +22413,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiColor4ubVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="4">const <ptype>GLubyte</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>
@@ -22429,7 +22429,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
@@ -22439,7 +22439,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>r</name></param>
@@ -22455,7 +22455,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>c</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
@@ -22463,7 +22463,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fNormal3fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
@@ -22475,14 +22475,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fNormal3fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>n</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
@@ -22491,20 +22491,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiTexCoord2fVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="2">const <ptype>GLfloat</ptype> *<name>tc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiVertex3fSUN</name></proto>
-            <param kind="ReplacementCodeSUN"><ptype>GLuint</ptype> <name>rc</name></param>
+            <param><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>x</name></param>
             <param><ptype>GLfloat</ptype> <name>y</name></param>
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
             <proto>void <name>glReplacementCodeuiVertex3fvSUN</name></proto>
-            <param kind="ReplacementCodeSUN" len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
+            <param len="1">const <ptype>GLuint</ptype> *<name>rc</name></param>
             <param len="3">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,7 +70,8 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color." />
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
-        <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[0, 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[-1, 1]" desc="This parameter will get clamped to the -1 to 1 range." />
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
@@ -7148,7 +7149,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7784,27 +7785,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8251,18 +8252,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="ClampedNeg1To1,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
@@ -8337,21 +8338,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped01,Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param kind="Clamped01"><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8361,21 +8362,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param kind="Clamped01"><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="Clamped01"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10855,8 +10856,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="Clamped01"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20425,7 +20426,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Clamped01" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0, 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22672,7 +22672,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSampleMaskIndexedNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param group="SampleMaskNV"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
         </command>
         <command>
             <proto>void <name>glSampleMaskSGIS</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -80,6 +80,17 @@ typedef unsigned int GLhandleARB;
         <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
         <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
         
+        <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix." />
+        <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix." />
+        <kind name="Matrix2x4" desc="This parameter represents a 2x4 matrix." />
+
+        <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
+        <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />>
+
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />>
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />>
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />>
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
@@ -21551,7 +21562,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2fvEXT</name></proto>
@@ -21559,7 +21570,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2fv"/>
         </command>
         <command>
@@ -21568,7 +21579,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3dvEXT</name></proto>
@@ -21576,7 +21587,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fv</name></proto>
@@ -21584,7 +21595,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x3fvEXT</name></proto>
@@ -21592,7 +21603,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -21601,7 +21612,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4dvEXT</name></proto>
@@ -21609,7 +21620,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fv</name></proto>
@@ -21617,7 +21628,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix2x4fvEXT</name></proto>
@@ -21625,7 +21636,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -21634,7 +21645,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3dvEXT</name></proto>
@@ -21642,7 +21653,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fv</name></proto>
@@ -21650,7 +21661,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3fvEXT</name></proto>
@@ -21658,7 +21669,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3fv"/>
         </command>
         <command>
@@ -21667,7 +21678,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2dvEXT</name></proto>
@@ -21675,7 +21686,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fv</name></proto>
@@ -21683,7 +21694,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x2fvEXT</name></proto>
@@ -21700,7 +21711,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4dvEXT</name></proto>
@@ -21708,7 +21719,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fv</name></proto>
@@ -21716,7 +21727,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix3x4fvEXT</name></proto>
@@ -21724,7 +21735,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -21733,7 +21744,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4dvEXT</name></proto>
@@ -21741,7 +21752,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fv</name></proto>
@@ -21749,7 +21760,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4fvEXT</name></proto>
@@ -21757,7 +21768,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4fv"/>
         </command>
         <command>
@@ -21766,7 +21777,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2dvEXT</name></proto>
@@ -21774,7 +21785,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fv</name></proto>
@@ -21782,7 +21793,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x2fvEXT</name></proto>
@@ -21790,7 +21801,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -21799,7 +21810,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3dvEXT</name></proto>
@@ -21807,7 +21818,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fv</name></proto>
@@ -21815,7 +21826,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniformMatrix4x3fvEXT</name></proto>
@@ -21823,7 +21834,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniformMatrix4x3fv"/>
         </command>
         <command>
@@ -26169,14 +26180,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x2" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2fv"/>
         </command>
         <command>
@@ -26184,14 +26195,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="305"/>
         </command>
         <command>
@@ -26199,7 +26210,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x3" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x3fv"/>
         </command>
         <command>
@@ -26207,14 +26218,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix2x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="307"/>
         </command>
         <command>
@@ -26222,7 +26233,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix2x4" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix2x4fv"/>
         </command>
         <command>
@@ -26230,21 +26241,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x3" len="count*9">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3fv"/>
         </command>
         <command>
@@ -26252,14 +26263,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="306"/>
         </command>
         <command>
@@ -26267,7 +26278,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x2" len="count*6">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x2fv"/>
         </command>
         <command>
@@ -26275,14 +26286,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix3x4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="309"/>
         </command>
         <command>
@@ -26290,7 +26301,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix3x4" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix3x4fv"/>
         </command>
         <command>
@@ -26298,21 +26309,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x4" len="count*16">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4fv"/>
         </command>
         <command>
@@ -26320,14 +26331,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="308"/>
         </command>
         <command>
@@ -26335,7 +26346,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x2" len="count*8">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x2fv"/>
         </command>
         <command>
@@ -26343,14 +26354,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniformMatrix4x3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <glx type="render" opcode="310"/>
         </command>
         <command>
@@ -26358,7 +26369,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLboolean</ptype> <name>transpose</name></param>
-            <param len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Matrix4x3" len="count*12">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniformMatrix4x3fv"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,6 +70,7 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color." />
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
+        <kind name="NDCCoord" desc="This parameter represents a normalized device coordinates (NDC)."/>
         <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
         <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
@@ -12253,7 +12254,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFrameZoomSGIX</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
+            <param><ptype>GLint</ptype> <name>factor</name></param>
             <glx type="render" opcode="2072"/>
         </command>
         <command>
@@ -12286,11 +12287,11 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLuint</ptype> <name>layer</name></param>
             <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param><ptype>GLfloat</ptype> <name>foveaArea</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferParameteri</name></proto>
@@ -13860,13 +13861,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetListParameterfvSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetListParameterivSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLocalConstantBooleanvEXT</name></proto>
@@ -14583,12 +14584,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetPixelTexGenParameterfvSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetPixelTexGenParameterivSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetPixelTransformParameterfvEXT</name></proto>
@@ -17031,14 +17032,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glLightf</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="86"/>
         </command>
         <command>
             <proto>void <name>glLightfv</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="87"/>
         </command>
         <command>
@@ -17087,7 +17088,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLineWidth</name></proto>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>width</name></param>
+            <param><ptype>GLfloat</ptype> <name>width</name></param>
             <glx type="render" opcode="95"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14812,7 +14812,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetProgramStringNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>id</name></param>
             <param group="VertexAttribEnumNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="ProgramCharacterNV" len="COMPSIZE(id,pname)"><ptype>GLubyte</ptype> *<name>program</name></param>
+            <param kind="String" len="COMPSIZE(id,pname)"><ptype>GLubyte</ptype> *<name>program</name></param>
             <glx type="vendor" opcode="1299"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8330,10 +8330,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="130"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -71,12 +71,14 @@ typedef unsigned int GLhandleARB;
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
         <kind name="Clamped01" desc="This parameter will get clamped to the 0 to 1 range." />
-        <kind name="StencilValue" desc="" />
+        <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
+        <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
         <kind name="BufferOffset" desc="This parameter represents an offset into a buffer." />
         <kind name="BufferSize" desc="This parameter represents the size of a buffer." />
-        <kind name="String" desc="This parameter represents a string of characters." />
-        <kind name="DrawBufferIndex" desc="This parameter represents the i in GL_DRAW_BUFFERi." />
+        <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar." />
+        <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS" />
+        
 
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -86,12 +86,17 @@ typedef unsigned int GLhandleARB;
 
         <kind name="Matrix3x2" desc="This parameter represents a 3x2 matrix." />
         <kind name="Matrix3x3" desc="This parameter represents a 3x3 matrix." />
-        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />>
+        <kind name="Matrix3x4" desc="This parameter represents a 3x4 matrix." />
 
-        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />>
-        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />>
-        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />>
+        <kind name="Matrix4x2" desc="This parameter represents a 4x2 matrix." />
+        <kind name="Matrix4x3" desc="This parameter represents a 4x3 matrix." />
+        <kind name="Matrix4x4" desc="This parameter represents a 4x4 matrix." />
 
+        <kind name="Vector1" desc="This parameter represents a vector with 1 components" />
+        <kind name="Vector2" desc="This parameter represents a vector with 2 components" />
+        <kind name="Vector3" desc="This parameter represents a vector with 3 components" />
+        <kind name="Vector4" desc="This parameter represents a vector with 4 components" />
+        
         <!-- Applicable to legacy OpenGL functions -->
         <kind name="ColorIndexValue" desc="This parameter represents a color in the color index." />
         <kind name="ColorIndexMask" desc="This parameter represents a color index mask. A color index value will be masked using this parameter." />
@@ -20796,14 +20801,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1f</name></proto>
@@ -20823,14 +20828,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1fv"/>
         </command>
         <command>
@@ -20856,14 +20861,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1iEXT</name></proto>
@@ -20877,14 +20882,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1iv"/>
         </command>
         <command>
@@ -20910,14 +20915,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1uiEXT</name></proto>
@@ -20931,14 +20936,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform1uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform1uiv"/>
         </command>
         <command>
@@ -20960,14 +20965,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2f</name></proto>
@@ -20989,14 +20994,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2fv"/>
         </command>
         <command>
@@ -21025,14 +21030,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2iEXT</name></proto>
@@ -21047,14 +21052,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2iv"/>
         </command>
         <command>
@@ -21083,14 +21088,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2uiEXT</name></proto>
@@ -21105,14 +21110,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform2uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform2uiv"/>
         </command>
         <command>
@@ -21136,14 +21141,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3f</name></proto>
@@ -21167,14 +21172,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3fv"/>
         </command>
         <command>
@@ -21206,14 +21211,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3iEXT</name></proto>
@@ -21229,14 +21234,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3iv"/>
         </command>
         <command>
@@ -21268,14 +21273,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3uiEXT</name></proto>
@@ -21291,14 +21296,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform3uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform3uiv"/>
         </command>
         <command>
@@ -21324,14 +21329,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4dvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4f</name></proto>
@@ -21357,14 +21362,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4fvEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4fv"/>
         </command>
         <command>
@@ -21399,14 +21404,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4i64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4iEXT</name></proto>
@@ -21423,14 +21428,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4ivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4iv"/>
         </command>
         <command>
@@ -21465,14 +21470,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4ui64vNV</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4uiEXT</name></proto>
@@ -21489,14 +21494,14 @@ typedef unsigned int GLhandleARB;
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glProgramUniform4uivEXT</name></proto>
             <param class="program"><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glProgramUniform4uiv"/>
         </command>
         <command>
@@ -25555,7 +25560,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1f</name></proto>
@@ -25572,13 +25577,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform1fv"/>
         </command>
         <command>
@@ -25600,13 +25605,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1iARB</name></proto>
@@ -25618,13 +25623,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform1iv"/>
         </command>
         <command>
@@ -25646,13 +25651,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1uiEXT</name></proto>
@@ -25664,13 +25669,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform1uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform1uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector1" len="count*1">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform1uiv"/>
         </command>
         <command>
@@ -25683,7 +25688,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2f</name></proto>
@@ -25702,13 +25707,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform2fv"/>
         </command>
         <command>
@@ -25733,13 +25738,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2iARB</name></proto>
@@ -25752,13 +25757,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform2iv"/>
         </command>
         <command>
@@ -25783,13 +25788,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2uiEXT</name></proto>
@@ -25802,13 +25807,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform2uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform2uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector2" len="count*2">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform2uiv"/>
         </command>
         <command>
@@ -25822,7 +25827,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3f</name></proto>
@@ -25843,13 +25848,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform3fv"/>
         </command>
         <command>
@@ -25877,13 +25882,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3iARB</name></proto>
@@ -25897,13 +25902,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform3iv"/>
         </command>
         <command>
@@ -25931,13 +25936,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3uiEXT</name></proto>
@@ -25951,13 +25956,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform3uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform3uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector3" len="count*3">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform3uiv"/>
         </command>
         <command>
@@ -25972,7 +25977,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4dv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLdouble</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4f</name></proto>
@@ -25995,13 +26000,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4fv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4fvARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLfloat</ptype> *<name>value</name></param>
             <alias name="glUniform4fv"/>
         </command>
         <command>
@@ -26032,13 +26037,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4i64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4i64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4iARB</name></proto>
@@ -26053,13 +26058,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4iv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4ivARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLint</ptype> *<name>value</name></param>
             <alias name="glUniform4iv"/>
         </command>
         <command>
@@ -26090,13 +26095,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4ui64vARB</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4ui64vNV</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint64EXT</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4uiEXT</name></proto>
@@ -26111,13 +26116,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glUniform4uiv</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glUniform4uivEXT</name></proto>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <param kind="Vector4" len="count*4">const <ptype>GLuint</ptype> *<name>value</name></param>
             <alias name="glUniform4uiv"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7784,18 +7784,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped01,Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8379,7 +8379,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="ColorIndexMask"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="ColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>
@@ -8402,17 +8402,17 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedBufferSubData</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param>const void *<name>data</name></param>
+            <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedBufferSubDataEXT</name></proto>
             <param class="buffer"><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>offset</name></param>
+            <param kind="BufferOffset"><ptype>GLsizeiptr</ptype> <name>offset</name></param>
             <param kind="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -8424,7 +8424,7 @@ typedef unsigned int GLhandleARB;
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
-            <param><ptype>GLint</ptype> <name>stencil</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>stencil</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
@@ -8437,7 +8437,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
-            <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
+            <param kind="DrawBufferIndex"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -9000,17 +9000,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
@@ -19927,7 +19927,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPathStencilFuncNV</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
             <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>
@@ -23407,7 +23407,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glStencilFuncSeparateATI</name></proto>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>frontfunc</name></param>
             <param group="StencilFunction"><ptype>GLenum</ptype> <name>backfunc</name></param>
-            <param kind="ClampedStencilValue"><ptype>GLint</ptype> <name>ref</name></param>
+            <param kind="StencilValue"><ptype>GLint</ptype> <name>ref</name></param>
             <param kind="StencilMask"><ptype>GLuint</ptype> <name>mask</name></param>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -1719,9 +1719,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8149" name="GL_SPRITE_MODE_SGIX" group="GetPName,SpriteParameterNameSGIX"/>
         <enum value="0x814A" name="GL_SPRITE_AXIS_SGIX" group="GetPName"/>
         <enum value="0x814B" name="GL_SPRITE_TRANSLATION_SGIX" group="GetPName"/>
-        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX" group="SpriteModeSGIX"/>
-        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX" group="SpriteModeSGIX"/>
-        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX"/>
+        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX"/>
+        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX"/>
         <enum value="0x814F" name="GL_TEXTURE_4D_BINDING_SGIS" group="GetPName"/>
     </enums>
 
@@ -23329,25 +23329,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2060"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfvSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2061"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameteriSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX"><ptype>GLint</ptype> <name>param</name></param>
+            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2062"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterivSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2063"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9110,14 +9110,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glColorTableParameterfv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2054"/>
         </command>
         <command>
             <proto>void <name>glColorTableParameterfvSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glColorTableParameterfv"/>
             <glx type="render" opcode="2054"/>
         </command>
@@ -9125,14 +9125,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glColorTableParameteriv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2055"/>
         </command>
         <command>
             <proto>void <name>glColorTableParameterivSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glColorTableParameteriv"/>
             <glx type="render" opcode="2055"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -16475,7 +16475,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glIndexFuncEXT</name></proto>
             <param group="IndexFunctionEXT"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>ref</name></param>
+            <param kind="ColorIndexValue"><ptype>GLclampf</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glIndexMask</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -1719,9 +1719,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8149" name="GL_SPRITE_MODE_SGIX" group="GetPName,SpriteParameterNameSGIX"/>
         <enum value="0x814A" name="GL_SPRITE_AXIS_SGIX" group="GetPName"/>
         <enum value="0x814B" name="GL_SPRITE_TRANSLATION_SGIX" group="GetPName"/>
-        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX"/>
-        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX"/>
-        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX"/>
+        <enum value="0x814C" name="GL_SPRITE_AXIAL_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814D" name="GL_SPRITE_OBJECT_ALIGNED_SGIX" group="SpriteModeSGIX"/>
+        <enum value="0x814E" name="GL_SPRITE_EYE_ALIGNED_SGIX" group="SpriteModeSGIX"/>
         <enum value="0x814F" name="GL_TEXTURE_4D_BINDING_SGIS" group="GetPName"/>
     </enums>
 
@@ -23329,25 +23329,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param group="SpriteModeSGIX"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2060"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfvSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2061"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameteriSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param group="SpriteModeSGIX"><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2062"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterivSGIX</name></proto>
             <param group="SpriteParameterNameSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param group="SpriteModeSGIX" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2063"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8358,7 +8358,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
-            <param kind="MaskedColorIndexValueF"><ptype>GLfloat</ptype> <name>c</name></param>
+            <param kind="MaskedColorIndexValue"><ptype>GLfloat</ptype> <name>c</name></param>
             <glx type="render" opcode="129"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -22464,10 +22464,10 @@ typedef unsigned int GLhandleARB;
             <param group="TriangleListSUN"><ptype>GLuint</ptype> <name>rc</name></param>
             <param><ptype>GLfloat</ptype> <name>s</name></param>
             <param><ptype>GLfloat</ptype> <name>t</name></param>
-            <param><ptype>GLfloat</ptype> <name>r</name></param>
-            <param><ptype>GLfloat</ptype> <name>g</name></param>
-            <param><ptype>GLfloat</ptype> <name>b</name></param>
-            <param><ptype>GLfloat</ptype> <name>a</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>r</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>g</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>b</name></param>
+            <param kind="Color"><ptype>GLfloat</ptype> <name>a</name></param>
             <param><ptype>GLfloat</ptype> <name>nx</name></param>
             <param><ptype>GLfloat</ptype> <name>ny</name></param>
             <param><ptype>GLfloat</ptype> <name>nz</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,8 +70,8 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color." />
         <kind name="Coord" desc="This parameter represents a coordinate." />
         <kind name="WinCoord" desc="This parameter represents a window coordinate." />
-        <kind name="Clamped[0, 1]" desc="This parameter will get clamped to the 0 to 1 range." />
-        <kind name="Clamped[-1, 1]" desc="This parameter will get clamped to the -1 to 1 range." />
+        <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+        <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range." />
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value." />
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values." />
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data." />
@@ -7149,7 +7149,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
             <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
@@ -7785,27 +7785,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendColor</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorEXT</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <alias name="glBlendColor"/>
             <glx type="render" opcode="4096"/>
         </command>
         <command>
             <proto>void <name>glBlendColorxOES</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
@@ -8338,21 +8338,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearColorx</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearColorxOES</name></proto>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[0, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[0; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepth</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLdouble</ptype> <name>depth</name></param>
             <glx type="render" opcode="132"/>
         </command>
         <command>
@@ -8362,21 +8362,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearDepthf</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfloat</ptype> <name>d</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>d</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthfOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>depth</name></param>
             <glx type="render" opcode="4308"/>
             <alias name="glClearDepthf"/>
         </command>
         <command>
             <proto>void <name>glClearDepthx</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearDepthxOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glClearIndex</name></proto>
@@ -10844,8 +10844,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangefOES</name></proto>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>n</name></param>
-            <param kind="ClampedFloat32"><ptype>GLclampf</ptype> <name>f</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>n</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLclampf</ptype> <name>f</name></param>
             <glx type="render" opcode="4309"/>
             <alias name="glDepthRangef"/>
         </command>
@@ -10856,8 +10856,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRangexOES</name></proto>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>n</name></param>
-            <param kind="Clamped[0, 1]"><ptype>GLfixed</ptype> <name>f</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>n</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfixed</ptype> <name>f</name></param>
         </command>
         <command>
             <proto>void <name>glDetachObjectARB</name></proto>
@@ -20426,7 +20426,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glPrioritizeTexturesxOES</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param class="texture" len="n">const <ptype>GLuint</ptype> *<name>textures</name></param>
-            <param kind="Clamped[0, 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
+            <param kind="Clamped[0; 1]" len="n">const <ptype>GLfixed</ptype> *<name>priorities</name></param>
         </command>
         <command>
             <proto>void <name>glProgramBinary</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -8252,18 +8252,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearAccum</name></proto>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>red</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>green</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfloat</ptype> <name>alpha</name></param>
             <glx type="render" opcode="128"/>
         </command>
         <command>
             <proto>void <name>glClearAccumxOES</name></proto>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
-            <param kind="Clamped[-1, 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>red</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>green</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>blue</name></param>
+            <param kind="Clamped[-1; 1],Color"><ptype>GLfixed</ptype> <name>alpha</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>

--- a/xml/readme.tex
+++ b/xml/readme.tex
@@ -181,6 +181,10 @@ Zero or more of each of the following tags, normally in this order
       statement. Unused.
 \item \tag{types} (see section~\ref{tag:types}) - defines API types.
       Usually only one tag is used.
+\item \tag{kinds} (see section~\ref{tag:kinds}) - defines tags
+      that can be used for parameter validation and more expressive types
+       in API bindings for languages other than C. 
+       One parameter can be of multiple kinds.
 \item \tag{groups} (see section~\ref{tag:groups}) - defines named groups
       of tokens for possible parameter validation in API bindings for
       languages other than C. Usually only one tag is used.
@@ -247,6 +251,62 @@ the following declarations:
 typedef ptrdiff_t GLintptr;
 \end{verbatim}
 
+\section{Kinds (\tag{kinds} tag)}
+\label{tag:kinds}
+
+The \tag{kinds} tag contain individual \tag{kind} tags describing
+some metadata not captured by the \tag{types} tag (see section~\ref{tag:types}) 
+or \tag{enums} tag (see section~\ref{tag:groups}).
+
+\subsection{Attributes of (\tag{kinds} tag)}
+
+\begin{itemize}
+\item \attr{name} - the name of the kind.
+\item \attr{desc} - a description of what the kind indicates.
+\end{itemize}
+
+\subsection{Contents of \tag{kinds} tags}
+
+Each \tag{kinds} block contains zero or more \tag{kind} tags, in
+arbitrary order.
+
+\subsection{Example of a \tag{kinds} tag}
+
+\begin{verbatim}
+<kinds>
+    <kind name="Color" desc="This parameter represents part of or a complete color." />
+    <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range." />
+</kinds>
+\end{verbatim}
+
+\section{Kind (\tag{kind} tag)}
+\label{tag:kind}
+
+Each \{kind} tag defines a single kind annotation.
+
+\subsection{Attributes of \tag{kind} tag}
+
+\begin{itemize}
+\item \attr{name} - kind name, an arbitrary string used
+      to identify this kind.
+\item \attr{desc} - kind description, a description of what it
+      means for a parameter or return value to be annotated with this kind.
+\end{itemize}
+
+\subsection{Contents of \tag{kind} tag}
+
+None.
+
+\subsection{Meaning of \tag{kind} tags}
+\label{tag:kind:meaning}
+
+If a \tag{proto} or \tag{param} tag of a \tag{command} has a
+\attr{kind} attribute defined, and that attribute matches a \tag{kind}
+name, then the return type or parameter type is considered to be
+further defined by the description provided by the \tag{kind} tag
+with the matching name. C language bindings do not attempt to
+enforce this constraint in any way, but other language bindings 
+may try to do so.
 
 \section{Enumerant Groups (\tag{groups} tag)}
 \label{tag:groups}
@@ -506,6 +566,8 @@ The \tag{proto} tag defines the return type and name of a command.
 
 \begin{itemize}
 \item \attr{group} - group name, an arbitrary string.
+\item \attr{kind} - kind list, a comma separated list of names of
+      previously defined \tag{kind} tags.
 \end{itemize}
 
 If the group name is defined, it may be interpreted as described in

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -60,7 +60,7 @@ Kinds = element kinds {
 # <kind> defines a description for a single kind.
 Kind = element kind {
     Name ,
-    attribute desc
+    attribute desc { text }
 }
 
 # <groups> defines a group of enum groups

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -15,6 +15,7 @@ start = element registry {
     (
         element comment { text } ? |
         Types      * |
+        Kinds      * |
         Groups     * |
         Enums      * |
         Commands   * |
@@ -49,6 +50,17 @@ Type = element type {
     text ,
     element name { TypeName } ? ,
     text
+}
+
+# <kinds> defines descriptions for kinds.
+Kinds = element kinds {
+    Kind *
+}
+
+# <kind> defines a description for a single kind.
+Kind = element kind {
+    Name ,
+    attribute desc
 }
 
 # <groups> defines a group of enum groups
@@ -141,6 +153,7 @@ Command = element command {
     Comment ? ,
     element proto {
         attribute group { text } ? ,
+        attribute kind { text } ? ,
         attribute class { text } ? ,
         text ,
         element ptype { TypeName } ? ,
@@ -150,6 +163,7 @@ Command = element command {
     } ,
     element param {
         attribute group { text } ? ,
+        attribute kind { text } ? ,
         attribute class { text } ? ,
         attribute len { text } ? ,
         text ,


### PR DESCRIPTION
This PR fixes the last stuff that was left in in #534. Basically this PR replaces and removes the last `CheckedFloat` and `CheckedInt32` kinds (as well a few others kinds that where leftovers and never described formally).

I thought I had fixed these things but it turned out that I had some +1 year old commits in this branch that I never opened a PR for.

cc @SunSerega 