### PR TITLE
Add version define to gl2ext.h

### DIFF
--- a/xml/genglvnd.py
+++ b/xml/genglvnd.py
@@ -213,7 +213,7 @@ genDateCommentString = [
     ''
 ]
 
-# GL_GLEXT_VERSION is defined only in glext.h
+# GL_GLEXT_VERSION is defined only in glext.h and gl2ext.h
 glextVersionStrings = [
     format("#define GL_GLEXT_VERSION %s" % time.strftime("%Y%m%d")),
     ''
@@ -364,7 +364,7 @@ buildList = [
         defaultExtensions = 'gles2',                # Default extensions for GLES 2
         addExtensions     = None,
         removeExtensions  = None,
-        prefixText        = prefixStrings + apiEntryPrefixStrings + genDateCommentString,
+        prefixText        = prefixStrings + apiEntryPrefixStrings + glextVersionStrings,
         genFuncPointers   = True,
         protectFile       = protectFile,
         protectFeature    = protectFeature,

--- a/xml/genheaders.py
+++ b/xml/genheaders.py
@@ -158,7 +158,7 @@ genDateCommentString = [
     ''
 ]
 
-# GL_GLEXT_VERSION is defined only in glext.h
+# GL_GLEXT_VERSION is defined only in glext.h and gl2ext.h
 glextVersionStrings = [
     format('#define GL_GLEXT_VERSION %s' % time.strftime('%Y%m%d')),
     ''
@@ -296,7 +296,7 @@ buildList = [
         defaultExtensions = 'gles2',                # Default extensions for GLES 2
         addExtensions     = None,
         removeExtensions  = None,
-        prefixText        = prefixStrings + apiEntryPrefixStrings + genDateCommentString,
+        prefixText        = prefixStrings + apiEntryPrefixStrings + glextVersionStrings,
         genFuncPointers   = True,
         protectFile       = protectFile,
         protectFeature    = protectFeature,


### PR DESCRIPTION
Closes: https://github.com/KhronosGroup/OpenGL-Registry/issues/617

* * *

- Should we use a different symbol name, in case users include both `glext.h` and `gl2ext.h` from different releases?
- Should I re-generate the headers, or should I leave that to the person in charge of the next release?