### PR TITLE
EXT_multisampled_render_to_texture2: Clarify discard behavior for multisample depth/stencil renderbuffer

### DIFF
--- a/extensions/EXT/EXT_multisampled_render_to_texture2.txt
+++ b/extensions/EXT/EXT_multisampled_render_to_texture2.txt
@@ -78,7 +78,7 @@ Additions to Section 4.4.3 of the OpenGL ES 2.0 Specification
     "After such a resolve, the contents of the multisample buffer become undefined.",
     add the following sentence:
 
-        "If the multisampled buffer is a depth or stencil texture, then it's discarded -
+        "If the multisampled buffer is a depth or stencil texture, then it is discarded -
         equivalent to the application calling InvalidateFramebuffer for this attachment.
         If the multisample buffer is a depth/stencil renderbuffer then it is not discarded."
 


### PR DESCRIPTION
[#279] (https://gitlab.khronos.org/opengl/API/-/issues/279): Clarify if EXT_multisampled_render_to_texture2 permits renderbuffer depth/stencil attachments to be discarded automatically.

Resolved: Spec updated to clarify that multisample depth/stencil renderbuffers are not discarded.