### PR TITLE
Add len attribute to glGetObjectLabelKHR

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -14398,7 +14398,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLsizei</ptype> *<name>length</name></param>
+            <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>label</name></param>
             <alias name="glGetObjectLabel"/>
         </command>


### PR DESCRIPTION
This was an old commit I had on one of my branches. It adds a `len="1"` attribute to glGetObjectLabelKHRs length parameter which is a return parameter of length 1.