### PR TITLE
Add GL_MESA_texture_const_bandwidth

### DIFF
--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -32,7 +32,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20250129
+#define GL_GLEXT_VERSION 20250203
 
 #include <KHR/khrplatform.h>
 
@@ -9403,6 +9403,11 @@ GLAPI void APIENTRY glResizeBuffersMESA (void);
 #ifndef GL_MESA_shader_integer_functions
 #define GL_MESA_shader_integer_functions 1
 #endif /* GL_MESA_shader_integer_functions */
+
+#ifndef GL_MESA_texture_const_bandwidth
+#define GL_MESA_texture_const_bandwidth 1
+#define GL_CONST_BW_TILING_MESA           0x8BBE
+#endif /* GL_MESA_texture_const_bandwidth */
 
 #ifndef GL_MESA_tile_raster_order
 #define GL_MESA_tile_raster_order 1

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -15,7 +15,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20240815
+#define GLX_GLXEXT_VERSION 20250203
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20240815 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20240815
+#define WGL_WGLEXT_VERSION 20250203
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-#define GL_GLEXT_VERSION 20250129
+#define GL_GLEXT_VERSION 20250203
 
 /* Generated C header for:
  * API: gles2
@@ -2608,6 +2608,11 @@ GL_APICALL void GL_APIENTRY glGetSamplerParameterfv (GLuint sampler, GLenum pnam
 #ifndef GL_MESA_shader_integer_functions
 #define GL_MESA_shader_integer_functions 1
 #endif /* GL_MESA_shader_integer_functions */
+
+#ifndef GL_MESA_texture_const_bandwidth
+#define GL_MESA_texture_const_bandwidth 1
+#define GL_CONST_BW_TILING_MESA           0x8BBE
+#endif /* GL_MESA_texture_const_bandwidth */
 
 #ifndef GL_NVX_blend_equation_advanced_multi_draw_buffers
 #define GL_NVX_blend_equation_advanced_multi_draw_buffers 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLSC2/glsc2.h
+++ b/api/GLSC2/glsc2.h
@@ -21,7 +21,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: glsc2

--- a/api/GLSC2/glsc2ext.h
+++ b/api/GLSC2/glsc2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250129 */
+/* Generated on date 20250203 */
 
 /* Generated C header for:
  * API: glsc2

--- a/extensions/MESA/MESA_texture_const_bandwidth.txt
+++ b/extensions/MESA/MESA_texture_const_bandwidth.txt
@@ -1,0 +1,84 @@
+Name
+
+    MESA_texture_const_bandwidth
+
+Name Strings
+
+    GL_MESA_texture_const_bandwidth
+
+Contact
+
+    Rob Clark <robdclark@chromium.org>
+
+Contributors
+
+    Rob Clark, Google
+    Lina Versace, Google
+    Tapani Pälli, Intel
+
+Status
+
+    Proposal
+
+Version
+
+    Version 1, September, 2023
+
+Number
+
+    OpenGL Extension 560
+    OpenGL ES Extension 347
+
+Dependencies
+
+    Requires EXT_memory_object.
+
+Overview
+
+    The use of data dependent bandwidth compressed formats (UBWC, AFBC, etc)
+    can introduce a form of side-channel, in that the bandwidth used for
+    texture access is dependent on the texture's contents.  In some cases
+    an application may want to disable the use of data dependent formats on
+    specific textures.
+
+    For that purpose, this extension extends EXT_memory_object to introduce
+    a new <param> CONST_BW_TILING_MESA.
+
+IP Status
+
+    None
+
+Issues
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Types
+
+    None
+
+New Tokens
+
+    Returned in the <params> parameter of GetInternalFormativ or
+    GetInternalFormati64v when the <pname> parameter is TILING_TYPES_EXT,
+    returned in the <params> parameter of GetTexParameter{if}v,
+    GetTexParameterI{i ui}v, GetTextureParameter{if}v, and
+    GetTextureParameterI{i ui}v when the <pname> parameter is
+    TEXTURE_TILING_EXT, and accepted by the <params> parameter of
+    TexParameter{ifx}{v}, TexParameterI{i ui}v, TextureParameter{if}{v},
+    TextureParameterI{i ui}v when the <pname> parameter is
+    TEXTURE_TILING_EXT:
+
+        CONST_BW_TILING_MESA                       0x8BBE
+
+Errors
+
+    None
+
+Revision History
+
+    Version 1, 2023-9-28 (Rob Clark)
+        Initial draft.

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -723,4 +723,6 @@
 </li>
 <li value=346><a href="extensions/QCOM/QCOM_ycbcr_degamma.txt">GL_QCOM_ycbcr_degamma</a>
 </li>
+<li value=347><a href="extensions/MESA/MESA_texture_const_bandwidth.txt">GL_MESA_texture_const_bandwidth</a>
+</li>
 </ol>

--- a/extensions/glext.php
+++ b/extensions/glext.php
@@ -1057,4 +1057,6 @@
 </li>
 <li value=559><a href="extensions/NV/NV_uniform_buffer_std430_layout.txt">GL_NV_uniform_buffer_std430_layout</a>
 </li>
+<li value=560><a href="extensions/MESA/MESA_texture_const_bandwidth.txt">GL_MESA_texture_const_bandwidth</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -3143,6 +3143,13 @@ registry = {
         'supporters' : { 'MESA' },
         'url' : 'extensions/MESA/GLX_MESA_swap_control.txt',
     },
+    'GL_MESA_texture_const_bandwidth' : {
+        'number' : 560,
+        'esnumber' : 347,
+        'flags' : { 'public' },
+        'supporters' : { 'MESA' },
+        'url' : 'extensions/MESA/MESA_texture_const_bandwidth.txt',
+    },
     'GL_MESA_tile_raster_order' : {
         'number' : 515,
         'esnumber' : 292,

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -4575,6 +4575,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8BBB" name="GL_FRAMEBUFFER_FLIP_Y_MESA"/>
         <enum value="0x8BBC" name="GL_FRAMEBUFFER_FLIP_X_MESA" />
         <enum value="0x8BBD" name="GL_FRAMEBUFFER_SWAP_XY_MESA" />
+        <enum value="0x8BBE" name="GL_CONST_BW_TILING_MESA"/>
     </enums>
 
     <enums namespace="GL" start="0x8BC0" end="0x8BFF" vendor="QCOM" comment="Reassigned from AMD to QCOM">
@@ -43486,6 +43487,11 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_MESA_shader_integer_functions" supported="gl|gles2"/>
+	<extension name="GL_MESA_texture_const_bandwidth" supported="gl|gles2">
+            <require>
+                <enum name="GL_CONST_BW_TILING_MESA"/>
+	    </require>
+        </extension>
         <extension name="GL_MESA_tile_raster_order" supported="gl">
             <require>
                 <enum name="GL_TILE_RASTER_ORDER_FIXED_MESA"/>


### PR DESCRIPTION
GL_MESA_texture_const_bandwidth adds a way for an app to request the use of a format which does have data dependent bandwidth characteristics, in order to avoid a potential side-channel.