### PR TITLE
Remove the last of the old kind attributes

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,9 +70,10 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color."/>
         <kind name="Coord" desc="This parameter represents a coordinate."/>
         <kind name="WinCoord" desc="This parameter represents a window coordinate."/>
-        <kind name="NDCCoord" desc="This parameter represents a normalized device coordinates (NDC)."/>
+        <kind name="NDCCoord" desc="This parameter represents a normalized< device coordinates (NDC)."/>
         <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range."/>
         <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range."/>
+        <kind name="Clamped[0; 65536]" desc="This parameter will get clamped to the 0 to 65536 (2^16) range, effectively making it a 16-bit value."/>
         <kind name="Range[0; x]" desc="This parameter must be greater or equal to 0. An upper bound may exist but it might vary."/>
         <kind name="Range[1; x]" desc="This parameter must be greater or equal to 1. An upper bound may exist but it might vary."/>
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value."/>
@@ -10567,15 +10568,15 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>w1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>worder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="2073"/>
         </command>
@@ -10585,15 +10586,15 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>w1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>w2</name></param>
             <param><ptype>GLint</ptype> <name>wstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>worder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>worder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder,wstride,worder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="2074"/>
         </command>
@@ -11876,17 +11877,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glEvalMesh1</name></proto>
             <param group="MeshMode1"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i2</name></param>
+            <param><ptype>GLint</ptype> <name>i1</name></param>
+            <param><ptype>GLint</ptype> <name>i2</name></param>
             <glx type="render" opcode="155"/>
         </command>
         <command>
             <proto>void <name>glEvalMesh2</name></proto>
             <param group="MeshMode2"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i2</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j1</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j2</name></param>
+            <param><ptype>GLint</ptype> <name>i1</name></param>
+            <param><ptype>GLint</ptype> <name>i2</name></param>
+            <param><ptype>GLint</ptype> <name>j1</name></param>
+            <param><ptype>GLint</ptype> <name>j2</name></param>
             <glx type="render" opcode="157"/>
         </command>
         <command>
@@ -11896,8 +11897,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEvalPoint2</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>i</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>j</name></param>
+            <param><ptype>GLint</ptype> <name>i</name></param>
+            <param><ptype>GLint</ptype> <name>j</name></param>
             <glx type="render" opcode="158"/>
         </command>
         <command>
@@ -12546,7 +12547,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -12554,7 +12555,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -12562,7 +12563,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
         </command>
         <command>
@@ -12570,7 +12571,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
             <alias name="glFramebufferTextureFaceARB"/>
         </command>
@@ -12579,8 +12580,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <glx type="render" opcode="237"/>
         </command>
         <command>
@@ -12588,8 +12589,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <alias name="glFramebufferTextureLayer"/>
         </command>
         <command>
@@ -12597,8 +12598,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <alias name="glFramebufferTextureLayer"/>
         </command>
         <command>
@@ -12606,8 +12607,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <param><ptype>GLint</ptype> <name>xscale</name></param>
             <param><ptype>GLint</ptype> <name>yscale</name></param>
         </command>
@@ -12616,7 +12617,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>baseViewIndex</name></param>
             <param><ptype>GLsizei</ptype> <name>numViews</name></param>
@@ -12626,7 +12627,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>baseViewIndex</name></param>
             <param><ptype>GLsizei</ptype> <name>numViews</name></param>
         </command>
@@ -12635,7 +12636,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture"/>
         </command>
         <command>
@@ -13301,13 +13302,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetCompressedMultiTexImageEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>lod</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>lod</name></param>
             <param len="COMPSIZE(target,lod)">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetCompressedTexImage</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param kind="CompressedTextureARB" len="COMPSIZE(target,level)">void *<name>img</name></param>
             <glx type="single" opcode="160"/>
             <glx type="render" opcode="335" name="glGetCompressedTexImagePBO" comment="PBO protocol"/>
@@ -13315,7 +13316,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetCompressedTexImageARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param kind="CompressedTextureARB" len="COMPSIZE(target,level)">void *<name>img</name></param>
             <alias name="glGetCompressedTexImage"/>
             <glx type="single" opcode="160"/>
