### PR TITLE
Add vendor extensions HUAWEI_shader_binary and HUAWEI_program_binary

### DIFF
--- a/api/GL/glcorearb.h
+++ b/api/GL/glcorearb.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML

--- a/api/GL/glext.h
+++ b/api/GL/glext.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -32,7 +32,7 @@ extern "C" {
 #define GLAPI extern
 #endif
 
-#define GL_GLEXT_VERSION 20250203
+#define GL_GLEXT_VERSION 20250824
 
 #include <KHR/khrplatform.h>
 

--- a/api/GL/glxext.h
+++ b/api/GL/glxext.h
@@ -15,7 +15,7 @@ extern "C" {
 **   https://github.com/KhronosGroup/OpenGL-Registry
 */
 
-#define GLX_GLXEXT_VERSION 20250203
+#define GLX_GLXEXT_VERSION 20250823
 
 /* Generated C header for:
  * API: glx

--- a/api/GL/wgl.h
+++ b/api/GL/wgl.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250823 */
 
 /* Generated C header for:
  * API: wgl

--- a/api/GL/wglext.h
+++ b/api/GL/wglext.h
@@ -20,7 +20,7 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#define WGL_WGLEXT_VERSION 20250203
+#define WGL_WGLEXT_VERSION 20250823
 
 /* Generated C header for:
  * API: wgl

--- a/api/GLES/gl.h
+++ b/api/GLES/gl.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <GLES/glplatform.h>
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES/glext.h
+++ b/api/GLES/glext.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: gles1

--- a/api/GLES2/gl2.h
+++ b/api/GLES2/gl2.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLES2/gl2ext.h
+++ b/api/GLES2/gl2ext.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-#define GL_GLEXT_VERSION 20250203
+#define GL_GLEXT_VERSION 20250824
 
 /* Generated C header for:
  * API: gles2
@@ -2399,6 +2399,16 @@ GL_APICALL void GL_APIENTRY glWindowRectanglesEXT (GLenum mode, GLsizei count, c
 #define GL_FJ_shader_binary_GCCSO 1
 #define GL_GCCSO_SHADER_BINARY_FJ         0x9260
 #endif /* GL_FJ_shader_binary_GCCSO */
+
+#ifndef GL_HUAWEI_program_binary
+#define GL_HUAWEI_program_binary 1
+#define GL_HUAWEI_PROGRAM_BINARY          0x9771
+#endif /* GL_HUAWEI_program_binary */
+
+#ifndef GL_HUAWEI_shader_binary
+#define GL_HUAWEI_shader_binary 1
+#define GL_HUAWEI_SHADER_BINARY           0x9770
+#endif /* GL_HUAWEI_shader_binary */
 
 #ifndef GL_IMG_bindless_texture
 #define GL_IMG_bindless_texture 1

--- a/api/GLES3/gl3.h
+++ b/api/GLES3/gl3.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -25,7 +25,7 @@ extern "C" {
 #define GL_GLES_PROTOTYPES 1
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: gles2

--- a/api/GLSC2/glsc2.h
+++ b/api/GLSC2/glsc2.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -21,7 +21,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: glsc2

--- a/api/GLSC2/glsc2ext.h
+++ b/api/GLSC2/glsc2ext.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 /*
-** Copyright 2013-2020 The Khronos Group Inc.
+** Copyright 2013-2025 The Khronos Group Inc.
 ** SPDX-License-Identifier: MIT
 **
 ** This header is generated from the Khronos OpenGL / OpenGL ES XML
@@ -19,7 +19,7 @@ extern "C" {
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20250203 */
+/* Generated on date 20250824 */
 
 /* Generated C header for:
  * API: glsc2

--- a/extensions/HUAWEI/HUAWEI_program_binary.txt
+++ b/extensions/HUAWEI/HUAWEI_program_binary.txt
@@ -1,0 +1,86 @@
+Name
+
+    HUAWEI_program_binary
+
+Name Strings
+
+    GL_HUAWEI_program_binary
+
+Contributors
+
+    Peng Li, HUAWEI Technologies
+
+Contact
+
+    Pan Gao (gaopan24 'at' hisilicon 'dot' com)
+
+Version
+
+    Last Modified Date: Aug 21, 2025
+    Revision: 1
+
+Number
+
+    OpenGL ES Extension #349
+
+Dependencies
+
+    OpenGL ES 2.0 is required.
+    OES_get_program_binary is required.
+
+    This extension is written based on the wording of the OpenGL ES 2.0.25
+    specification and the OES_get_program_binary extension.
+
+Overview
+
+    The OES_get_program_binary extension enables applications to retrieve program
+    binaries using GetProgramBinaryOES and reload them using ProgramBinaryOES.
+
+    The mechanism for retrieval and reloading of program binaries is vendor
+    neutral, but the binary format itself is vendor specific.
+
+    This extension adds a token to identify program binaries that are
+    compatible with HUAWEI GPUs.
+
+Issues
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Accepted by the <binaryFormat> parameter of ProgramBinaryOES:
+
+        HUAWEI_PROGRAM_BINARY              0x9771
+
+Additions to Chapter 2 of the OpenGL ES 2.0 Specification (OpenGL ES Operation)
+
+    At the end of the section 2.15.4, Program Binaries from OES_get_program_binary:
+
+    "When querying PROGRAM_BINARY_FORMATS_OES, the format HUAWEI_PROGRAM_BINARY will be
+    present in the list of returned program binary formats and the format could be used as
+    <binaryFormat> in GetProgramBinaryOES or ProgramBinaryOES.
+
+    An implementation may reject a HUAWEI_PROGRAM_BINARY binary if it determines
+    the program binary was produced by an incompatible or outdated version of the compiler.
+    In this case the application should fall back to providing the original OpenGL Shading
+    Language source shaders, and perhaps again retrieve the program binary for future use."
+
+Errors
+
+    None
+
+New State
+
+    None
+
+New Implementation Dependent State
+
+    None
+
+Revision History
+
+    #1  Aug 21, 2025  Peng Li           First draft

--- a/extensions/HUAWEI/HUAWEI_shader_binary.txt
+++ b/extensions/HUAWEI/HUAWEI_shader_binary.txt
@@ -1,0 +1,78 @@
+Name
+
+    HUAWEI_shader_binary
+
+Name Strings
+
+    GL_HUAWEI_shader_binary
+
+Contributors
+
+    Peng Li, HUAWEI Technologies
+
+Contact
+
+    Pan Gao (gaopan24 'at' hisilicon 'dot' com)
+
+Version
+
+    Last Modified Date: Aug 21, 2025
+    Revision: 1
+
+Number
+
+    OpenGL ES Extension #350
+
+Dependencies
+
+    OpenGL ES 2.0 is required.
+
+    This extension is written based on the wording of the OpenGL ES 2.0.25 specification.
+
+Overview
+
+    This extension enables OpenGL ES 2.0 applications running on HUAWEI
+    GPU devices to use shader binaries precompiled with Maleoon shader compiler.
+
+    The shader objects loaded with this extension are functionally equivalent to
+    shaders created from source without further restrictions on OpenGL ES objects
+    or states they could be worked with.
+
+Issues
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Accepted by the <binaryFormat> parameter of ShaderBinary:
+
+        HUAWEI_SHADER_BINARY              0x9770
+
+Additions to Chapter 2 of the OpenGL ES 2.0 Specification (OpenGL ES Operation)
+
+    At the end of section 2.10.2 (Loading Shader Binaries), add:
+
+    "Using a <binaryFormat> of HUAWEI_SHADER_BINARY will result in implementation attempting
+    to load shader binaries in <binary> according to the format developed by HUAWEI."
+
+Errors
+
+    An INVALID_VALUE error is generated if the <binary> parameter points
+    to an invalid binary stream that is incompatible or outdated with implementation
+    on the given devices.
+
+New State
+
+    None
+
+New Implementation Dependent State
+
+    None
+
+Revision History
+
+    #1  Aug 21, 2025  Peng Li           First draft

--- a/extensions/esext.php
+++ b/extensions/esext.php
@@ -727,4 +727,8 @@
 </li>
 <li value=348><a href="extensions/EXT/EXT_shader_clock.txt">GL_EXT_shader_clock</a>
 </li>
+<li value=349><a href="extensions/HUAWEI/HUAWEI_program_binary.txt">GL_HUAWEI_program_binary</a>
+</li>
+<li value=350><a href="extensions/HUAWEI/HUAWEI_shader_binary.txt">GL_HUAWEI_shader_binary</a>
+</li>
 </ol>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -2794,6 +2794,16 @@ registry = {
         'supporters' : { 'HP' },
         'url' : 'extensions/HP/HP_texture_lighting.txt',
     },
+    'GL_HUAWEI_program_binary' : {
+        'esnumber' : 349,
+        'flags' : { 'public' },
+        'url' : 'extensions/HUAWEI/HUAWEI_program_binary.txt',
+    },
+    'GL_HUAWEI_shader_binary' : {
+        'esnumber' : 350,
+        'flags' : { 'public' },
+        'url' : 'extensions/HUAWEI/HUAWEI_shader_binary.txt',
+    },
     'GL_IBM_cull_vertex' : {
         'number' : 199,
         'flags' : { 'public' },

--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -7037,7 +7037,9 @@ typedef unsigned int GLhandleARB;
     </enums>
 
     <enums namespace="GL" start="0x9770" end="0x977F" vendor="HUAWEI" comment="Reserved for Pan Gao">
-            <unused start="0x9770" end="0x977F" vendor="HUAWEI"/>
+        <enum value="0x9770" name="GL_HUAWEI_SHADER_BINARY" group="ShaderBinaryFormat"/>
+        <enum value="0x9771" name="GL_HUAWEI_PROGRAM_BINARY"/>
+            <unused start="0x9772" end="0x977F" vendor="HUAWEI"/>
     </enums>
 
 <!-- Enums reservable for future use. To reserve a new range, allocate one
@@ -42897,6 +42899,16 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TEXTURE_LIGHTING_MODE_HP"/>
                 <enum name="GL_TEXTURE_POST_SPECULAR_HP"/>
                 <enum name="GL_TEXTURE_PRE_SPECULAR_HP"/>
+            </require>
+        </extension>
+        <extension name="GL_HUAWEI_program_binary" supported="gles2">
+            <require>
+                <enum name="GL_HUAWEI_PROGRAM_BINARY"/>
+            </require>
+        </extension>
+        <extension name="GL_HUAWEI_shader_binary" supported="gles2">
+            <require>
+                <enum name="GL_HUAWEI_SHADER_BINARY"/>
             </require>
         </extension>
         <extension name="GL_IBM_cull_vertex" supported="gl">


### PR DESCRIPTION
 `HUAWEI_shader_binary` and `HUAWEI_program_binary` are added to load binary format shaders for devices with HUAWEI GPUs.