### PR TITLE
Expose NV_texture_barrier on GLES2

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -45098,7 +45098,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_REFLECTION_MAP_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_texture_barrier" supported="gl|glcore">
+        <extension name="GL_NV_texture_barrier" supported="gl|glcore|gles2">
             <require>
                 <command name="glTextureBarrierNV"/>
             </require>


### PR DESCRIPTION
NV_texture_barrier is OpenGL ES Extension #271. Let the XML know about that, so it gets added to the appropriate extension headers.