@@ -13323,7 +13324,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetCompressedTextureImage</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>pixels</name></param>
         </command>
@@ -13331,13 +13332,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetCompressedTextureImageEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>lod</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>lod</name></param>
             <param len="COMPSIZE(target,lod)">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetCompressedTextureSubImage</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -14148,7 +14149,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexImageEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -14157,7 +14158,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexLevelParameterfvEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
@@ -14165,7 +14166,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetMultiTexLevelParameterivEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -15366,7 +15367,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexImage</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -15376,7 +15377,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="138"/>
@@ -15384,7 +15385,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="139"/>
@@ -15392,7 +15393,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTexLevelParameterxvOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
@@ -15496,7 +15497,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureImageEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,level,format,type)">void *<name>pixels</name></param>
@@ -15512,7 +15513,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameterfvEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
@@ -15527,7 +15528,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameterivEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -17112,14 +17113,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glLighti</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="88"/>
         </command>
         <command>
             <proto>void <name>glLightiv</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="89"/>
         </command>
         <command>
@@ -17148,7 +17149,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLineStipple</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
+            <param kind="Clamped[0; 65536]"><ptype>GLint</ptype> <name>factor</name></param>
             <param><ptype>GLushort</ptype> <name>pattern</name></param>
             <glx type="render" opcode="94"/>
         </command>
@@ -17350,7 +17351,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="143"/>
         </command>
