### PR TITLE
Add missing registry.py contents for GL_EXT_shader_clock

### DIFF
--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2248,6 +2248,11 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/EXT/EXT_separate_specular_color.txt',
     },
+    'GL_EXT_shader_clock' : {
+        'esnumber' : 348,
+        'flags' : { 'public' },
+        'url' : 'extensions/EXT/EXT_shader_clock.txt',
+    },
     'GL_EXT_shader_framebuffer_fetch' : {
         'number' : 520,
         'esnumber' : 122,


### PR DESCRIPTION
Make sure OpenGL ES extension GL_EXT_shader_clock is registered properly so esnumber calculation is correct.