### PR TITLE
Reserve enums for QCOM - GL_QCOM_graph_pipeline extension

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7032,6 +7032,10 @@ typedef unsigned int GLhandleARB;
             <unused start="0x9740" end="0x975F" vendor="MESA"/>
     </enums>
 
+    <enums namespace="GL" start="0x9760" end="0x976F" vendor="QCOM" comment="Reserved for Ashish Mathur">
+            <unused start="0x9760" end="0x976F" vendor="QCOM"/>
+    </enums>
+
 <!-- Enums reservable for future use. To reserve a new range, allocate one
      or more multiples of 16 starting at the lowest available point in this
      block and note it in a new <enums> block immediately above.
@@ -7041,7 +7045,7 @@ typedef unsigned int GLhandleARB;
      file) File requests in the Khronos Bugzilla, OpenGL project, Registry
      component. -->
 
-    <enums namespace="GL" start="0x9760" end="99999" vendor="ARB" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
+    <enums namespace="GL" start="0x9770" end="99999" vendor="ARB" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
         <unused start="0x9760" end="99999" comment="RESERVED"/>
     </enums>
 


### PR DESCRIPTION
Reserve enums for QCOM GL_QCOM_graph_pipeline extension