@@ -17360,17 +17361,17 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(target,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="144"/>
         </command>
         <command>
             <proto>void <name>glMap1xOES</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLfixed</ptype> <name>u1</name></param>
-            <param><ptype>GLfixed</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param><ptype>GLfixed</ptype> <name>points</name></param>
         </command>
         <command>
@@ -17379,11 +17380,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
             <glx type="render" opcode="145"/>
         </command>
@@ -17393,25 +17394,25 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(target,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="146"/>
         </command>
         <command>
             <proto>void <name>glMap2xOES</name></proto>
             <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLfixed</ptype> <name>u1</name></param>
-            <param><ptype>GLfixed</ptype> <name>u2</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param><ptype>GLint</ptype> <name>uorder</name></param>
-            <param><ptype>GLfixed</ptype> <name>v1</name></param>
-            <param><ptype>GLfixed</ptype> <name>v2</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>v1</name></param>
+            <param kind="Coord"><ptype>GLfixed</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param><ptype>GLfixed</ptype> <name>points</name></param>
         </command>
         <command>
@@ -17454,8 +17455,8 @@ typedef unsigned int GLhandleARB;
             <param group="MapTypeNV"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>ustride</name></param>
             <param><ptype>GLsizei</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param><ptype>GLboolean</ptype> <name>packed</name></param>
             <param len="COMPSIZE(target,uorder,vorder)">const void *<name>points</name></param>
         </command>
@@ -17562,7 +17563,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17572,7 +17573,7 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>order</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>order</name></param>
             <param kind="Coord" len="COMPSIZE(size,stride,order)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17582,11 +17583,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLdouble</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLdouble</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -17596,11 +17597,11 @@ typedef unsigned int GLhandleARB;
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>uorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>uorder</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v1</name></param>
             <param kind="Coord"><ptype>GLfloat</ptype> <name>v2</name></param>
             <param><ptype>GLint</ptype> <name>vstride</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>vorder</name></param>
+            <param kind="Range[1; x]"><ptype>GLint</ptype> <name>vorder</name></param>
             <param kind="Coord" len="COMPSIZE(size,ustride,uorder,vstride,vorder)">const <ptype>GLfloat</ptype> *<name>points</name></param>
         </command>
         <command>
@@ -18917,10 +18918,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -18929,11 +18930,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -18942,12 +18943,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -18957,7 +18958,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexParameterIuivEXT</name></proto>
@@ -19006,8 +19007,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -19017,9 +19018,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -19030,10 +19031,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -19316,7 +19317,7 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferSamplePositionsfvAMD</name></proto>
@@ -19331,7 +19332,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTexture2DEXT</name></proto>
@@ -19339,7 +19340,7 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTexture3DEXT</name></proto>
@@ -19347,22 +19348,22 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTextureEXT</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTextureFaceEXT</name></proto>
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>face</name></param>
         </command>
         <command>
@@ -19378,8 +19379,8 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferTextureMultiviewOVR</name></proto>
@@ -20076,7 +20077,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapfv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLfloat</ptype> *<name>values</name></param>
             <glx type="render" opcode="168"/>
             <glx type="render" opcode="323" name="glPixelMapfvPBO" comment="PBO protocol"/>
@@ -20084,7 +20085,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapuiv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLuint</ptype> *<name>values</name></param>
             <glx type="render" opcode="169"/>
             <glx type="render" opcode="324" name="glPixelMapuivPBO" comment="PBO protocol"/>
@@ -20092,7 +20093,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelMapusv</name></proto>
             <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
-            <param kind="CheckedInt32"><ptype>GLsizei</ptype> <name>mapsize</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>mapsize</name></param>
             <param len="mapsize">const <ptype>GLushort</ptype> *<name>values</name></param>
             <glx type="render" opcode="170"/>
             <glx type="render" opcode="325" name="glPixelMapusvPBO" comment="PBO protocol"/>
@@ -24421,7 +24422,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGeni</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="119"/>
         </command>
         <command>
@@ -24434,7 +24435,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGeniv</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="120"/>
         </command>
         <command>
@@ -24680,14 +24681,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexParameteri</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="107"/>
         </command>
         <command>
             <proto>void <name>glTexParameteriv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="108"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -12316,7 +12316,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFrameZoomSGIX</name></proto>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>factor</name></param>
+            <param><ptype>GLint</ptype> <name>factor</name></param>
             <glx type="render" opcode="2072"/>
         </command>
         <command>
@@ -12349,11 +12349,11 @@ typedef unsigned int GLhandleARB;
             <param class="framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLuint</ptype> <name>layer</name></param>
             <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param><ptype>GLfloat</ptype> <name>foveaArea</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferParameteri</name></proto>
@@ -13923,13 +13923,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetListParameterfvSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetListParameterivSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLocalConstantBooleanvEXT</name></proto>
@@ -14646,12 +14646,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetPixelTexGenParameterfvSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetPixelTexGenParameterivSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetPixelTransformParameterfvEXT</name></proto>
@@ -17094,14 +17094,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glLightf</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="86"/>
         </command>
         <command>
             <proto>void <name>glLightfv</name></proto>
             <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="87"/>
         </command>
         <command>
@@ -17150,7 +17150,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLineWidth</name></proto>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>width</name></param>
+            <param><ptype>GLfloat</ptype> <name>width</name></param>
             <glx type="render" opcode="95"/>
         </command>
         <command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -70,8 +70,11 @@ typedef unsigned int GLhandleARB;
         <kind name="Color" desc="This parameter represents part of or a complete color."/>
         <kind name="Coord" desc="This parameter represents a coordinate."/>
         <kind name="WinCoord" desc="This parameter represents a window coordinate."/>
+        <kind name="NDCCoord" desc="This parameter represents a normalized device coordinates (NDC)."/>
         <kind name="Clamped[0; 1]" desc="This parameter will get clamped to the 0 to 1 range."/>
         <kind name="Clamped[-1; 1]" desc="This parameter will get clamped to the -1 to 1 range."/>
+        <kind name="Range[0; x]" desc="This parameter must be greater or equal to 0. An upper bound may exist but it might vary."/>
+        <kind name="Range[1; x]" desc="This parameter must be greater or equal to 1. An upper bound may exist but it might vary."/>
         <kind name="StencilValue" desc="This parameter represents an unmasked stencil value."/>
         <kind name="StencilMask" desc="This parameter represents mask to apply to stencil values."/>
         <kind name="CompressedTextureARB" desc="This parameter contains compressed texture data."/>
@@ -79,6 +82,7 @@ typedef unsigned int GLhandleARB;
         <kind name="BufferSize" desc="This parameter represents the size of a buffer."/>
         <kind name="String" desc="This parameter represents a string of characters. A GLubyte parameter should be treated as GLchar."/>
         <kind name="DrawBufferIndex" desc="This parameter represents an index to a draw buffer in the range 0 to the value of GL_MAX_COLOR_ATTACHMENTS"/>
+        <kind name="Zero" desc="This parameter must be zero."/>
 
         <kind name="Matrix2x2" desc="This parameter represents a 2x2 matrix."/>
         <kind name="Matrix2x3" desc="This parameter represents a 2x3 matrix."/>
@@ -9293,10 +9297,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9304,11 +9308,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9316,12 +9320,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9329,8 +9333,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9340,9 +9344,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9353,10 +9357,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9367,10 +9371,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="214"/>
@@ -9379,10 +9383,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage1D"/>
@@ -9391,11 +9395,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="215"/>
@@ -9404,11 +9408,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage2D"/>
@@ -9417,12 +9421,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <glx type="render" opcode="216"/>
@@ -9431,12 +9435,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param kind="CompressedTextureARB" len="imageSize">const void *<name>data</name></param>
             <alias name="glCompressedTexImage3D"/>
@@ -9445,20 +9449,20 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9469,8 +9473,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9481,9 +9485,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9495,9 +9499,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9509,10 +9513,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9525,10 +9529,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9541,7 +9545,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTexSubImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -9556,10 +9560,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9567,11 +9571,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
@@ -9579,19 +9583,19 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>bits</name></param>
         </command>
         <command>
             <proto>void <name>glCompressedTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9602,8 +9606,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -9612,7 +9616,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9625,9 +9629,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -9637,7 +9641,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCompressedTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -9652,10 +9656,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -9768,14 +9772,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameteriv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="4106"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterivEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glConvolutionParameteriv"/>
             <glx type="render" opcode="4106"/>
         </command>
@@ -9965,31 +9969,31 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyMultiTexImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyMultiTexSubImage1DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -9998,9 +10002,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexSubImage2DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10010,10 +10014,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyMultiTexSubImage3DEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10044,56 +10048,56 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <glx type="render" opcode="4119"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <alias name="glCopyTexImage1D"/>
             <glx type="render" opcode="4119"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <glx type="render" opcode="4120"/>
         </command>
         <command>
             <proto>void <name>glCopyTexImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
             <alias name="glCopyTexImage2D"/>
             <glx type="render" opcode="4120"/>
         </command>
         <command>
             <proto>void <name>glCopyTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10102,8 +10106,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10113,9 +10117,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10125,9 +10129,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10138,10 +10142,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10151,10 +10155,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTexSubImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10164,8 +10168,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCopyTexSubImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -10178,47 +10182,47 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param><ptype>GLint</ptype> <name>border</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureLevelsAPPLE</name></proto>
-            <param><ptype>GLuint</ptype> <name>destinationTexture</name></param>
-            <param><ptype>GLuint</ptype> <name>sourceTexture</name></param>
-            <param><ptype>GLint</ptype> <name>sourceBaseLevel</name></param>
-            <param><ptype>GLsizei</ptype> <name>sourceLevelCount</name></param>
+            <param class="texture"><ptype>GLuint</ptype> <name>destinationTexture</name></param>
+            <param class="texture"><ptype>GLuint</ptype> <name>sourceTexture</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>sourceBaseLevel</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>sourceLevelCount</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glCopyTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10226,11 +10230,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -10238,9 +10242,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -10249,12 +10253,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
-            <param><ptype>GLint</ptype> <name>x</name></param>
-            <param><ptype>GLint</ptype> <name>y</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -10262,10 +10266,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param kind="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -12487,8 +12491,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleIMG</name></proto>
@@ -12496,8 +12500,8 @@ typedef unsigned int GLhandleARB;
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DOES</name></proto>
@@ -24454,10 +24458,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -24467,11 +24471,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -24481,7 +24485,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage2DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24500,12 +24504,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -24515,12 +24519,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -24530,7 +24534,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24551,7 +24555,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24564,13 +24568,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLsizei</ptype> <name>size4d</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth,size4d)">const void *<name>pixels</name></param>
@@ -24578,8 +24582,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexPageCommitmentARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24590,8 +24594,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexPageCommitmentEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24604,7 +24608,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexPageCommitmentMemNV</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>layer</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>layer</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
@@ -24718,14 +24722,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <alias name="glTexStorage1D"/>
@@ -24733,7 +24737,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24741,7 +24745,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24750,7 +24754,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage2DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24759,7 +24763,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24768,7 +24772,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24778,7 +24782,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DMultisample</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24788,7 +24792,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorage3DMultisampleOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24799,7 +24803,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageAttribs2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24808,7 +24812,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageAttribs3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24818,7 +24822,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
@@ -24827,7 +24831,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24837,7 +24841,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem2DMultisampleEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24848,7 +24852,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24859,7 +24863,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexStorageMem3DMultisampleEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -24875,14 +24879,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLsizei</ptype> <name>layers</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>layers</name></param>
             <param group="TextureStorageMaskAMD"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glTexSubImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -24893,8 +24897,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -24905,9 +24909,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24919,9 +24923,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24933,10 +24937,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -24949,10 +24953,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -24965,7 +24969,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage3DOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -24979,11 +24983,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTexSubImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>woffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param><ptype>GLint</ptype> <name>woffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25059,10 +25063,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width)">const void *<name>pixels</name></param>
