### PR TITLE
Add GL_CLIP_ORIGIN and GL_CLIP_DEPTH_MODE to the GetPName enum group.

### DIFF
--- a/xml/gl.xml
+++ b/xml/gl.xml
@@ -6593,10 +6593,10 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9359" name="GL_VIEWPORT_SWIZZLE_Y_NV"/>
         <enum value="0x935A" name="GL_VIEWPORT_SWIZZLE_Z_NV"/>
         <enum value="0x935B" name="GL_VIEWPORT_SWIZZLE_W_NV"/>
-        <enum value="0x935C" name="GL_CLIP_ORIGIN"/>
-        <enum value="0x935C" name="GL_CLIP_ORIGIN_EXT" alias="GL_CLIP_ORIGIN"/>
-        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE"/>
-        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE_EXT" alias="GL_CLIP_DEPTH_MODE"/>
+        <enum value="0x935C" name="GL_CLIP_ORIGIN" group="GetPName"/>
+        <enum value="0x935C" name="GL_CLIP_ORIGIN_EXT" alias="GL_CLIP_ORIGIN"  group="GetPName"/>
+        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE" group="GetPName"/>
+        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE_EXT" alias="GL_CLIP_DEPTH_MODE"  group="GetPName"/>
         <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE" group="ClipControlDepth"/>
         <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE_EXT" alias="GL_NEGATIVE_ONE_TO_ONE"/>
         <enum value="0x935F" name="GL_ZERO_TO_ONE" group="ClipControlDepth"/>


### PR DESCRIPTION
Adds `GL_CLIP_ORIGIN`, `GL_CLIP_ORIGIN_EXT`, `GL_CLIP_DEPTH_MODE`, and `GL_CLIP_DEPTH_MODE_EXT` to the `GetPName` enum group as these are valid enums when calling `glGetInteger`.