@@ -25071,11 +25075,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height)">const void *<name>pixels</name></param>
@@ -25105,12 +25109,12 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
+            <param kind="Zero"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
@@ -25189,7 +25193,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameterIuiv</name></proto>
@@ -25242,7 +25246,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glTextureParameterivEXT"/>
         </command>
         <command>
@@ -25256,7 +25260,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureRangeAPPLE</name></proto>
@@ -25273,22 +25277,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25297,7 +25301,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25305,7 +25309,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage2DMultisample</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25315,7 +25319,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25324,7 +25328,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25334,7 +25338,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25343,7 +25347,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorage3DMultisample</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25354,7 +25358,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25364,7 +25368,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLuint</ptype> <name>memory</name></param>
@@ -25373,7 +25377,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25383,7 +25387,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem2DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25394,7 +25398,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>levels</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25405,7 +25409,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageMem3DMultisampleEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param kind="Range[1; x]"><ptype>GLsizei</ptype> <name>samples</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25417,7 +25421,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureStorageSparseAMD</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="SizedInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
@@ -25428,7 +25432,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage1D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25439,8 +25443,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage1DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -25449,7 +25453,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage2D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -25462,9 +25466,9 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage2DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25474,7 +25478,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureSubImage3D</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLint</ptype> <name>level</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -25489,10 +25493,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureSubImage3DEXT</name></proto>
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>xoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>yoffset</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>zoffset</name></param>
+            <param kind="Range[0; x]"><ptype>GLint</ptype> <name>level</name></param>
+            <param><ptype>GLint</ptype> <name>xoffset</name></param>
+            <param><ptype>GLint</ptype> <name>yoffset</name></param>
+            <param><ptype>GLint</ptype> <name>zoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9243,7 +9243,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCombinerParameterfvNV</name></proto>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="4137"/>
         </command>
         <command>
@@ -9262,7 +9262,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCombinerStageParameterfvNV</name></proto>
             <param group="CombinerStageNV"><ptype>GLenum</ptype> <name>stage</name></param>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glCommandListSegmentsNV</name></proto>
@@ -9723,14 +9723,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameterf</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>params</name></param>
+            <param><ptype>GLfloat</ptype> <name>params</name></param>
             <glx type="render" opcode="4103"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterfEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>params</name></param>
+            <param><ptype>GLfloat</ptype> <name>params</name></param>
             <alias name="glConvolutionParameterf"/>
             <glx type="render" opcode="4103"/>
         </command>
@@ -9738,14 +9738,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameterfv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="4104"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterfvEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glConvolutionParameterfv"/>
             <glx type="render" opcode="4104"/>
         </command>
@@ -9753,14 +9753,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glConvolutionParameteri</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>params</name></param>
+            <param><ptype>GLint</ptype> <name>params</name></param>
             <glx type="render" opcode="4105"/>
         </command>
         <command>
             <proto>void <name>glConvolutionParameteriEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>params</name></param>
+            <param><ptype>GLint</ptype> <name>params</name></param>
             <alias name="glConvolutionParameteri"/>
             <glx type="render" opcode="4105"/>
         </command>
@@ -12193,25 +12193,25 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glFogf</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="80"/>
         </command>
         <command>
             <proto>void <name>glFogfv</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="81"/>
         </command>
         <command>
             <proto>void <name>glFogi</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="82"/>
         </command>
         <command>
             <proto>void <name>glFogiv</name></proto>
             <param group="FogParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="83"/>
         </command>
         <command>
@@ -12246,70 +12246,70 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glFragmentLightModelfSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModelfvSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModeliSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightModelivSGIX</name></proto>
             <param group="FragmentLightModelParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightfSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightfvSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightiSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentLightivSGIX</name></proto>
             <param group="FragmentLightNameSGIX"><ptype>GLenum</ptype> <name>light</name></param>
             <param group="FragmentLightParameterSGIX"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialfSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialfvSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialiSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFragmentMaterialivSGIX</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glFrameTerminatorGREMEDY</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9255,7 +9255,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCombinerParameterivNV</name></proto>
             <param group="CombinerParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="4139"/>
         </command>
         <command>
@@ -17535,13 +17535,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMapParameterfvNV</name></proto>
             <param group="EvalTargetNV"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="MapParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(target,pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(target,pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMapParameterivNV</name></proto>
             <param group="EvalTargetNV"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="MapParameterNV"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(target,pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(target,pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void *<name>glMapTexture2DINTEL</name></proto>
@@ -17603,28 +17603,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMaterialf</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="96"/>
         </command>
         <command>
             <proto>void <name>glMaterialfv</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="97"/>
         </command>
         <command>
             <proto>void <name>glMateriali</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="98"/>
         </command>
         <command>
             <proto>void <name>glMaterialiv</name></proto>
             <param group="TriangleFace"><ptype>GLenum</ptype> <name>face</name></param>
             <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="99"/>
         </command>
         <command>
@@ -18839,7 +18839,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexEnvfvEXT"/>
         </command>
         <command>
@@ -18847,14 +18847,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexEnviEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexEnvivEXT"/>
         </command>
         <command>
@@ -18862,7 +18862,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexGendEXT</name></proto>
@@ -18884,7 +18884,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexGenfvEXT"/>
         </command>
         <command>
@@ -18892,14 +18892,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexGeniEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexGenivEXT"/>
         </command>
         <command>
@@ -18907,7 +18907,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexImage1DEXT</name></proto>
@@ -18967,7 +18967,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexParameterfvEXT"/>
         </command>
         <command>
@@ -18975,14 +18975,14 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexParameteriEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <vecequiv name="glMultiTexParameterivEXT"/>
         </command>
         <command>
@@ -18990,7 +18990,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexRenderbufferEXT</name></proto>
@@ -20102,13 +20102,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelStoref</name></proto>
             <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="single" opcode="109"/>
         </command>
         <command>
             <proto>void <name>glPixelStorei</name></proto>
             <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="single" opcode="110"/>
         </command>
         <command>
@@ -20119,22 +20119,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelTexGenParameterfSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameterfvSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameteriSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenParameterivSGIS</name></proto>
             <param group="PixelTexGenParameterNameSGIS"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPixelTexGenSGIX</name></proto>
@@ -20144,13 +20144,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPixelTransferf</name></proto>
             <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="166"/>
         </command>
         <command>
             <proto>void <name>glPixelTransferi</name></proto>
             <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="167"/>
         </command>
         <command>
@@ -20209,51 +20209,51 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPointParameterf</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2065"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfARB</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
             <glx type="render" opcode="2065"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfEXT</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfSGIS</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <alias name="glPointParameterf"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfv</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2066"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvARB</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
             <glx type="render" opcode="2066"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvEXT</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
         </command>
         <command>
             <proto>void <name>glPointParameterfvSGIS</name></proto>
             <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glPointParameterfv"/>
         </command>
         <command>
@@ -20304,7 +20304,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPointSize</name></proto>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>size</name></param>
+            <param><ptype>GLfloat</ptype> <name>size</name></param>
             <glx type="render" opcode="100"/>
         </command>
         <command>
@@ -24297,28 +24297,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexEnvf</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="111"/>
         </command>
         <command>
             <proto>void <name>glTexEnvfv</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="112"/>
         </command>
         <command>
             <proto>void <name>glTexEnvi</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="113"/>
         </command>
         <command>
             <proto>void <name>glTexEnviv</name></proto>
             <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="114"/>
         </command>
         <command>
@@ -24391,7 +24391,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGenf</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="117"/>
         </command>
         <command>
@@ -24404,7 +24404,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexGenfv</name></proto>
             <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
             <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="118"/>
         </command>
         <command>
@@ -24662,14 +24662,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexParameterf</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="105"/>
         </command>
         <command>
             <proto>void <name>glTexParameterfv</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="106"/>
         </command>
         <command>
@@ -25049,11 +25049,11 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLuint</ptype> <name>layer</name></param>
             <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param kind="NDCCoord"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param><ptype>GLfloat</ptype> <name>foveaArea</name></param>
         </command>
         <command>
             <proto>void <name>glTextureImage1DEXT</name></proto>
@@ -25215,7 +25215,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param><ptype>GLfloat</ptype> <name>param</name></param>
             <vecequiv name="glTextureParameterfvEXT"/>
         </command>
         <command>
@@ -25229,7 +25229,7 @@ typedef unsigned int GLhandleARB;
             <param class="texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTextureParameteri</name></proto>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -9173,14 +9173,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glColorTableParameterfv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2054"/>
         </command>
         <command>
             <proto>void <name>glColorTableParameterfvSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glColorTableParameterfv"/>
             <glx type="render" opcode="2054"/>
         </command>
@@ -9188,14 +9188,14 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glColorTableParameteriv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2055"/>
         </command>
         <command>
             <proto>void <name>glColorTableParameterivSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param kind="Color" len="4">const <ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glColorTableParameteriv"/>
             <glx type="render" opcode="2055"/>
         </command>

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -17189,28 +17189,28 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glListParameterfSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32"><ptype>GLfloat</ptype> <name>param</name></param>
+            <param kind="Clamped[0; 1]"><ptype>GLfloat</ptype> <name>param</name></param>
             <glx type="render" opcode="2078"/>
         </command>
         <command>
             <proto>void <name>glListParameterfvSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
+            <param kind="Clamped[0; 1]" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2079"/>
         </command>
         <command>
             <proto>void <name>glListParameteriSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32"><ptype>GLint</ptype> <name>param</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
             <glx type="render" opcode="2080"/>
         </command>
         <command>
             <proto>void <name>glListParameterivSGIX</name></proto>
             <param class="display list"><ptype>GLuint</ptype> <name>list</name></param>
             <param group="ListParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
-            <param kind="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+            <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2081"/>
         </command>
         <command>

--- a/xml/readme.tex
+++ b/xml/readme.tex
@@ -301,13 +301,12 @@ None.
 \label{tag:kind:meaning}
 
 If a \tag{proto} or \tag{param} tag of a \tag{command} has a
-\attr{kind} attribute defined, and and the comma separated elemenst
-if the attribute matches a \tag{kind} name, 
-then the return type or parameter type is considered to be
-further defined by the description provided by the \tag{kind} tags
-with the matching names. C language bindings do not attempt to
-enforce this constraint in any way, but other language bindings 
-may try to do so.
+\attr{kind} attribute defined, and if the comma separated elements
+matches a \tag{kind} name, then the return type or parameter type
+is considered to be further defined by the description provided by
+the \tag{kind} tags with the matching names. C language bindings do
+not attempt to enforce this constraint in any way, but other 
+language bindings may try to do so.
 
 \section{Enumerant Groups (\tag{groups} tag)}
 \label{tag:groups}


### PR DESCRIPTION
This PR fixes the last stuff that was left in in #534. Basically this PR replaces and removes the last `CheckedFloat` and `CheckedInt32` kinds (as well a few others kinds that where leftovers and never described formally).

I thought I had fixed these things but it turned out that I had some +1 year old commits in this branch that I never opened a PR for.

cc @SunSerega 

This is a fixed version of #621 with cleaner git history.